### PR TITLE
feat: support theme control via postMessage for iframe embedding

### DIFF
--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -43,6 +43,19 @@ class UIStore {
         }
       });
     });
+
+    // Allow parent windows to control theme via postMessage
+    if (typeof window !== "undefined") {
+      window.addEventListener("message", (event: MessageEvent) => {
+        if (
+          event.data &&
+          event.data.type === "theme:set" &&
+          (event.data.theme === "light" || event.data.theme === "dark")
+        ) {
+          this.theme = event.data.theme;
+        }
+      });
+    }
   }
 
   toggleTheme() {

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -172,6 +172,38 @@ describe("UIStore", () => {
     });
   });
 
+  describe("postMessage theme control", () => {
+    it("should change theme on valid theme:set message", () => {
+      ui.theme = "light";
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "theme:set", theme: "dark" },
+        }),
+      );
+      expect(ui.theme).toBe("dark");
+    });
+
+    it("should ignore invalid theme values", () => {
+      ui.theme = "light";
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "theme:set", theme: "purple" },
+        }),
+      );
+      expect(ui.theme).toBe("light");
+    });
+
+    it("should ignore unrelated message types", () => {
+      ui.theme = "light";
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "some-other-event", theme: "dark" },
+        }),
+      );
+      expect(ui.theme).toBe("light");
+    });
+  });
+
   describe("toggles", () => {
     it("should toggle theme between light and dark", () => {
       ui.theme = "light";


### PR DESCRIPTION
## Summary

- Adds a `postMessage` listener to `UIStore` that accepts `{type: "theme:set", theme: "light"|"dark"}` messages
- Enables parent windows to control agentsview's theme without reloading the iframe
- Closes #31

## Details

When agentsview is embedded as a cross-origin iframe, the host application can now send a `theme:set` message to switch themes instantly. This avoids the jarring reload previously needed when using the `?theme=` URL parameter approach.

The implementation is minimal — a single `window.addEventListener("message", ...)` in the UIStore constructor. Since `this.theme` is a `$state` field, assigning it triggers the existing `$effect` that updates the DOM class and persists to localStorage.

## Protocol

```js
iframe.contentWindow.postMessage({ type: "theme:set", theme: "dark" }, "*");
```

Only `"light"` and `"dark"` are accepted; other values are silently ignored.

## Test plan

- [x] Valid `theme:set` message changes theme
- [x] Invalid theme value (e.g. "purple") is ignored
- [x] Unrelated message types are ignored
- [x] Full test suite passes (384/384, +3 new)