### PR TITLE
feat: enabling session id button for all agents

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -202,7 +202,7 @@
                   })}
                 </span>
               {/if}
-              {#if session.agent === "claude" || session.agent === "codex"}
+              {#if session.id}
                 {@const rawId = sessionDisplayId(session.id)}
                 <button
                   class="session-id"


### PR DESCRIPTION
Minor change that allows for copying session ids for all agents. Previously it was gated for claude and codex only. Non-prefixed session ids are gracefully handled already.

This is exactly the kind of tool I was looking for, so thank you for building this! I am using Copilot CLI, and was looking for this session id button since it was mentioned in release notes. Hopefully this is a straightforward enough change, but let me know if you have any additional feedback!