### PR TITLE
Support subagent transcript viewing for Agent tool calls

### DIFF
--- a/frontend/src/lib/components/content/ToolBlock.svelte
+++ b/frontend/src/lib/components/content/ToolBlock.svelte
@@ -8,6 +8,11 @@
     generateFallbackContent,
   } from "../../utils/tool-params.js";
 
+  /** Returns true for tool names that represent a subagent call ("Task" or "Agent"). */
+  function isSubagentTool(name: string | undefined): boolean {
+    return name === "Task" || name === "Agent";
+  }
+
   interface Props {
     content: string;
     label?: string;
@@ -33,7 +38,7 @@
 
   /** For Task tool calls, extract key metadata fields */
   let taskMeta = $derived.by(() => {
-    if (toolCall?.tool_name !== "Task" || !inputParams)
+    if (!isSubagentTool(toolCall?.tool_name) || !inputParams)
       return null;
     const meta: { label: string; value: string }[] = [];
     if (inputParams.subagent_type) {
@@ -107,13 +112,13 @@
   });
 
   let taskPrompt = $derived(
-    toolCall?.tool_name === "Task"
+    isSubagentTool(toolCall?.tool_name)
       ? inputParams?.prompt ?? null
       : null,
   );
 
   let subagentSessionId = $derived(
-    toolCall?.tool_name === "Task"
+    isSubagentTool(toolCall?.tool_name)
       ? toolCall?.subagent_session_id ?? null
       : null,
   );

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -27,13 +27,14 @@ const THINKING_LEGACY_RE =
   /\[Thinking\]\n?([\s\S]*?)(?=\n\[|\n\n|$)/g;
 
 const TOOL_NAMES =
-  "Tool|Read|Write|Edit|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Skill|" +
+  "Tool|Read|Write|Edit|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Agent|Skill|" +
   "SendMessage|Question|Todo List|Entering Plan Mode|" +
   "Exiting Plan Mode|exec_command|shell_command|" +
   "write_stdin|apply_patch|shell|parallel|view_image|" +
   "request_user_input|update_plan";
 
 const TOOL_ALIASES: Record<string, string> = {
+  Agent: "Task",
   exec_command: "Bash",
   shell_command: "Bash",
   write_stdin: "Bash",

--- a/frontend/src/lib/utils/tool-params.ts
+++ b/frontend/src/lib/utils/tool-params.ts
@@ -106,7 +106,7 @@ export function generateFallbackContent(
   toolName: string,
   params: Params,
 ): string | null {
-  if (toolName === "Task") return null;
+  if (toolName === "Task" || toolName === "Agent") return null;
   if (toolName === "Edit") {
     const lines: string[] = [];
     if (params.old_string != null) {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -374,7 +374,7 @@ func codexCategoryDetail(
 			return fmt.Sprintf("%s in %s", pattern, path)
 		}
 		return firstNonEmpty(pattern, path)
-	case "Task":
+	case "Task", "Agent":
 		desc := codexArgValue(args, "description")
 		agent := codexArgValue(args, "subagent_type")
 		if desc != "" && agent != "" {

--- a/internal/parser/content.go
+++ b/internal/parser/content.go
@@ -162,7 +162,7 @@ func formatToolUse(block gjson.Result) string {
 			skill = input.Get("name").Str
 		}
 		return fmt.Sprintf("[Skill: %s]", skill)
-	case "Task":
+	case "Task", "Agent":
 		return formatTask(input)
 	case "Skill":
 		return fmt.Sprintf("[Skill: %s]", input.Get("skill").Str)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -375,6 +375,11 @@ func TestFormatToolUseVariants(t *testing.T) {
 			"[Task: explore (Explore)]",
 		},
 		{
+			"Agent",
+			`{"type":"tool_use","name":"Agent","input":{"description":"explore","subagent_type":"Explore"}}`,
+			"[Task: explore (Explore)]",
+		},
+		{
 			"EnterPlanMode",
 			`{"type":"tool_use","name":"EnterPlanMode","input":{}}`,
 			"[Entering Plan Mode]",

--- a/internal/parser/taxonomy.go
+++ b/internal/parser/taxonomy.go
@@ -18,7 +18,7 @@ func NormalizeToolCategory(rawName string) string {
 		return "Grep"
 	case "Glob":
 		return "Glob"
-	case "Task":
+	case "Task", "Agent":
 		return "Task"
 	case "Skill":
 		return "Tool"

--- a/internal/parser/taxonomy_test.go
+++ b/internal/parser/taxonomy_test.go
@@ -16,6 +16,7 @@ func TestNormalizeToolCategory(t *testing.T) {
 		{"Grep", "Grep"},
 		{"Glob", "Glob"},
 		{"Task", "Task"},
+		{"Agent", "Task"},
 		{"Skill", "Tool"},
 
 		// Codex tools

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -583,7 +583,7 @@ var (
 	thinkingLegacyRe = regexp.MustCompile(
 		`(?s)\[Thinking\]\n?(.*?)(?:\n\[|\n\n|$)`)
 	toolBlockRe = regexp.MustCompile(
-		`(?s)\[(Tool|Read|Write|Edit|Bash|Glob|Grep|Task|` +
+		`(?s)\[(Tool|Read|Write|Edit|Bash|Glob|Grep|Task|Agent|` +
 			`Question|Todo List|Entering Plan Mode|` +
 			`Exiting Plan Mode|exec_command|shell_command|` +
 			`write_stdin|apply_patch|shell|parallel|` +


### PR DESCRIPTION
## Summary
Claude Code renamed its subagent tool from `Task` to `Agent`. This adds `Agent` handling across parser, taxonomy, frontend, and subagent transcript rendering so it works identically to `Task`.

## Key changes
- Parse `agent_progress` events to map Agent tool calls to subagent session IDs
- Normalize `Agent` to `Task` category in tool taxonomy
- Extend `SubagentInline` rendering and content-parser regex to cover Agent
- Add Agent tool name mapping and normalization tests