### PR TITLE
feat: switchable message layout variants (default, compact, stream)

### DIFF
--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -242,7 +242,7 @@
   </div>
 {:else}
   <div
-    class="message-list-scroll"
+    class="message-list-scroll layout-{ui.messageLayout}"
     bind:this={containerRef}
     data-session-id={sessions.activeSessionId}
     data-messages-session-id={messages.sessionId}
@@ -322,5 +322,87 @@
   .empty-text {
     font-size: 14px;
     font-weight: 500;
+  }
+
+  /* ── Compact layout ── */
+  .layout-compact {
+    padding: 4px 0;
+  }
+
+  .layout-compact .virtual-row {
+    padding: 2px 12px;
+  }
+
+  .layout-compact :global(.message) {
+    padding: 6px 12px;
+    border-left-width: 2px;
+    border-radius: 0;
+  }
+
+  .layout-compact :global(.message-header) {
+    margin-bottom: 4px;
+    gap: 6px;
+  }
+
+  .layout-compact :global(.role-icon) {
+    width: 16px;
+    height: 16px;
+    font-size: 9px;
+  }
+
+  .layout-compact :global(.role-label) {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 700;
+  }
+
+  .layout-compact :global(.timestamp) {
+    font-size: 10px;
+  }
+
+  .layout-compact :global(.text-content) {
+    font-size: 13px;
+    line-height: 1.55;
+  }
+
+  .layout-compact :global(.message-body) {
+    gap: 4px;
+  }
+
+  /* ── Stream layout ── */
+  .layout-stream {
+    padding: 0;
+  }
+
+  .layout-stream .virtual-row {
+    padding: 0;
+  }
+
+  .layout-stream :global(.message) {
+    border-left: none;
+    border-radius: 0;
+    padding: 16px 24px;
+  }
+
+  .layout-stream :global(.message.is-user) {
+    background: color-mix(
+      in srgb,
+      var(--accent-blue) 5%,
+      transparent
+    ) !important;
+  }
+
+  .layout-stream :global(.message:not(.is-user)) {
+    background: transparent !important;
+  }
+
+  .layout-stream :global(.message-header) {
+    display: none;
+  }
+
+  .layout-stream :global(.text-content) {
+    font-size: 14px;
+    line-height: 1.75;
   }
 </style>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -219,6 +219,33 @@
 
       <button
         class="header-btn"
+        onclick={() => ui.cycleLayout()}
+        title="Cycle layout: {ui.messageLayout} (l)"
+        aria-label="Cycle message layout"
+      >
+        {#if ui.messageLayout === "default"}
+          <!-- Default: cards/bordered -->
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M1.5 2A1.5 1.5 0 000 3.5v2A1.5 1.5 0 001.5 7h13A1.5 1.5 0 0016 5.5v-2A1.5 1.5 0 0014.5 2h-13zm0 1h13a.5.5 0 01.5.5v2a.5.5 0 01-.5.5h-13a.5.5 0 01-.5-.5v-2a.5.5 0 01.5-.5zm0 6A1.5 1.5 0 000 10.5v2A1.5 1.5 0 001.5 14h13a1.5 1.5 0 001.5-1.5v-2A1.5 1.5 0 0014.5 9h-13zm0 1h13a.5.5 0 01.5.5v2a.5.5 0 01-.5.5h-13a.5.5 0 01-.5-.5v-2a.5.5 0 01.5-.5z"/>
+          </svg>
+        {:else if ui.messageLayout === "compact"}
+          <!-- Compact: terminal lines -->
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M3 4l4 4-4 4" stroke="currentColor" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="9" y1="12" x2="14" y2="12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+        {:else}
+          <!-- Stream: continuous flow -->
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <rect x="1" y="1" width="14" height="4" rx="1" opacity="0.2"/>
+            <rect x="1" y="6" width="14" height="4" rx="1" opacity="0.08"/>
+            <rect x="1" y="11" width="14" height="4" rx="1" opacity="0.2"/>
+          </svg>
+        {/if}
+      </button>
+
+      <button
+        class="header-btn"
         onclick={handleExport}
         disabled={!sessions.activeSessionId}
         title="Export session (e)"

--- a/frontend/src/lib/components/modals/ShortcutsModal.svelte
+++ b/frontend/src/lib/components/modals/ShortcutsModal.svelte
@@ -10,6 +10,7 @@
     { key: "[", action: "Previous session" },
     { key: "o", action: "Toggle sort order" },
     { key: "t", action: "Toggle thinking blocks" },
+    { key: "l", action: "Cycle message layout" },
     { key: "r", action: "Trigger sync" },
     { key: "e", action: "Export session" },
     { key: "p", action: "Publish to Gist" },

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -1,4 +1,5 @@
 type Theme = "light" | "dark";
+export type MessageLayout = "default" | "compact" | "stream";
 type ModalType =
   | "commandPalette"
   | "shortcuts"
@@ -43,6 +44,12 @@ function readBlockFilters(): Set<BlockType> {
   return new Set(ALL_BLOCK_TYPES);
 }
 
+const LAYOUT_KEY = "agentsview-message-layout";
+const VALID_LAYOUTS: MessageLayout[] = [
+  "default",
+  "compact",
+  "stream",
+];
 function readStoredTheme(): Theme | null {
   if (
     typeof localStorage !== "undefined" &&
@@ -54,9 +61,25 @@ function readStoredTheme(): Theme | null {
   return null;
 }
 
+function readStoredLayout(): MessageLayout {
+  try {
+    const raw = localStorage?.getItem(LAYOUT_KEY);
+    if (
+      raw &&
+      VALID_LAYOUTS.includes(raw as MessageLayout)
+    ) {
+      return raw as MessageLayout;
+    }
+  } catch {
+    // ignore
+  }
+  return "default";
+}
+
 class UIStore {
   theme: Theme = $state(readStoredTheme() || "light");
   sortNewestFirst: boolean = $state(false);
+  messageLayout: MessageLayout = $state(readStoredLayout());
   activeModal: ModalType = $state(null);
   selectedOrdinal: number | null = $state(null);
   pendingScrollOrdinal: number | null = $state(null);
@@ -84,6 +107,17 @@ class UIStore {
           typeof localStorage.setItem === "function"
         ) {
           localStorage.setItem("theme", this.theme);
+        }
+      });
+
+      $effect(() => {
+        try {
+          localStorage?.setItem(
+            LAYOUT_KEY,
+            this.messageLayout,
+          );
+        } catch {
+          // ignore
         }
       });
     });
@@ -162,6 +196,16 @@ class UIStore {
 
   toggleSort() {
     this.sortNewestFirst = !this.sortNewestFirst;
+  }
+
+  cycleLayout() {
+    const idx = VALID_LAYOUTS.indexOf(this.messageLayout);
+    this.messageLayout =
+      VALID_LAYOUTS[(idx + 1) % VALID_LAYOUTS.length]!;
+  }
+
+  setLayout(layout: MessageLayout) {
+    this.messageLayout = layout;
   }
 
   selectOrdinal(ordinal: number) {

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -279,4 +279,34 @@ describe("UIStore", () => {
       expect(ui.hasBlockFilters).toBe(false);
     });
   });
+
+  describe("messageLayout", () => {
+    beforeEach(() => {
+      ui.setLayout("default");
+    });
+
+    it("should default to 'default'", () => {
+      expect(ui.messageLayout).toBe("default");
+    });
+
+    it("should set layout explicitly", () => {
+      ui.setLayout("compact");
+      expect(ui.messageLayout).toBe("compact");
+
+      ui.setLayout("stream");
+      expect(ui.messageLayout).toBe("stream");
+    });
+
+    it("should cycle through layouts", () => {
+      ui.setLayout("default");
+      ui.cycleLayout();
+      expect(ui.messageLayout).toBe("compact");
+
+      ui.cycleLayout();
+      expect(ui.messageLayout).toBe("stream");
+
+      ui.cycleLayout();
+      expect(ui.messageLayout).toBe("default");
+    });
+  });
 });

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -71,6 +71,7 @@ export function registerShortcuts(
       "[": () => sessions.navigateSession(-1),
       o: () => ui.toggleSort(),
       t: () => ui.toggleThinking(),
+      l: () => ui.cycleLayout(),
       r: () => sync.triggerSync(() => sessions.load()),
       e: () => {
         if (sessions.activeSessionId) {


### PR DESCRIPTION
## Summary

Adds three switchable message display modes so users can match the view to their reading preference. The layout persists to localStorage and can be cycled via button or keyboard shortcut.

### Layouts

| Layout | Description |
|--------|-------------|
| **Default** | Current layout — role icons, left-border accent, full padding. Zero visual change. |
| **Compact** | Dense terminal-style — smaller role icons (16px), uppercase labels, 2px border, reduced padding, tighter line height. Great for scanning long sessions quickly. |
| **Stream** | Continuous flow — no borders, no message headers, alternating subtle background bands for user (blue tint) vs assistant (transparent). Optimized for reading like a document. |

### Interaction

- **Header button**: Click the layout icon (changes shape per active layout) to cycle through modes
- **Keyboard**: Press `l` to cycle layouts
- **Persistence**: Layout preference saved to `localStorage` and restored on reload

## Changes

- **`frontend/src/lib/stores/ui.svelte.ts`** — New `MessageLayout` type (`"default" | "compact" | "stream"`), `messageLayout` state with `localStorage` persistence via `$effect`, `cycleLayout()` and `setLayout()` methods
- **`frontend/src/lib/stores/ui.test.ts`** — 3 new tests for layout default, explicit set, and cycling
- **`frontend/src/lib/components/content/MessageList.svelte`** — Applies `layout-{variant}` class on scroll container; ~80 lines of scoped CSS overrides using `:global()` to style child `MessageContent` components per layout
- **`frontend/src/lib/components/layout/AppHeader.svelte`** — Layout cycle button with variant-specific SVG icon, placed next to the sort order button
- **`frontend/src/lib/utils/keyboard.ts`** — Added `l` shortcut for `cycleLayout()`
- **`frontend/src/lib/components/modals/ShortcutsModal.svelte`** — Documents the new `l` shortcut

## Design decisions

- **CSS-only variants**: All three layouts use the same HTML structure — differentiation is entirely CSS via parent class. No conditional rendering, no component duplication.
- **`:global()` targeting**: Scoped CSS in `MessageList` uses `:global()` to override child `MessageContent` styles when a layout class is active. This avoids modifying `MessageContent.svelte` at all.
- **Stream layout hides headers**: The stream layout sets `display: none` on `.message-header` and removes borders entirely, creating a clean "continuous prose" reading experience.

## Test plan

- [x] `npm run check` — 0 errors, 0 new warnings
- [x] `npm run test` — 28 UI store tests pass (3 new), all keyboard tests pass
- [ ] Manual: click layout button in header → cycles through Default → Compact → Stream
- [ ] Manual: press `l` → same cycling behavior
- [ ] Manual: refresh page → layout persists from localStorage
- [ ] Manual: verify Default layout looks identical to current behavior
- [ ] Manual: verify Compact layout has dense, terminal-like appearance
- [ ] Manual: verify Stream layout has no borders, alternating background bands
- [ ] Manual: all three layouts work in both light and dark themes