### PR TITLE
feat: copy message button

### DIFF
--- a/frontend/src/lib/components/content/MessageContent.svelte
+++ b/frontend/src/lib/components/content/MessageContent.svelte
@@ -174,6 +174,12 @@
     opacity: 1;
   }
 
+  @media (hover: none) {
+    .copy-btn {
+      opacity: 1;
+    }
+  }
+
   .copy-btn:hover {
     background: var(--bg-surface-hover);
     color: var(--text-secondary);

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -176,6 +176,12 @@
     opacity: 1;
   }
 
+  @media (hover: none) {
+    .copy-btn {
+      opacity: 1;
+    }
+  }
+
   .copy-btn:hover {
     background: var(--bg-surface-hover);
     color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- Add copy-to-clipboard button on each message (top-right corner, appears on hover)
- Shows checkmark icon for 1.5s after successful copy
- Copies raw markdown content of the message
- Works for both user and assistant messages
- Also available on tool call groups (concatenates all message content)

## Test plan
- [ ] Hover over a user message → copy icon appears
- [ ] Click copy → icon changes to checkmark, content copied to clipboard
- [ ] Paste in editor → raw markdown content matches
- [ ] Works in dark and light themes
- [ ] Tool call groups also have copy button

🤖 Generated with [Claude Code](https://claude.com/claude-code)