### PR TITLE
fix(parser): extract reasoningText in Copilot parser as thinking blocks

### DIFF
--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -109,7 +109,8 @@ func (b *copilotSessionBuilder) handleAssistantMessage(
 	data gjson.Result, ts time.Time,
 ) {
 	content := strings.TrimSpace(data.Get("content").Str)
-	hasThinking := data.Get("reasoningText").Str != ""
+	reasoningText := strings.TrimSpace(data.Get("reasoningText").Str)
+	hasThinking := reasoningText != ""
 
 	var toolCalls []ParsedToolCall
 	data.Get("toolRequests").ForEach(
@@ -139,6 +140,16 @@ func (b *copilotSessionBuilder) handleAssistantMessage(
 	displayContent := content
 	if hasToolUse && content == "" {
 		displayContent = formatCopilotToolCalls(toolCalls)
+	}
+
+	// Prepend thinking block when reasoning text is present.
+	if hasThinking {
+		thinkBlock := "[Thinking]\n" + reasoningText + "\n[/Thinking]"
+		if displayContent != "" {
+			displayContent = thinkBlock + "\n\n" + displayContent
+		} else {
+			displayContent = thinkBlock
+		}
 	}
 
 	if displayContent == "" && !hasToolUse {

--- a/internal/parser/copilot_test.go
+++ b/internal/parser/copilot_test.go
@@ -140,8 +140,41 @@ func TestParseCopilotSession_Reasoning(t *testing.T) {
 
 	_, msgs := parseAndValidateHelper(t, path, "m", 2)
 
-	if !msgs[1].HasThinking {
+	ast := msgs[1]
+	if !ast.HasThinking {
 		t.Error("expected HasThinking on assistant message with reasoningText")
+	}
+	if !strings.Contains(ast.Content, "[Thinking]\nLet me think about this carefully...\n[/Thinking]") {
+		t.Errorf("expected thinking block in content, got: %q", ast.Content)
+	}
+	if !strings.Contains(ast.Content, "Here is my analysis.") {
+		t.Errorf("expected visible content after thinking block, got: %q", ast.Content)
+	}
+	// Thinking block must precede the visible content.
+	thinkIdx := strings.Index(ast.Content, "[Thinking]")
+	visibleIdx := strings.Index(ast.Content, "Here is my analysis.")
+	if thinkIdx >= visibleIdx {
+		t.Errorf("thinking block should appear before visible content")
+	}
+}
+
+func TestParseCopilotSession_ReasoningOnly(t *testing.T) {
+	// A message with only reasoningText and no visible content or tool calls
+	// should still be emitted with thinking content.
+	path := writeCopilotJSONL(t,
+		`{"type":"session.start","data":{"sessionId":"reason-only"},"timestamp":"2025-01-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"What do you think?"},"timestamp":"2025-01-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"","reasoningText":"Pondering the question..."},"timestamp":"2025-01-15T10:00:02Z"}`,
+	)
+
+	_, msgs := parseAndValidateHelper(t, path, "m", 2)
+
+	ast := msgs[1]
+	if !ast.HasThinking {
+		t.Error("expected HasThinking")
+	}
+	if !strings.Contains(ast.Content, "[Thinking]\nPondering the question...\n[/Thinking]") {
+		t.Errorf("expected thinking block in content, got: %q", ast.Content)
 	}
 }
 


### PR DESCRIPTION
When I viewed sessions in the CLI, there was a lot of useful reasoning/thinking text that I was seeing in copilot but not in the UI. 

Here is an example before these changes:
<img width="1512" height="352" alt="Screenshot 2026-03-06 at 10 16 01 PM" src="https://github.com/user-attachments/assets/a95c889f-618a-4515-af0c-d4e9ec15b1a0" />


And that same message re-synced with these changes:
<img width="1506" height="552" alt="Screenshot 2026-03-06 at 10 14 56 PM" src="https://github.com/user-attachments/assets/a604c387-0154-4c09-a8a3-1365bf8c8922" />

This solution simply hoists that reasoning text into a Thinking Block.

Previously the Copilot parser detected reasoningText but discarded it, only setting HasThinking=true as a boolean flag. The frontend renders thinking content by looking for [Thinking]...[/Thinking] markers in message content, so nothing was ever displayed.

Now reasoningText is extracted and wrapped in [Thinking]...[/Thinking] markers, consistent with how Claude, Gemini, OpenCode, and other parsers handle thinking content. When both reasoning and visible content exist, the thinking block is prepended with a blank line separator.

Also updates TestParseCopilotSession_Reasoning to assert the thinking block appears in content, and adds TestParseCopilotSession_ReasoningOnly for messages with only reasoningText and no visible content.