### PR TITLE
fix: extract Gemini tool result content and expand tool name coverage

### DIFF
--- a/internal/parser/content.go
+++ b/internal/parser/content.go
@@ -164,7 +164,7 @@ func formatToolUse(block gjson.Result) string {
 		return formatBash(input)
 	// Amp tools
 	case "edit_file":
-		return fmt.Sprintf("[Write: %s]", input.Get("path").Str)
+		return fmt.Sprintf("[Edit: %s]", input.Get("path").Str)
 	case "create_file":
 		return fmt.Sprintf("[Write: %s]", input.Get("path").Str)
 	case "shell_command":

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -60,7 +60,7 @@ func ParseGeminiSession(
 				role = RoleAssistant
 			}
 
-			content, hasThinking, hasToolUse, tcs :=
+			content, hasThinking, hasToolUse, tcs, trs :=
 				extractGeminiContent(msg)
 			if strings.TrimSpace(content) == "" {
 				return true
@@ -82,6 +82,7 @@ func ParseGeminiSession(
 				HasToolUse:    hasToolUse,
 				ContentLength: len(content),
 				ToolCalls:     tcs,
+				ToolResults:   trs,
 			})
 			ordinal++
 			return true
@@ -119,10 +120,11 @@ func ParseGeminiSession(
 // message, including its content, thoughts, and tool calls.
 func extractGeminiContent(
 	msg gjson.Result,
-) (string, bool, bool, []ParsedToolCall) {
+) (string, bool, bool, []ParsedToolCall, []ParsedToolResult) {
 	var (
 		parts       []string
 		parsed      []ParsedToolCall
+		results     []ParsedToolResult
 		hasThinking bool
 		hasToolUse  bool
 	)
@@ -167,17 +169,42 @@ func extractGeminiContent(
 		})
 	}
 
-	// Extract tool calls
+	// Extract tool calls and inline results
 	toolCalls := msg.Get("toolCalls")
 	if toolCalls.IsArray() {
 		toolCalls.ForEach(func(_, tc gjson.Result) bool {
 			hasToolUse = true
 			name := tc.Get("name").Str
+			tcID := tc.Get("id").Str
 			if name != "" {
 				parsed = append(parsed, ParsedToolCall{
-					ToolName: name,
-					Category: NormalizeToolCategory(name),
+					ToolName:  name,
+					Category:  NormalizeToolCategory(name),
+					ToolUseID: tcID,
+					InputJSON: tc.Get("args").Raw,
 				})
+				// Extract inline tool results from
+				// result[].functionResponse.response.output
+				tc.Get("result").ForEach(
+					func(_, r gjson.Result) bool {
+						output := r.Get(
+							"functionResponse.response.output",
+						)
+						if !output.Exists() {
+							return true
+						}
+						rid := r.Get("functionResponse.id").Str
+						if rid == "" {
+							rid = tcID
+						}
+						results = append(results, ParsedToolResult{
+							ToolUseID:     rid,
+							ContentLength: toolResultContentLength(output),
+							ContentRaw:    output.Raw,
+						})
+						return true
+					},
+				)
 			}
 			parts = append(parts, formatGeminiToolCall(tc))
 			return true
@@ -185,7 +212,7 @@ func extractGeminiContent(
 	}
 
 	return strings.Join(parts, "\n\n"),
-		hasThinking, hasToolUse, parsed
+		hasThinking, hasToolUse, parsed, results
 }
 
 func formatGeminiToolCall(tc gjson.Result) string {
@@ -198,23 +225,31 @@ func formatGeminiToolCall(tc gjson.Result) string {
 		return fmt.Sprintf(
 			"[Read: %s]", args.Get("file_path").Str,
 		)
-	case "write_file", "edit_file":
+	case "write_file":
 		return fmt.Sprintf(
 			"[Write: %s]", args.Get("file_path").Str,
 		)
-	case "run_command", "execute_command":
+	case "edit_file", "replace":
+		return fmt.Sprintf(
+			"[Edit: %s]", args.Get("file_path").Str,
+		)
+	case "run_command", "execute_command", "run_shell_command":
 		cmd := args.Get("command").Str
 		return fmt.Sprintf("[Bash]\n$ %s", cmd)
 	case "list_directory":
 		return fmt.Sprintf(
 			"[List: %s]", args.Get("dir_path").Str,
 		)
-	case "search_files", "grep":
+	case "search_files", "grep", "grep_search":
 		query := args.Get("query").Str
 		if query == "" {
 			query = args.Get("pattern").Str
 		}
 		return fmt.Sprintf("[Grep: %s]", query)
+	case "glob":
+		return fmt.Sprintf(
+			"[Glob: %s]", args.Get("pattern").Str,
+		)
 	default:
 		label := displayName
 		if label == "" {

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -54,6 +54,89 @@ func TestParseGeminiSession_ToolCalls(t *testing.T) {
 		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{ToolName: "read_file", Category: "Read"}})
 	})
 
+	t.Run("tool calls with results", func(t *testing.T) {
+		content := loadFixture(t, "gemini/tool_calls_with_results.json")
+		_, msgs := runGeminiParserTest(t, content)
+
+		require.Equal(t, 2, len(msgs))
+		assistantMsg := msgs[1]
+		assert.True(t, assistantMsg.HasToolUse)
+
+		// Verify ToolUseID and InputJSON are extracted
+		require.Equal(t, 2, len(assistantMsg.ToolCalls))
+		assertToolCalls(t, assistantMsg.ToolCalls, []ParsedToolCall{
+			{
+				ToolName:  "read_file",
+				Category:  "Read",
+				ToolUseID: "read_file_1772747340739_0",
+				InputJSON: `{"file_path":".planning/ONE-PAGER.md"}`,
+			},
+			{
+				ToolName:  "run_command",
+				Category:  "Bash",
+				ToolUseID: "run_command_1772747340739_1",
+				InputJSON: `{"command":"ls -la"}`,
+			},
+		})
+
+		// Verify tool results are extracted
+		require.Equal(t, 2, len(assistantMsg.ToolResults))
+		assert.Equal(t, "read_file_1772747340739_0", assistantMsg.ToolResults[0].ToolUseID)
+		assert.Equal(t, len("# Agentstrove -- One-Pager\n\nDraft: 2026-03-04"), assistantMsg.ToolResults[0].ContentLength)
+		// Verify DecodeContent works on the raw content
+		assert.Equal(t, "# Agentstrove -- One-Pager\n\nDraft: 2026-03-04", DecodeContent(assistantMsg.ToolResults[0].ContentRaw))
+
+		assert.Equal(t, "run_command_1772747340739_1", assistantMsg.ToolResults[1].ToolUseID)
+		assert.Equal(t, "total 42\ndrwxr-xr-x  5 user user 160 Mar  4 10:00 .", DecodeContent(assistantMsg.ToolResults[1].ContentRaw))
+	})
+
+	t.Run("programmatic tool call with result", func(t *testing.T) {
+		content := testjsonl.GeminiSessionJSON("sess-tc-result", "hash", tsEarly, tsEarlyS5, []map[string]any{
+			testjsonl.GeminiUserMsg("u1", tsEarly, "list files"),
+			testjsonl.GeminiAssistantMsg("a1", tsEarlyS5, "Running command.", &testjsonl.GeminiMsgOpts{
+				ToolCalls: []testjsonl.GeminiToolCall{
+					{
+						ID:           "run_cmd_1",
+						Name:         "run_command",
+						DisplayName:  "RunCommand",
+						Args:         map[string]string{"command": "ls"},
+						ResultOutput: "file1.go\nfile2.go",
+					},
+				},
+			}),
+		})
+		_, msgs := runGeminiParserTest(t, content)
+		require.Equal(t, 2, len(msgs))
+		require.Equal(t, 1, len(msgs[1].ToolCalls))
+		assert.Equal(t, "run_cmd_1", msgs[1].ToolCalls[0].ToolUseID)
+
+		require.Equal(t, 1, len(msgs[1].ToolResults))
+		assert.Equal(t, "run_cmd_1", msgs[1].ToolResults[0].ToolUseID)
+		assert.Equal(t, len("file1.go\nfile2.go"), msgs[1].ToolResults[0].ContentLength)
+		assert.Equal(t, "file1.go\nfile2.go", DecodeContent(msgs[1].ToolResults[0].ContentRaw))
+	})
+
+	t.Run("tool call without result", func(t *testing.T) {
+		content := testjsonl.GeminiSessionJSON("sess-tc-no-result", "hash", tsEarly, tsEarlyS5, []map[string]any{
+			testjsonl.GeminiUserMsg("u1", tsEarly, "read it"),
+			testjsonl.GeminiAssistantMsg("a1", tsEarlyS5, "Reading.", &testjsonl.GeminiMsgOpts{
+				ToolCalls: []testjsonl.GeminiToolCall{
+					{
+						ID:          "read_1",
+						Name:        "read_file",
+						DisplayName: "ReadFile",
+						Args:        map[string]string{"file_path": "main.go"},
+					},
+				},
+			}),
+		})
+		_, msgs := runGeminiParserTest(t, content)
+		require.Equal(t, 2, len(msgs))
+		require.Equal(t, 1, len(msgs[1].ToolCalls))
+		assert.Equal(t, "read_1", msgs[1].ToolCalls[0].ToolUseID)
+		assert.Equal(t, 0, len(msgs[1].ToolResults))
+	})
+
 	t.Run("empty tool name skipped", func(t *testing.T) {
 		content := testjsonl.GeminiSessionJSON("sess-uuid-empty-tc", "hash", tsEarly, tsEarlyS5, []map[string]any{
 			testjsonl.GeminiUserMsg("u1", tsEarly, "do it"),

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -484,7 +484,7 @@ func TestFormatToolUseVariants(t *testing.T) {
 		{
 			"edit_file",
 			`{"type":"tool_use","name":"edit_file","input":{"path":"main.go"}}`,
-			"[Write: main.go]",
+			"[Edit: main.go]",
 		},
 		{
 			"create_file",
@@ -1060,7 +1060,12 @@ func TestFormatGeminiToolCall(t *testing.T) {
 		{
 			"edit_file",
 			`{"name":"edit_file","args":{"file_path":"fix.go"},"displayName":"EditFile"}`,
-			"[Write: fix.go]",
+			"[Edit: fix.go]",
+		},
+		{
+			"replace",
+			`{"name":"replace","args":{"file_path":"fix.go"},"displayName":"Replace"}`,
+			"[Edit: fix.go]",
 		},
 		{
 			"run_command",
@@ -1071,6 +1076,11 @@ func TestFormatGeminiToolCall(t *testing.T) {
 			"execute_command",
 			`{"name":"execute_command","args":{"command":"ls -la"},"displayName":"Exec"}`,
 			"[Bash]\n$ ls -la",
+		},
+		{
+			"run_shell_command",
+			`{"name":"run_shell_command","args":{"command":"make build"},"displayName":"Shell"}`,
+			"[Bash]\n$ make build",
 		},
 		{
 			"list_directory",
@@ -1086,6 +1096,16 @@ func TestFormatGeminiToolCall(t *testing.T) {
 			"grep with pattern",
 			`{"name":"grep","args":{"pattern":"func main"},"displayName":"Grep"}`,
 			"[Grep: func main]",
+		},
+		{
+			"grep_search with query",
+			`{"name":"grep_search","args":{"query":"TODO"},"displayName":"GrepSearch"}`,
+			"[Grep: TODO]",
+		},
+		{
+			"glob",
+			`{"name":"glob","args":{"pattern":"**/*.go"},"displayName":"Glob"}`,
+			"[Glob: **/*.go]",
 		},
 		{
 			"unknown tool with displayName",

--- a/internal/parser/taxonomy.go
+++ b/internal/parser/taxonomy.go
@@ -31,13 +31,15 @@ func NormalizeToolCategory(rawName string) string {
 		return "Edit"
 
 	// Gemini tools
-	case "read_file":
+	case "read_file", "list_directory":
 		return "Read"
-	case "write_file", "edit_file":
+	case "write_file":
 		return "Write"
-	case "run_command", "execute_command":
+	case "edit_file", "replace":
+		return "Edit"
+	case "run_command", "execute_command", "run_shell_command":
 		return "Bash"
-	case "search_files", "grep":
+	case "search_files", "grep", "grep_search":
 		return "Grep"
 
 	// OpenCode tools (lowercase variants)
@@ -56,7 +58,7 @@ func NormalizeToolCategory(rawName string) string {
 		return "Task"
 
 	// Copilot tools
-	// Note: "edit_file" (Write), "shell" (Bash), "grep" (Grep),
+	// Note: "edit_file" (Edit), "shell" (Bash), "grep" (Grep),
 	// and "glob" (Glob) are handled in earlier sections.
 	case "view":
 		return "Read"

--- a/internal/parser/taxonomy_test.go
+++ b/internal/parser/taxonomy_test.go
@@ -29,11 +29,15 @@ func TestNormalizeToolCategory(t *testing.T) {
 		// Gemini tools
 		{"read_file", "Read"},
 		{"write_file", "Write"},
-		{"edit_file", "Write"},
+		{"edit_file", "Edit"},
+		{"replace", "Edit"},
+		{"list_directory", "Read"},
 		{"run_command", "Bash"},
 		{"execute_command", "Bash"},
+		{"run_shell_command", "Bash"},
 		{"search_files", "Grep"},
 		{"grep", "Grep"},
+		{"grep_search", "Grep"},
 
 		// OpenCode tools (lowercase)
 		// "grep" already tested above in Gemini section.

--- a/internal/parser/testdata/gemini/tool_calls_with_results.json
+++ b/internal/parser/testdata/gemini/tool_calls_with_results.json
@@ -1,0 +1,66 @@
+{
+  "lastUpdated": "2024-01-01T10:00:05Z",
+  "messages": [
+    {
+      "content": "Read the planning doc",
+      "id": "u1",
+      "timestamp": "2024-01-01T10:00:00Z",
+      "type": "user"
+    },
+    {
+      "content": "Let me read that file.",
+      "id": "a1",
+      "model": "gemini-2.5-pro",
+      "thoughts": [
+        {
+          "description": "I need to read the planning document.",
+          "subject": "Planning",
+          "timestamp": "2024-01-01T10:00:01Z"
+        }
+      ],
+      "timestamp": "2024-01-01T10:00:05Z",
+      "toolCalls": [
+        {
+          "id": "read_file_1772747340739_0",
+          "name": "read_file",
+          "displayName": "ReadFile",
+          "args": {"file_path":".planning/ONE-PAGER.md"},
+          "status": "success",
+          "result": [
+            {
+              "functionResponse": {
+                "id": "read_file_1772747340739_0",
+                "name": "read_file",
+                "response": {
+                  "output": "# Agentstrove -- One-Pager\n\nDraft: 2026-03-04"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "run_command_1772747340739_1",
+          "name": "run_command",
+          "displayName": "RunCommand",
+          "args": {"command":"ls -la"},
+          "status": "success",
+          "result": [
+            {
+              "functionResponse": {
+                "id": "run_command_1772747340739_1",
+                "name": "run_command",
+                "response": {
+                  "output": "total 42\ndrwxr-xr-x  5 user user 160 Mar  4 10:00 ."
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "type": "gemini"
+    }
+  ],
+  "projectHash": "abc123def456",
+  "sessionId": "sess-uuid-tool-results",
+  "startTime": "2024-01-01T10:00:00Z"
+}

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -385,9 +385,11 @@ func (b *SessionBuilder) StringNoTrailingNewline() string {
 
 // GeminiToolCall defines a tool call for Gemini test fixtures.
 type GeminiToolCall struct {
-	Name        string
-	DisplayName string
-	Args        map[string]string
+	ID           string
+	Name         string
+	DisplayName  string
+	Args         map[string]string
+	ResultOutput string // if set, generates inline functionResponse result
 }
 
 // GeminiThought defines a thought for Gemini test fixtures.
@@ -452,8 +454,24 @@ func GeminiAssistantMsg(
 				"displayName": tc.DisplayName,
 				"status":      "success",
 			}
+			if tc.ID != "" {
+				entry["id"] = tc.ID
+			}
 			if tc.Args != nil {
 				entry["args"] = tc.Args
+			}
+			if tc.ResultOutput != "" {
+				entry["result"] = []map[string]any{
+					{
+						"functionResponse": map[string]any{
+							"id":   tc.ID,
+							"name": tc.Name,
+							"response": map[string]any{
+								"output": tc.ResultOutput,
+							},
+						},
+					},
+				}
 			}
 			tcs = append(tcs, entry)
 		}


### PR DESCRIPTION
## Summary
- Extract inline tool results from Gemini's `toolCalls[].result[].functionResponse.response.output` format, which was missed when tool result content storage was added in #96
- Populate `ToolUseID` and `InputJSON` on Gemini `ParsedToolCall` so the frontend ToolBlock can display tool call details
- Add missing Gemini tool name variants (`replace`, `run_shell_command`, `grep_search`, `glob`, `list_directory`) to taxonomy and display formatting
- Recategorize `edit_file` from "Write" to "Edit" across all agents (taxonomy, gemini format, amp format)

Note: frontend `extractToolParamMeta` category-based dispatch for cross-agent tool rendering consistency will follow in a separate PR.

Fixes #113

## Test plan
- [ ] Verify Gemini tool call detail now shows content when clicked
- [ ] Verify tool result output appears in collapsible output section
- [ ] Run `make test` (Go unit tests pass)
- [ ] Check existing Claude/Codex/Copilot/Amp sessions still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)