### PR TITLE
feat: exclude common dependency/build dirs from recursive watcher

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -123,6 +123,14 @@ Environment variables:
   AMP_DIR                 Amp threads directory
   AGENT_VIEWER_DATA_DIR   Data directory (database, config)
 
+Watcher excludes:
+  Add "watch_exclude_patterns" to ~/.agentsview/config.json to skip
+  directory names/patterns while recursively watching roots.
+  Example:
+  {
+    "watch_exclude_patterns": [".git", "node_modules", ".next", "dist"]
+  }
+
 Multiple directories:
   Add arrays to ~/.agentsview/config.json to scan multiple locations:
   {
@@ -518,7 +526,7 @@ func startFileWatcher(
 	onChange := func(paths []string) {
 		engine.SyncPaths(paths)
 	}
-	watcher, err := sync.NewWatcher(watcherDebounce, onChange)
+	watcher, err := sync.NewWatcher(watcherDebounce, onChange, cfg.WatchExcludePatterns)
 	if err != nil {
 		log.Printf(
 			"warning: file watcher unavailable: %v"+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,18 +51,19 @@ type ProxyConfig struct {
 
 // Config holds all application configuration.
 type Config struct {
-	Host          string         `json:"host"`
-	Port          int            `json:"port"`
-	NoBrowser     bool           `json:"no_browser"`
-	DataDir       string         `json:"data_dir"`
-	DBPath        string         `json:"-"`
-	PublicURL     string         `json:"public_url,omitempty"`
-	PublicOrigins []string       `json:"public_origins,omitempty"`
-	Proxy         ProxyConfig    `json:"proxy,omitempty"`
-	CursorSecret  string         `json:"cursor_secret"`
-	GithubToken   string         `json:"github_token,omitempty"`
-	Terminal      TerminalConfig `json:"terminal,omitempty"`
-	WriteTimeout  time.Duration  `json:"-"`
+	Host                 string         `json:"host"`
+	Port                 int            `json:"port"`
+	NoBrowser            bool           `json:"no_browser"`
+	DataDir              string         `json:"data_dir"`
+	DBPath               string         `json:"-"`
+	PublicURL            string         `json:"public_url,omitempty"`
+	PublicOrigins        []string       `json:"public_origins,omitempty"`
+	Proxy                ProxyConfig    `json:"proxy,omitempty"`
+	WatchExcludePatterns []string       `json:"watch_exclude_patterns,omitempty"`
+	CursorSecret         string         `json:"cursor_secret"`
+	GithubToken          string         `json:"github_token,omitempty"`
+	Terminal             TerminalConfig `json:"terminal,omitempty"`
+	WriteTimeout         time.Duration  `json:"-"`
 
 	// AgentDirs maps each AgentType to its configured
 	// directories. Single-dir agents store a one-element
@@ -129,6 +130,7 @@ func Default() (Config, error) {
 		WriteTimeout:                   30 * time.Second,
 		AgentDirs:                      agentDirs,
 		agentDirSource:                 agentDirSource,
+		WatchExcludePatterns:           []string{".git", "node_modules", "__pycache__", ".venv", "venv", "vendor", ".next"},
 		ResultContentBlockedCategories: []string{"Read", "Glob"},
 	}, nil
 }
@@ -190,6 +192,7 @@ func (c *Config) loadFile() error {
 		PublicURL                      string         `json:"public_url"`
 		PublicOrigins                  []string       `json:"public_origins"`
 		Proxy                          ProxyConfig    `json:"proxy"`
+		WatchExcludePatterns           []string       `json:"watch_exclude_patterns"`
 		ResultContentBlockedCategories []string       `json:"result_content_blocked_categories"`
 		Terminal                       TerminalConfig `json:"terminal"`
 	}
@@ -213,6 +216,9 @@ func (c *Config) loadFile() error {
 		file.Proxy.TLSCert != "" || file.Proxy.TLSKey != "" ||
 		file.Proxy.AllowedSubnets != nil {
 		c.Proxy = file.Proxy
+	}
+	if file.WatchExcludePatterns != nil {
+		c.WatchExcludePatterns = file.WatchExcludePatterns
 	}
 	if file.ResultContentBlockedCategories != nil {
 		c.ResultContentBlockedCategories = file.ResultContentBlockedCategories

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,6 +20,9 @@ type Watcher struct {
 	onChange func(paths []string)
 	watcher  *fsnotify.Watcher
 	debounce time.Duration
+	excludes []string
+	roots    []string
+	rootsMu  sync.RWMutex
 	pending  map[string]time.Time
 	mu       sync.Mutex
 	stop     chan struct{}
@@ -28,9 +33,7 @@ type Watcher struct {
 
 // NewWatcher creates a file watcher that calls onChange when
 // files are modified after the debounce period elapses.
-func NewWatcher(
-	debounce time.Duration, onChange func(paths []string),
-) (*Watcher, error) {
+func NewWatcher(debounce time.Duration, onChange func(paths []string), excludes []string) (*Watcher, error) {
 	if onChange == nil {
 		return nil, fmt.Errorf("onChange callback is nil: %w", os.ErrInvalid)
 	}
@@ -44,6 +47,7 @@ func NewWatcher(
 		onChange: onChange,
 		watcher:  fsw,
 		debounce: debounce,
+		excludes: normalizeExcludePatterns(excludes),
 		pending:  make(map[string]time.Time),
 		stop:     make(chan struct{}),
 		done:     make(chan struct{}),
@@ -56,12 +60,18 @@ func NewWatcher(
 // subdirectories to the watch list. Returns the number
 // of directories watched and unwatched (failed to add).
 func (w *Watcher) WatchRecursive(root string) (watched int, unwatched int, err error) {
+	root = filepath.Clean(root)
+	w.addRoot(root)
 	err = filepath.WalkDir(root,
 		func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return nil // skip inaccessible dirs
 			}
 			if d.IsDir() {
+				// Skip entire excluded subtrees, but always keep the root.
+				if path != root && w.shouldExcludeForRoot(path, root) {
+					return filepath.SkipDir
+				}
 				if addErr := w.watcher.Add(path); addErr != nil {
 					unwatched++
 				} else {
@@ -123,7 +133,10 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 	}
 
 	if event.Op&fsnotify.Create != 0 {
-		w.watchIfDir(event.Name)
+		isDir, excluded := w.watchIfDir(event.Name)
+		if isDir && excluded {
+			return
+		}
 	}
 
 	w.mu.Lock()
@@ -132,12 +145,116 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 }
 
 // watchIfDir adds a path to the watch list if it is a directory.
-func (w *Watcher) watchIfDir(path string) {
+// Returns whether path is a directory and whether it was excluded.
+func (w *Watcher) watchIfDir(path string) (isDir bool, excluded bool) {
 	info, err := os.Stat(path)
 	if err != nil || !info.IsDir() {
-		return
+		return false, false
+	}
+	if w.shouldExclude(path) {
+		return true, true
 	}
 	_ = w.watcher.Add(path)
+	return true, false
+}
+
+func normalizeExcludePatterns(patterns []string) []string {
+	if len(patterns) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		p = strings.TrimSpace(filepath.Clean(p))
+		if p == "" || p == "." {
+			continue
+		}
+		if !slices.Contains(out, p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func (w *Watcher) addRoot(root string) {
+	w.rootsMu.Lock()
+	defer w.rootsMu.Unlock()
+	if !slices.Contains(w.roots, root) {
+		w.roots = append(w.roots, root)
+	}
+}
+
+func (w *Watcher) shouldExclude(path string) bool {
+	if len(w.excludes) == 0 {
+		return false
+	}
+	root, ok := w.mostSpecificContainingRoot(path)
+	if !ok {
+		return false
+	}
+	return w.shouldExcludeForRoot(path, root)
+}
+
+func (w *Watcher) shouldExcludeForRoot(path string, root string) bool {
+	if len(w.excludes) == 0 {
+		return false
+	}
+	clean := filepath.Clean(path)
+	root = filepath.Clean(root)
+	rel, err := filepath.Rel(root, clean)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	rel = filepath.Clean(rel)
+	if rel == "." {
+		return false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+
+	for _, pat := range w.excludes {
+		if strings.Contains(pat, string(filepath.Separator)) {
+			if ok, _ := filepath.Match(pat, rel); ok {
+				return true
+			}
+			continue
+		}
+		for _, part := range parts {
+			if ok, _ := filepath.Match(pat, part); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (w *Watcher) mostSpecificContainingRoot(path string) (string, bool) {
+	w.rootsMu.RLock()
+	defer w.rootsMu.RUnlock()
+
+	if len(w.roots) == 0 {
+		return "", false
+	}
+
+	clean := filepath.Clean(path)
+	var best string
+	for _, root := range w.roots {
+		rel, err := filepath.Rel(root, clean)
+		if err != nil {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if best == "" || len(root) > len(best) {
+			best = root
+		}
+	}
+	if best == "" {
+		return "", false
+	}
+	return best, true
 }
 
 func (w *Watcher) flush() {

--- a/internal/sync/watcher_test.go
+++ b/internal/sync/watcher_test.go
@@ -17,7 +17,7 @@ func startTestWatcherNoCleanup(
 ) (*Watcher, string) {
 	t.Helper()
 	dir := t.TempDir()
-	w, err := NewWatcher(debounce, onChange)
+	w, err := NewWatcher(debounce, onChange, nil)
 	if err != nil {
 		t.Fatalf("NewWatcher: %v", err)
 	}
@@ -282,8 +282,206 @@ func TestWatcherDebounceLogic(t *testing.T) {
 	}
 }
 
+func TestWatchRecursive_ExcludesDirectoryNames(t *testing.T) {
+	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{".git", "node_modules"})
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	w.Start()
+	t.Cleanup(func() { w.Stop() })
+
+	root := t.TempDir()
+	included := filepath.Join(root, "project", "src")
+	excludedGit := filepath.Join(root, "project", ".git", "objects")
+	excludedModules := filepath.Join(root, "project", "node_modules", "pkg")
+	for _, p := range []string{included, excludedGit, excludedModules} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", p, err)
+		}
+	}
+
+	if _, _, err := w.WatchRecursive(root); err != nil {
+		t.Fatalf("WatchRecursive: %v", err)
+	}
+
+	got := w.watcher.WatchList()
+	if slices.Contains(got, filepath.Join(root, "project", ".git")) {
+		t.Fatal(".git should be excluded from watch list")
+	}
+	if slices.Contains(got, filepath.Join(root, "project", "node_modules")) {
+		t.Fatal("node_modules should be excluded from watch list")
+	}
+	if !slices.Contains(got, included) {
+		t.Fatalf("expected included dir %s in watch list", included)
+	}
+}
+
+func TestWatcherAutoWatchesNewDirs_RespectsExcludes(t *testing.T) {
+	pathsCh := make(chan []string, 10)
+	w, err := NewWatcher(20*time.Millisecond, func(paths []string) {
+		pathsCh <- paths
+	}, []string{".git"})
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	t.Cleanup(func() { w.Stop() })
+
+	root := t.TempDir()
+	if _, _, err := w.WatchRecursive(root); err != nil {
+		t.Fatalf("WatchRecursive: %v", err)
+	}
+	w.Start()
+
+	gitDir := filepath.Join(root, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if slices.Contains(w.watcher.WatchList(), gitDir) {
+		t.Fatal("newly created excluded dir should not be watched")
+	}
+
+	fileInGit := filepath.Join(gitDir, "config")
+	if err := os.WriteFile(fileInGit, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	select {
+	case paths := <-pathsCh:
+		if slices.Contains(paths, fileInGit) {
+			t.Fatal("changes inside excluded dir should not trigger onChange")
+		}
+	case <-time.After(200 * time.Millisecond):
+		// no events from excluded dir; expected
+	}
+}
+
+func TestWatchRecursive_RootUnderExcludedAncestorStillWatchesDescendants(t *testing.T) {
+	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{"venv"})
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	w.Start()
+	t.Cleanup(func() { w.Stop() })
+
+	base := t.TempDir()
+	root := filepath.Join(base, "venv", "project")
+	included := filepath.Join(root, "src")
+	if err := os.MkdirAll(included, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", included, err)
+	}
+
+	if _, _, err := w.WatchRecursive(root); err != nil {
+		t.Fatalf("WatchRecursive: %v", err)
+	}
+
+	got := w.watcher.WatchList()
+	if !slices.Contains(got, root) {
+		t.Fatalf("expected root %s in watch list", root)
+	}
+	if !slices.Contains(got, included) {
+		t.Fatalf("expected included dir %s in watch list", included)
+	}
+}
+
+func TestWatchRecursive_ExcludesSlashPatternRelativeToRoot(t *testing.T) {
+	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{"foo/bar"})
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	w.Start()
+	t.Cleanup(func() { w.Stop() })
+
+	root := t.TempDir()
+	excluded := filepath.Join(root, "foo", "bar")
+	includedSibling := filepath.Join(root, "foo", "baz")
+	for _, p := range []string{excluded, includedSibling} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", p, err)
+		}
+	}
+
+	if _, _, err := w.WatchRecursive(root); err != nil {
+		t.Fatalf("WatchRecursive: %v", err)
+	}
+
+	got := w.watcher.WatchList()
+	if slices.Contains(got, excluded) {
+		t.Fatalf("expected %s to be excluded", excluded)
+	}
+	if !slices.Contains(got, includedSibling) {
+		t.Fatalf("expected %s to be included", includedSibling)
+	}
+}
+
+func TestWatchRecursive_OverlappingRoots_UsesMostSpecificRoot(t *testing.T) {
+	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{"venv"})
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	w.Start()
+	t.Cleanup(func() { w.Stop() })
+
+	base := t.TempDir()
+	parentRoot := filepath.Join(base, "workspace")
+	nestedRoot := filepath.Join(parentRoot, "venv", "project")
+	included := filepath.Join(nestedRoot, "src")
+	for _, p := range []string{parentRoot, included} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", p, err)
+		}
+	}
+
+	if _, _, err := w.WatchRecursive(parentRoot); err != nil {
+		t.Fatalf("WatchRecursive(parent): %v", err)
+	}
+	if _, _, err := w.WatchRecursive(nestedRoot); err != nil {
+		t.Fatalf("WatchRecursive(nested): %v", err)
+	}
+
+	got := w.watcher.WatchList()
+	if !slices.Contains(got, nestedRoot) {
+		t.Fatalf("expected nested root %s in watch list", nestedRoot)
+	}
+	if !slices.Contains(got, included) {
+		t.Fatalf("expected included dir %s in watch list", included)
+	}
+}
+
+func TestWatcherExcludedCreateDir_DoesNotTriggerOnChange(t *testing.T) {
+	pathsCh := make(chan []string, 10)
+	w, err := NewWatcher(20*time.Millisecond, func(paths []string) {
+		pathsCh <- paths
+	}, []string{".git"})
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	t.Cleanup(func() { w.Stop() })
+
+	root := t.TempDir()
+	if _, _, err := w.WatchRecursive(root); err != nil {
+		t.Fatalf("WatchRecursive: %v", err)
+	}
+	w.Start()
+
+	gitDir := filepath.Join(root, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+
+	select {
+	case paths := <-pathsCh:
+		if slices.Contains(paths, gitDir) {
+			t.Fatal("excluded directory create should not trigger onChange")
+		}
+	case <-time.After(250 * time.Millisecond):
+		// Expected: no callback for excluded dir creation.
+	}
+}
+
 func TestNewWatcher_NilOnChange(t *testing.T) {
-	_, err := NewWatcher(time.Second, nil)
+	_, err := NewWatcher(time.Second, nil, nil)
 	if err == nil {
 		t.Fatal("NewWatcher(nil) should return error")
 	}


### PR DESCRIPTION
## Summary
- Fixes startup FD exhaustion caused by recursively watching every directory under project roots, which can surface as `too many open files` errors.
- Adds configurable watcher exclusions via `watch_exclude_patterns` and wires them into recursive watch setup and dynamic new-directory watches.
- Sets safe, tool-specific defaults for exclusions: `.git`, `node_modules`, `__pycache__`, `.venv`, `venv`, `vendor`, `.next`.

## Problem
`WatchRecursive` previously added every subdirectory with no filtering. On macOS this consumes one FD per watched dir; large project trees quickly exhausted system limits.

## Fix
- Extend watcher construction to accept exclusion patterns.
- Skip excluded subtrees during recursive walk (`filepath.SkipDir`).
- Respect exclusions when auto-adding newly created directories.
- Normalize/dedupe exclusion patterns.
- Add config support and defaults, plus help text/docs snippet.
- Add tests for recursive exclusion and auto-watch exclusion behavior.

## Validation
- `go test ./internal/sync ./internal/config -count=1`