### PR TITLE
fix: preserve project name casing in group headers

### DIFF
--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -78,17 +78,11 @@ class SyncStore {
       this.lastSyncStats = status.stats;
       // Suppress notifications on initial hydration and
       // when a local sync just completed (pendingHydration).
-      // When a session watch is active, still update stats but
-      // skip the sidebar-resetting notifySyncComplete() — the
-      // SSE already handles incremental message updates and a
-      // full session list reload would reset sidebar scroll.
       if (this.pendingHydration) {
         this.pendingHydration = false;
       } else if (changed && !isInitial) {
         this.loadStats();
-        if (!this.watchEventSource) {
-          this.notifySyncComplete();
-        }
+        this.notifySyncComplete();
       }
     } catch (error) {
       this.pendingHydration = false;


### PR DESCRIPTION
## Summary

- Remove `text-transform: capitalize` from `.group-header` so project names display with their original casing from the filesystem
- Revert the `notifySyncComplete()` suppression during session watches — it caused stale sidebar and filter state (projects, agents, session counts stopped updating while any session was selected)

## Test plan

- [ ] Open a session with "Group by project" enabled — project names should show original casing (e.g. "myProject" not "Myproject")
- [ ] While watching a live session, trigger a background sync — sidebar session list and filter dropdowns should update without going stale