### PR TITLE
feat(desktop): add Hide and Hide Others to macOS app menu

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -615,7 +615,8 @@ fn setup_menu(app: &mut App) -> Result<(), DynError> {
         .item(&check_updates)
         .separator();
 
-    if cfg!(target_os = "macos") {
+    #[cfg(target_os = "macos")]
+    {
         builder = builder.hide().hide_others().separator();
     }
 


### PR DESCRIPTION
Add standard macOS menu items (Hide AgentsView, Hide Others) with their default keyboard shortcuts (Cmd+H, Cmd+Option+H) to the app menu, gated behind `#[cfg(target_os = "macos")]` so other platforms are unaffected.

<img width="274" height="197" alt="agentsview-macos-menu" src="https://github.com/user-attachments/assets/706f81c5-fa95-4890-98cb-7e5ae53a4a52" />
