### PR TITLE
fix: show user messages starting with skill/command invocations in transcript

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -23,7 +23,7 @@ import (
 // formatting changes). Old databases with a lower user_version
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
-const dataVersion = 4
+const dataVersion = 5
 
 //go:embed schema.sql
 var schemaSQL string

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -17,8 +17,12 @@ import (
 )
 
 var (
-	xmlTaskIDRe  = regexp.MustCompile(`<task-id>([^<]+)</task-id>`)
-	xmlToolUseRe = regexp.MustCompile(`<tool-use-id>([^<]+)</tool-use-id>`)
+	xmlTaskIDRe   = regexp.MustCompile(`<task-id>([^<]+)</task-id>`)
+	xmlToolUseRe  = regexp.MustCompile(`<tool-use-id>([^<]+)</tool-use-id>`)
+	xmlCmdNameRe  = regexp.MustCompile(`<command-name>([^<]+)</command-name>`)
+	xmlCmdMsgRe   = regexp.MustCompile(`<command-message>([^<]+)</command-message>`)
+	xmlCmdArgsRe  = regexp.MustCompile(`<command-args>([^<]*)</command-args>`)
+	xmlCmdStripRe = regexp.MustCompile(`<command-(?:name|message|args)>[^<]*</command-(?:name|message|args)>`)
 )
 
 const (
@@ -326,6 +330,19 @@ func extractMessagesFrom(
 		content := gjson.Get(e.line, "message.content")
 		text, hasThinking, hasToolUse, tcs, trs :=
 			ExtractTextContent(content)
+
+		// Convert command/skill invocation XML into readable
+		// text (e.g. "/roborev-fix 450"). If the content
+		// looks like a command envelope but can't be
+		// normalized, skip it to avoid raw XML in transcripts.
+		if e.entryType == "user" {
+			if cmdText, ok := extractCommandText(text); ok {
+				text = cmdText
+			} else if isCommandEnvelope(text) {
+				continue
+			}
+		}
+
 		if strings.TrimSpace(text) == "" && len(trs) == 0 {
 			continue
 		}
@@ -639,6 +656,19 @@ func extractMessages(entries []dagEntry) (
 		content := gjson.Get(e.line, "message.content")
 		text, hasThinking, hasToolUse, tcs, trs :=
 			ExtractTextContent(content)
+
+		// Convert command/skill invocation XML into readable
+		// text (e.g. "/roborev-fix 450"). If the content
+		// looks like a command envelope but can't be
+		// normalized, skip it to avoid raw XML in transcripts.
+		if e.entryType == "user" {
+			if cmdText, ok := extractCommandText(text); ok {
+				text = cmdText
+			} else if isCommandEnvelope(text) {
+				continue
+			}
+		}
+
 		if strings.TrimSpace(text) == "" && len(trs) == 0 {
 			continue
 		}
@@ -840,6 +870,69 @@ func truncate(s string, maxLen int) string {
 	return string(r[:maxLen]) + "..."
 }
 
+// extractCommandText detects Claude Code command/skill invocation
+// messages and returns a human-readable representation like
+// "/skill-name args". Only matches messages whose trimmed content
+// starts with <command-message> or <command-name> (the standard
+// envelope format), so user messages that merely mention these
+// tags in prose are not affected.
+// Returns ("", false) if the content is not a command message.
+func extractCommandText(content string) (string, bool) {
+	trimmed := strings.TrimLeftFunc(content, func(r rune) bool {
+		return r == '\uFEFF' || unicode.IsSpace(r)
+	})
+	if !strings.HasPrefix(trimmed, "<command-message>") &&
+		!strings.HasPrefix(trimmed, "<command-name>") {
+		return "", false
+	}
+	// Verify the content is purely command XML tags with no
+	// trailing prose — strip all known tags and check the
+	// remainder is whitespace-only.
+	stripped := xmlCmdStripRe.ReplaceAllString(trimmed, "")
+	if strings.TrimSpace(stripped) != "" {
+		return "", false
+	}
+	m := xmlCmdNameRe.FindStringSubmatch(content)
+	if m == nil {
+		// Bare <command-message> without <command-name>: extract
+		// the command-message value as a fallback.
+		if cm := xmlCmdMsgRe.FindStringSubmatch(content); cm != nil {
+			return "/" + cm[1], true
+		}
+		return "", false
+	}
+	name := m[1]
+	// Ensure the name starts with "/" for display.
+	if !strings.HasPrefix(name, "/") {
+		name = "/" + name
+	}
+	args := ""
+	if am := xmlCmdArgsRe.FindStringSubmatch(content); am != nil {
+		args = strings.TrimSpace(am[1])
+	}
+	if args != "" {
+		return name + " " + args, true
+	}
+	return name, true
+}
+
+// isCommandEnvelope returns true if the content is a pure
+// command XML envelope (starts with a command tag and contains
+// nothing but command tags and whitespace). Used as a fallback
+// to skip messages that look like command envelopes but couldn't
+// be normalized by extractCommandText.
+func isCommandEnvelope(content string) bool {
+	trimmed := strings.TrimLeftFunc(content, func(r rune) bool {
+		return r == '\uFEFF' || unicode.IsSpace(r)
+	})
+	if !strings.HasPrefix(trimmed, "<command-message>") &&
+		!strings.HasPrefix(trimmed, "<command-name>") {
+		return false
+	}
+	stripped := xmlCmdStripRe.ReplaceAllString(trimmed, "")
+	return strings.TrimSpace(stripped) == ""
+}
+
 // isClaudeSystemMessage returns true if the content matches
 // a known system-injected user message pattern.
 func isClaudeSystemMessage(content string) bool {
@@ -850,8 +943,6 @@ func isClaudeSystemMessage(content string) bool {
 		"This session is being continued",
 		"[Request interrupted",
 		"<task-notification>",
-		"<command-message>",
-		"<command-name>",
 		"<local-command-",
 		"Stop hook feedback:",
 	}

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -135,8 +135,6 @@ func TestParseClaudeSession_SkippedMessages(t *testing.T) {
 			testjsonl.ClaudeUserJSON("This session is being continued from a previous conversation.", tsZero),
 			testjsonl.ClaudeUserJSON("[Request interrupted by user]", tsZeroS1),
 			testjsonl.ClaudeUserJSON("<task-notification>data</task-notification>", tsZeroS2),
-			testjsonl.ClaudeUserJSON("<command-message>x</command-message>", "2024-01-01T00:00:03Z"),
-			testjsonl.ClaudeUserJSON("<command-name>commit</command-name>", "2024-01-01T00:00:04Z"),
 			testjsonl.ClaudeUserJSON("<local-command-result>ok</local-command-result>", "2024-01-01T00:00:05Z"),
 			testjsonl.ClaudeUserJSON("Stop hook feedback: rejected", "2024-01-01T00:00:06Z"),
 			testjsonl.ClaudeUserJSON("real user message", "2024-01-01T00:00:07Z"),
@@ -145,6 +143,41 @@ func TestParseClaudeSession_SkippedMessages(t *testing.T) {
 		assert.Equal(t, 1, sess.MessageCount)
 		assert.Equal(t, "real user message", msgs[0].Content)
 		assert.Equal(t, "real user message", sess.FirstMessage)
+	})
+
+	t.Run("skill invocation shown as user message", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON(
+				"<command-message>roborev-fix</command-message>\n<command-name>/roborev-fix</command-name>\n<command-args>450</command-args>",
+				tsZero,
+			),
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "Looking at issue 450..."},
+			}, tsZeroS1),
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		assert.Equal(t, 2, sess.MessageCount)
+		assert.Equal(t, 1, sess.UserMessageCount)
+		assert.Equal(t, "/roborev-fix 450", sess.FirstMessage)
+		assert.Equal(t, RoleUser, msgs[0].Role)
+		assert.Equal(t, "/roborev-fix 450", msgs[0].Content)
+	})
+
+	t.Run("skill invocation without args shown as user message", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON(
+				"<command-message>superpowers:brainstorming</command-message>\n<command-name>/superpowers:brainstorming</command-name>",
+				tsZero,
+			),
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "Starting brainstorming..."},
+			}, tsZeroS1),
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		assert.Equal(t, 2, sess.MessageCount)
+		assert.Equal(t, "/superpowers:brainstorming", sess.FirstMessage)
+		assert.Equal(t, RoleUser, msgs[0].Role)
+		assert.Equal(t, "/superpowers:brainstorming", msgs[0].Content)
 	})
 
 	t.Run("assistant with system-like content not filtered", func(t *testing.T) {

--- a/internal/parser/iflow.go
+++ b/internal/parser/iflow.go
@@ -355,6 +355,19 @@ func extractMessagesIflow(entries []dagEntryIflow) (
 		content := gjson.Get(e.line, "message.content")
 		text, hasThinking, hasToolUse, tcs, trs :=
 			ExtractTextContent(content)
+
+		// Convert command/skill invocation XML into readable
+		// text (e.g. "/roborev-fix 450"). If the content
+		// looks like a command envelope but can't be
+		// normalized, skip it to avoid raw XML in transcripts.
+		if e.entryType == "user" {
+			if cmdText, ok := extractCommandText(text); ok {
+				text = cmdText
+			} else if isCommandEnvelope(text) {
+				continue
+			}
+		}
+
 		if strings.TrimSpace(text) == "" && len(trs) == 0 && len(tcs) == 0 {
 			continue
 		}
@@ -443,8 +456,6 @@ func isIflowSystemMessage(content string) bool {
 		"This session is being continued",
 		"[Request interrupted",
 		"<task-notification>",
-		"<command-message>",
-		"<command-name>",
 		"<local-command-",
 		"Stop hook feedback:",
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -923,10 +923,13 @@ func TestIsClaudeSystemMessage(t *testing.T) {
 		{"task-notification",
 			"<task-notification>some data</task-notification>",
 			true},
-		{"command-message",
-			"<command-message>foo</command-message>", true},
-		{"command-name",
-			"<command-name>commit</command-name>", true},
+		{"command-message is not system",
+			"<command-message>foo</command-message>", false},
+		{"command-name is not system",
+			"<command-name>commit</command-name>", false},
+		{"command-message with args is not system",
+			"<command-message>roborev-fix</command-message>\n<command-name>/roborev-fix</command-name>\n<command-args>450</command-args>",
+			false},
 		{"local-command tag",
 			"<local-command-result>ok</local-command-result>",
 			true},
@@ -936,13 +939,13 @@ func TestIsClaudeSystemMessage(t *testing.T) {
 			"  \n This session is being continued...",
 			true},
 		{"leading tabs trimmed",
-			"\t<command-name>commit</command-name>",
+			"\t<task-notification>data</task-notification>",
 			true},
 		{"BOM prefix trimmed",
 			"\uFEFFThis session is being continued...",
 			true},
 		{"BOM plus whitespace trimmed",
-			"\uFEFF \t<command-name>commit</command-name>",
+			"\uFEFF \t<task-notification>data</task-notification>",
 			true},
 		{"whitespace before BOM trimmed",
 			" \uFEFFThis session is being continued...",
@@ -965,6 +968,94 @@ func TestIsClaudeSystemMessage(t *testing.T) {
 			if got != tt.want {
 				t.Errorf(
 					"isClaudeSystemMessage(%q) = %v, want %v",
+					tt.content, got, tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestExtractCommandText(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		ok      bool
+	}{
+		{
+			"skill with args",
+			"<command-message>roborev-fix</command-message>\n<command-name>/roborev-fix</command-name>\n<command-args>450</command-args>",
+			"/roborev-fix 450",
+			true,
+		},
+		{
+			"skill without args",
+			"<command-message>superpowers:brainstorming</command-message>\n<command-name>/superpowers:brainstorming</command-name>",
+			"/superpowers:brainstorming",
+			true,
+		},
+		{
+			"command-name first format",
+			"<command-name>/model</command-name>\n            <command-message>model</command-message>\n            <command-args></command-args>",
+			"/model",
+			true,
+		},
+		{
+			"command-name first with args",
+			"<command-name>/roborev-fix</command-name>\n<command-message>roborev-fix</command-message>\n<command-args>491</command-args>",
+			"/roborev-fix 491",
+			true,
+		},
+		{
+			"not a command message",
+			"Fix the login bug",
+			"",
+			false,
+		},
+		{
+			"empty string",
+			"",
+			"",
+			false,
+		},
+		{
+			"prose mentioning command-name tag not rewritten",
+			"The <command-name>foo</command-name> tag is used for...",
+			"",
+			false,
+		},
+		{
+			"tag followed by prose not rewritten",
+			"<command-message>foo</command-message> is the XML wrapper...",
+			"",
+			false,
+		},
+		{
+			"bare command-message without command-name",
+			"<command-message>insights</command-message>",
+			"/insights",
+			true,
+		},
+		{
+			"BOM-prefixed command envelope",
+			"\uFEFF<command-name>/commit</command-name>\n<command-message>commit</command-message>",
+			"/commit",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := extractCommandText(tt.content)
+			if ok != tt.ok {
+				t.Errorf(
+					"extractCommandText(%q) ok = %v, want %v",
+					tt.content, ok, tt.ok,
+				)
+			}
+			if got != tt.want {
+				t.Errorf(
+					"extractCommandText(%q) = %q, want %q",
 					tt.content, got, tt.want,
 				)
 			}


### PR DESCRIPTION
## Summary

- User messages containing `<command-message>`/`<command-name>` XML tags (skill invocations like `/roborev-fix 450`) were incorrectly filtered out by `isClaudeSystemMessage`, causing sessions started with a slash command to show no first user message
- Extracts command name and arguments into readable text (e.g. `/roborev-fix 450`) and displays them as normal user messages
- Only matches pure command XML envelopes (no trailing prose), with fallback for bare `<command-message>`-only entries and safe skipping of unrecognized envelopes
- Removes matching frontend filter in `MessageList.svelte`
- Bumps `dataVersion` to 5 so existing databases automatically resync

Fixes wesm/agentsview#206

## Test plan

- [x] `TestExtractCommandText` — 9 cases covering both envelope formats, with/without args, prose false positives, bare fallback
- [x] `TestIsClaudeSystemMessage` — updated to verify command tags are no longer filtered
- [x] `TestParseClaudeSession_SkippedMessages` — integration tests for skill invocations appearing as user messages
- [x] Full parser test suite passes
- [x] Manual verification: start a session with a slash command, confirm the command appears as the first user message in the transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)