### PR TITLE
fix: support Cursor's nested transcript directory layout

### DIFF
--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -586,12 +586,22 @@ func DiscoverCursorSessions(
 			if err != nil {
 				continue
 			}
+			dirName := sf.Name()
 			for _, sub := range subEntries {
 				if sub.IsDir() {
 					continue
 				}
 				name := sub.Name()
 				if !IsCursorTranscriptExt(name) {
+					continue
+				}
+				// Only accept files whose stem matches
+				// the parent directory name, e.g.
+				// <uuid>/<uuid>.jsonl.
+				stem := strings.TrimSuffix(
+					name, filepath.Ext(name),
+				)
+				if stem != dirName {
 					continue
 				}
 				fullPath := filepath.Join(
@@ -643,16 +653,16 @@ func FindCursorSourceFile(
 			if !entry.IsDir() {
 				continue
 			}
-			// Flat layout: agent-transcripts/<id>.ext
+			// Nested layout first (matches discovery
+			// precedence), then flat layout.
 			candidates := []string{
 				filepath.Join(
 					projectsDir, entry.Name(),
-					"agent-transcripts", target,
+					"agent-transcripts", sessionID, target,
 				),
-				// Nested layout: agent-transcripts/<id>/<id>.ext
 				filepath.Join(
 					projectsDir, entry.Name(),
-					"agent-transcripts", sessionID, target,
+					"agent-transcripts", target,
 				),
 			}
 			for _, candidate := range candidates {

--- a/internal/parser/discovery_test.go
+++ b/internal/parser/discovery_test.go
@@ -1234,6 +1234,15 @@ func TestDiscoverCursorSessions_NestedLayout(t *testing.T) {
 			wantCount: 1,
 		},
 		{
+			name: "NestedIgnoresAuxiliaryFiles",
+			files: map[string]string{
+				filepath.Join(cursorTranscripts, "eee", "eee.jsonl"):   `{"role":"user"}`,
+				filepath.Join(cursorTranscripts, "eee", "other.jsonl"): `{"role":"user"}`,
+				filepath.Join(cursorTranscripts, "eee", "notes.txt"):   "notes",
+			},
+			wantCount: 1,
+		},
+		{
 			name: "MixedFlatAndNested",
 			files: map[string]string{
 				filepath.Join(cursorTranscripts, "flat.txt"):               "user:\nhi",


### PR DESCRIPTION
## Summary

- Cursor recently changed its transcript storage from a flat layout (`agent-transcripts/<uuid>.jsonl`) to a nested layout (`agent-transcripts/<uuid>/<uuid>.jsonl`). The discovery and source file lookup functions only handled the flat layout, causing sessions from newer Cursor versions to be invisible.
- Updates `DiscoverCursorSessions` and `FindCursorSourceFile` to handle both flat and nested layouts.
- Extracts dedup logic into `cursorAddSeen` helper to avoid repetition between the two code paths.

## Test plan

- [x] New table-driven tests for nested layout discovery (jsonl, txt, dedup, mixed flat+nested)
- [x] New tests for `FindCursorSourceFile` with nested layout
- [x] Existing flat-layout tests continue to pass
- [x] Verified against real Cursor transcript directory on macOS (`~/.cursor/projects/`)