### PR TITLE
 fix: preserve pinned messages after session resync (#259)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1228,17 +1228,31 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 	insertMessages(t, d,
 		userMsg("s1", 0, "msg0"),
 		asstMsg("s1", 1, "msg1"),
+		userMsg("s1", 2, "msg2"),
 	)
 
-	// Pin ordinal-0 message with a note.
 	msgs, err := d.GetAllMessages(ctx, "s1")
 	if err != nil {
 		t.Fatalf("GetAllMessages: %v", err)
 	}
+
+	// Pin ordinal-0 with a note and ordinal-2 with no note.
 	note := "important"
-	pinID, err := d.PinMessage("s1", msgs[0].ID, &note)
-	if err != nil || pinID == 0 {
-		t.Fatalf("PinMessage: id=%d err=%v", pinID, err)
+	if _, err := d.PinMessage("s1", msgs[0].ID, &note); err != nil {
+		t.Fatalf("PinMessage ord=0: %v", err)
+	}
+	if _, err := d.PinMessage("s1", msgs[2].ID, nil); err != nil {
+		t.Fatalf("PinMessage ord=2: %v", err)
+	}
+
+	// Record created_at before replace so we can verify it is preserved.
+	prePins, err := d.ListPinnedMessages(ctx, "s1")
+	if err != nil {
+		t.Fatalf("ListPinnedMessages before replace: %v", err)
+	}
+	pinCreatedAt := make(map[int]string) // ordinal → created_at
+	for _, p := range prePins {
+		pinCreatedAt[p.Ordinal] = p.CreatedAt
 	}
 
 	// Full replace (simulates a resync of an OpenCode or
@@ -1246,6 +1260,7 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 	if err := d.ReplaceSessionMessages("s1", []Message{
 		userMsg("s1", 0, "msg0-updated"),
 		asstMsg("s1", 1, "msg1-updated"),
+		userMsg("s1", 2, "msg2-updated"),
 	}); err != nil {
 		t.Fatalf("ReplaceSessionMessages: %v", err)
 	}
@@ -1254,26 +1269,55 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAllMessages after replace: %v", err)
 	}
-	if len(newMsgs) != 2 {
-		t.Fatalf("want 2 messages after replace, got %d", len(newMsgs))
+	if len(newMsgs) != 3 {
+		t.Fatalf("want 3 messages after replace, got %d", len(newMsgs))
 	}
 
 	pins, err := d.ListPinnedMessages(ctx, "s1")
 	if err != nil {
 		t.Fatalf("ListPinnedMessages: %v", err)
 	}
-	if len(pins) != 1 {
-		t.Fatalf("want 1 pin after replace, got %d", len(pins))
+	if len(pins) != 2 {
+		t.Fatalf("want 2 pins after replace, got %d", len(pins))
 	}
-	if pins[0].MessageID != newMsgs[0].ID {
-		t.Errorf("pin message_id = %d, want %d (new ordinal-0 id)",
-			pins[0].MessageID, newMsgs[0].ID)
+
+	byOrdinal := make(map[int]PinnedMessage)
+	for _, p := range pins {
+		byOrdinal[p.Ordinal] = p
 	}
-	if pins[0].Ordinal != 0 {
-		t.Errorf("pin ordinal = %d, want 0", pins[0].Ordinal)
+
+	// Ordinal-0: note preserved, message_id updated, created_at preserved.
+	p0, ok := byOrdinal[0]
+	if !ok {
+		t.Fatal("pin for ordinal 0 missing after replace")
 	}
-	if pins[0].Note == nil || *pins[0].Note != note {
-		t.Errorf("pin note = %v, want %q", pins[0].Note, note)
+	if p0.MessageID != newMsgs[0].ID {
+		t.Errorf("ord=0 pin message_id = %d, want %d",
+			p0.MessageID, newMsgs[0].ID)
+	}
+	if p0.Note == nil || *p0.Note != note {
+		t.Errorf("ord=0 pin note = %v, want %q", p0.Note, note)
+	}
+	if p0.CreatedAt != pinCreatedAt[0] {
+		t.Errorf("ord=0 pin created_at = %q, want %q",
+			p0.CreatedAt, pinCreatedAt[0])
+	}
+
+	// Ordinal-2: nil note preserved, message_id updated.
+	p2, ok := byOrdinal[2]
+	if !ok {
+		t.Fatal("pin for ordinal 2 missing after replace")
+	}
+	if p2.MessageID != newMsgs[2].ID {
+		t.Errorf("ord=2 pin message_id = %d, want %d",
+			p2.MessageID, newMsgs[2].ID)
+	}
+	if p2.Note != nil {
+		t.Errorf("ord=2 pin note = %v, want nil", p2.Note)
+	}
+	if p2.CreatedAt != pinCreatedAt[2] {
+		t.Errorf("ord=2 pin created_at = %q, want %q",
+			p2.CreatedAt, pinCreatedAt[2])
 	}
 }
 
@@ -1317,6 +1361,9 @@ func TestReplaceSessionMessagesDropsPinsForRemovedOrdinals(t *testing.T) {
 	}
 	if pins[0].Ordinal != 0 {
 		t.Errorf("surviving pin ordinal = %d, want 0", pins[0].Ordinal)
+	}
+	if pins[0].Note != nil {
+		t.Errorf("surviving pin note = %v, want nil", pins[0].Note)
 	}
 }
 

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -364,7 +364,7 @@ func (db *DB) MaxOrdinal(sessionID string) int {
 // change for existing messages.
 type savedPin struct {
 	ordinal   int
-	note      sql.NullString
+	note      *string
 	createdAt string
 }
 
@@ -405,16 +405,15 @@ func (db *DB) ReplaceSessionMessages(
 	if err != nil {
 		return fmt.Errorf("saving pins: %w", err)
 	}
+	defer pinRows.Close()
 	var pins []savedPin
 	for pinRows.Next() {
 		var sp savedPin
 		if err := pinRows.Scan(&sp.ordinal, &sp.note, &sp.createdAt); err != nil {
-			pinRows.Close()
 			return fmt.Errorf("scanning pin: %w", err)
 		}
 		pins = append(pins, sp)
 	}
-	pinRows.Close()
 	if err := pinRows.Err(); err != nil {
 		return fmt.Errorf("iterating pins: %w", err)
 	}


### PR DESCRIPTION
ReplaceSessionMessages deleted all messages for a session and relied on the ON DELETE CASCADE FK on pinned_messages.message_id to clean up pins. This meant that every call to writeSessionFull (OpenCode sessions and explicit single-session re-syncs) silently wiped all user pins.

The ordinal column already exists in pinned_messages as a stable key for exactly this scenario. Fix: save (ordinal, note, created_at) for any existing pins before deletion, then re-attach them by matching ordinal to the newly inserted message rows. Pins for ordinals that no longer exist in the replacement set are silently dropped.

Adds two regression tests:
- TestReplaceSessionMessagesPreservesPins: pin + note survive replace
- TestReplaceSessionMessagesDropsPinsForRemovedOrdinals: pin for a removed ordinal is dropped, surviving ordinal is re-linked

Addresses #259 