### PR TITLE
feat: add Positron Assistant session support

### DIFF
--- a/internal/parser/positron.go
+++ b/internal/parser/positron.go
@@ -1,0 +1,148 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ParsePositronSession parses a Positron Assistant chat session
+// file. The format is identical to VSCode Copilot sessions.
+// Returns (nil, nil, nil) if the file is empty or contains no
+// meaningful content.
+func ParsePositronSession(
+	path, project, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	var data []byte
+	if strings.HasSuffix(path, ".jsonl") {
+		data, err = reconstructJSONL(path)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return nil, nil, nil
+	}
+
+	// Reuse VSCode Copilot parsing logic since formats are identical
+	sess, msgs, err := parseVSCodeCopilotData(
+		data, path, project, machine,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sess == nil {
+		return nil, nil, nil
+	}
+
+	// Override agent type and ID prefix for Positron
+	sess.Agent = AgentPositron
+	sess.ID = "positron:" + sess.ID
+
+	sess.File = FileInfo{
+		Path:  path,
+		Size:  info.Size(),
+		Mtime: info.ModTime().UnixNano(),
+	}
+
+	return sess, msgs, nil
+}
+
+// DiscoverPositronSessions finds all chat session files under the
+// Positron User directory. The structure mirrors VSCode:
+// <userDir>/workspaceStorage/<hash>/chatSessions/<uuid>.json
+func DiscoverPositronSessions(userDir string) []DiscoveredFile {
+	if userDir == "" {
+		return nil
+	}
+
+	var files []DiscoveredFile
+
+	// Scan workspaceStorage/<hash>/chatSessions/*.{json,jsonl}
+	wsDir := filepath.Join(userDir, "workspaceStorage")
+	hashDirs, err := os.ReadDir(wsDir)
+	if err != nil {
+		return nil
+	}
+
+	for _, entry := range hashDirs {
+		if !entry.IsDir() {
+			continue
+		}
+
+		hashPath := filepath.Join(wsDir, entry.Name())
+		chatDir := filepath.Join(hashPath, "chatSessions")
+		sessionFiles, err := os.ReadDir(chatDir)
+		if err != nil {
+			continue
+		}
+
+		// Read workspace.json to get project name
+		project := ReadVSCodeWorkspaceManifest(hashPath)
+		if project == "" {
+			project = "unknown"
+		}
+
+		for _, f := range sessionFiles {
+			if f.IsDir() {
+				continue
+			}
+			name := f.Name()
+			if !strings.HasSuffix(name, ".json") &&
+				!strings.HasSuffix(name, ".jsonl") {
+				continue
+			}
+			files = append(files, DiscoveredFile{
+				Path:    filepath.Join(chatDir, name),
+				Project: project,
+				Agent:   AgentPositron,
+			})
+		}
+	}
+
+	return files
+}
+
+// FindPositronSourceFile locates a Positron session file by its
+// raw ID (prefix already stripped).
+func FindPositronSourceFile(userDir, rawID string) string {
+	if userDir == "" || !IsValidSessionID(rawID) {
+		return ""
+	}
+
+	// Search through workspaceStorage
+	wsDir := filepath.Join(userDir, "workspaceStorage")
+	hashDirs, err := os.ReadDir(wsDir)
+	if err != nil {
+		return ""
+	}
+
+	for _, entry := range hashDirs {
+		if !entry.IsDir() {
+			continue
+		}
+		base := filepath.Join(
+			wsDir, entry.Name(), "chatSessions",
+		)
+		// Prefer .jsonl over .json
+		for _, ext := range []string{".jsonl", ".json"} {
+			candidate := filepath.Join(base, rawID+ext)
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate
+			}
+		}
+	}
+
+	return ""
+}

--- a/internal/parser/positron_test.go
+++ b/internal/parser/positron_test.go
@@ -1,0 +1,207 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParsePositronSession(t *testing.T) {
+	// Create a minimal Positron session JSON
+	sessionJSON := `{
+		"version": 3,
+		"requesterUsername": "testuser",
+		"responderUsername": "Positron Assistant",
+		"sessionId": "test-session-123",
+		"creationDate": 1700000000000,
+		"lastMessageDate": 1700001000000,
+		"requests": [
+			{
+				"requestId": "req-1",
+				"message": {
+					"text": "Hello, help me with R code",
+					"parts": []
+				},
+				"response": [
+					{
+						"value": "I can help you with R code."
+					}
+				],
+				"timestamp": 1700000000000
+			},
+			{
+				"requestId": "req-2",
+				"message": {
+					"text": "How do I load a CSV?",
+					"parts": []
+				},
+				"response": [
+					{
+						"kind": "toolInvocationSerialized",
+						"toolId": "copilot_readFile",
+						"toolCallId": "call-1",
+						"isComplete": true
+					},
+					{
+						"value": "Use read.csv() function."
+					}
+				],
+				"timestamp": 1700001000000
+			}
+		]
+	}`
+
+	tmpDir := t.TempDir()
+	sessionPath := filepath.Join(tmpDir, "test-session.json")
+	if err := os.WriteFile(
+		sessionPath, []byte(sessionJSON), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	sess, msgs, err := ParsePositronSession(
+		sessionPath, "test-project", "test-machine",
+	)
+	if err != nil {
+		t.Fatalf("ParsePositronSession failed: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected session, got nil")
+	}
+
+	// Verify session metadata
+	if sess.Agent != AgentPositron {
+		t.Errorf("agent = %v, want %v", sess.Agent, AgentPositron)
+	}
+	if sess.ID != "positron:test-session-123" {
+		t.Errorf("ID = %v, want positron:test-session-123", sess.ID)
+	}
+	if sess.Project != "test-project" {
+		t.Errorf("project = %v, want test-project", sess.Project)
+	}
+	if sess.FirstMessage != "Hello, help me with R code" {
+		t.Errorf(
+			"firstMessage = %v, want 'Hello, help me with R code'",
+			sess.FirstMessage,
+		)
+	}
+
+	// Verify messages
+	if len(msgs) != 4 {
+		t.Fatalf("len(msgs) = %d, want 4", len(msgs))
+	}
+
+	// First user message
+	if msgs[0].Role != RoleUser {
+		t.Errorf("msgs[0].Role = %v, want user", msgs[0].Role)
+	}
+	if msgs[0].Content != "Hello, help me with R code" {
+		t.Errorf("msgs[0].Content = %v", msgs[0].Content)
+	}
+
+	// First assistant response
+	if msgs[1].Role != RoleAssistant {
+		t.Errorf("msgs[1].Role = %v, want assistant", msgs[1].Role)
+	}
+
+	// Second assistant should have tool use
+	if !msgs[3].HasToolUse {
+		t.Error("msgs[3] should have tool use")
+	}
+}
+
+func TestDiscoverPositronSessions(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create directory structure:
+	// <tmpDir>/workspaceStorage/<hash>/chatSessions/<uuid>.json
+	// <tmpDir>/workspaceStorage/<hash>/workspace.json
+	hashDir := filepath.Join(
+		tmpDir, "workspaceStorage", "abc123hash",
+	)
+	chatDir := filepath.Join(hashDir, "chatSessions")
+	if err := os.MkdirAll(chatDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create workspace.json
+	wsJSON := `{"folder": "file:///Users/test/myproject"}`
+	if err := os.WriteFile(
+		filepath.Join(hashDir, "workspace.json"),
+		[]byte(wsJSON),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create session files
+	sessionJSON := `{"version": 3, "requests": []}`
+	for _, name := range []string{
+		"session-1.json",
+		"session-2.jsonl",
+	} {
+		if err := os.WriteFile(
+			filepath.Join(chatDir, name),
+			[]byte(sessionJSON),
+			0644,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create a non-session file that should be ignored
+	if err := os.WriteFile(
+		filepath.Join(chatDir, "readme.txt"),
+		[]byte("ignore me"),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	files := DiscoverPositronSessions(tmpDir)
+	if len(files) != 2 {
+		t.Fatalf("len(files) = %d, want 2", len(files))
+	}
+
+	for _, f := range files {
+		if f.Agent != AgentPositron {
+			t.Errorf("agent = %v, want positron", f.Agent)
+		}
+		if f.Project != "myproject" {
+			t.Errorf("project = %v, want myproject", f.Project)
+		}
+	}
+}
+
+func TestFindPositronSourceFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create directory structure
+	hashDir := filepath.Join(
+		tmpDir, "workspaceStorage", "abc123hash",
+	)
+	chatDir := filepath.Join(hashDir, "chatSessions")
+	if err := os.MkdirAll(chatDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create session file
+	sessionPath := filepath.Join(chatDir, "test-uuid.json")
+	if err := os.WriteFile(
+		sessionPath, []byte(`{}`), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test finding existing session
+	found := FindPositronSourceFile(tmpDir, "test-uuid")
+	if found != sessionPath {
+		t.Errorf("found = %v, want %v", found, sessionPath)
+	}
+
+	// Test finding non-existent session
+	notFound := FindPositronSourceFile(tmpDir, "nonexistent")
+	if notFound != "" {
+		t.Errorf("expected empty string, got %v", notFound)
+	}
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -30,6 +30,7 @@ const (
 	AgentCortex        AgentType = "cortex"
 	AgentHermes        AgentType = "hermes"
 	AgentWarp          AgentType = "warp"
+	AgentPositron      AgentType = "positron"
 )
 
 // AgentDef describes a supported coding agent's filesystem
@@ -280,6 +281,20 @@ var Registry = []AgentDef{
 		DefaultDirs: warpDefaultDirs(),
 		IDPrefix:    "warp:",
 		FileBased:   false,
+	},
+	{
+		Type:        AgentPositron,
+		DisplayName: "Positron Assistant",
+		EnvVar:      "POSITRON_DIR",
+		ConfigKey:   "positron_dirs",
+		DefaultDirs: []string{
+			"Library/Application Support/Positron/User",
+		},
+		IDPrefix:       "positron:",
+		WatchSubdirs:   []string{"workspaceStorage"},
+		FileBased:      true,
+		DiscoverFunc:   DiscoverPositronSessions,
+		FindSourceFunc: FindPositronSourceFile,
 	},
 }
 

--- a/internal/parser/vscode_copilot.go
+++ b/internal/parser/vscode_copilot.go
@@ -131,6 +131,35 @@ func ParseVSCodeCopilotSession(
 		return nil, nil, nil
 	}
 
+	sess, msgs, err := parseVSCodeCopilotData(
+		data, path, project, machine,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sess == nil {
+		return nil, nil, nil
+	}
+
+	sess.Agent = AgentVSCodeCopilot
+	sess.ID = "vscode-copilot:" + strings.TrimPrefix(
+		sess.ID, "vscode-copilot:",
+	)
+	sess.File = FileInfo{
+		Path:  path,
+		Size:  info.Size(),
+		Mtime: info.ModTime().UnixNano(),
+	}
+
+	return sess, msgs, nil
+}
+
+// parseVSCodeCopilotData parses VSCode-style chat session JSON
+// data. Used by both VSCode Copilot and Positron parsers since
+// the formats are identical.
+func parseVSCodeCopilotData(
+	data []byte, path, project, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
 	var session vscodeCopilotSession
 	if err := json.Unmarshal(data, &session); err != nil {
 		return nil, nil, fmt.Errorf(
@@ -209,7 +238,6 @@ func ParseVSCodeCopilotSession(
 			strings.TrimSuffix(base, ".jsonl"), ".json",
 		)
 	}
-	sessionID = "vscode-copilot:" + sessionID
 
 	// Use customTitle as first message if we have no user text
 	if firstMessage == "" && session.CustomTitle != "" {
@@ -234,17 +262,11 @@ func ParseVSCodeCopilotSession(
 		ID:               sessionID,
 		Project:          project,
 		Machine:          machine,
-		Agent:            AgentVSCodeCopilot,
 		FirstMessage:     firstMessage,
 		StartedAt:        startedAt,
 		EndedAt:          endedAt,
 		MessageCount:     len(messages),
 		UserMessageCount: userCount,
-		File: FileInfo{
-			Path:  path,
-			Size:  info.Size(),
-			Mtime: info.ModTime().UnixNano(),
-		},
 	}
 
 	return sess, messages, nil

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1385,6 +1385,8 @@ func (e *Engine) processFile(
 		res = e.processCortex(file, info)
 	case parser.AgentHermes:
 		res = e.processHermes(file, info)
+	case parser.AgentPositron:
+		res = e.processPositron(file, info)
 	default:
 		res = processResult{
 			err: fmt.Errorf(
@@ -2013,6 +2015,36 @@ func (e *Engine) processHermes(
 		},
 	}
 }
+
+func (e *Engine) processPositron(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	if e.shouldSkipByPath(file.Path, info) {
+		return processResult{skip: true}
+	}
+
+	sess, msgs, err := parser.ParsePositronSession(
+		file.Path, file.Project, e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if sess == nil {
+		return processResult{}
+	}
+
+	hash, err := ComputeFileHash(file.Path)
+	if err == nil {
+		sess.File.Hash = hash
+	}
+
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: *sess, Messages: msgs},
+		},
+	}
+}
+
 func (e *Engine) processCursor(
 	file parser.DiscoveredFile, info os.FileInfo,
 ) processResult {


### PR DESCRIPTION
Add support for parsing and syncing Positron Assistant chat sessions.

Positron is an IDE based on VS Code, so sessions use the same format as
VSCode Copilot. Sessions are stored at: `~/Library/Application Support/Positron/User/workspaceStorage/<hash>/chatSessions/`

Changes:
   - Add AgentPositron type and registry entry in types.go
   - Create positron.go with parser and discovery functions
   - Refactor vscode_copilot.go to extract shared parseVSCodeCopilotData()
   - Add processPositron handler in sync engine
   - Add comprehensive test coverage