### PR TITLE
feat: add OpenHands CLI session support and shallow watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # agentsview
 
 A local-first desktop and web application for browsing, searching, and analyzing
-AI agent coding sessions. Supports Claude Code, Codex, OpenCode, and 11 other
-agents.
+AI agent coding sessions. Supports Claude Code, Codex, OpenCode, and many
+other agents.
 
 <p align="center">
   <img src="https://agentsview.io/screenshots/dashboard.png" alt="Analytics dashboard" width="720">
@@ -51,7 +51,7 @@ behavior, and track usage patterns over time.
 - **Full-text search** across all message content, instantly
 - **Analytics dashboard** with activity heatmaps, tool usage, velocity metrics,
   and project breakdowns
-- **Multi-agent support** for Claude Code, Codex, OpenCode, and 11 other agents
+- **Multi-agent support** for Claude Code, Codex, OpenCode, and many other agents
   ([full list](#supported-agents))
 - **Live updates** via SSE as active sessions receive new messages
 - **Keyboard-first** navigation (vim-style `j`/`k`/`[`/`]`)
@@ -345,6 +345,7 @@ frontend/           Svelte 5 SPA (Vite, TypeScript)
 | Copilot        | `~/.copilot/`                                      | `COPILOT_DIR`         |
 | Gemini         | `~/.gemini/`                                       | `GEMINI_DIR`          |
 | OpenCode       | `~/.local/share/opencode/`                         | `OPENCODE_DIR`        |
+| OpenHands CLI  | `~/.openhands/conversations/`                      | `OPENHANDS_CONVERSATIONS_DIR` |
 | Cursor         | `~/.cursor/projects/`                              | `CURSOR_PROJECTS_DIR` |
 | Amp            | `~/.local/share/amp/threads/`                      | `AMP_DIR`             |
 | iFlow          | `~/.iflow/projects/`                               | `IFLOW_DIR`           |

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -79,9 +79,9 @@ func main() {
 func printUsage() {
 	fmt.Printf(`agentsview %s - local web viewer for AI agent sessions
 
-Syncs Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, Cursor,
-and Amp session data into SQLite, serves an analytics dashboard and
-session browser via a local web UI.
+Syncs Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, OpenHands,
+Cursor, and Amp session data into SQLite, serves an analytics dashboard
+and session browser via a local web UI.
 
 Usage:
   agentsview [flags]          Start the server (default command)
@@ -150,6 +150,7 @@ Environment variables:
   COPILOT_DIR             Copilot CLI directory
   GEMINI_DIR              Gemini CLI directory
   OPENCODE_DIR            OpenCode data directory
+  OPENHANDS_CONVERSATIONS_DIR OpenHands CLI conversations directory
   CURSOR_PROJECTS_DIR     Cursor projects directory
   IFLOW_DIR               iFlow projects directory
   AMP_DIR                 Amp threads directory

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -513,8 +513,9 @@ func startFileWatcher(
 	}
 
 	type watchRoot struct {
-		dir  string
-		root string // actual path passed to WatchRecursive
+		dir     string
+		root    string // actual path passed to WatchRecursive
+		shallow bool   // use shallow watch (root only)
 	}
 
 	var roots []watchRoot
@@ -526,7 +527,7 @@ func startFileWatcher(
 			if len(def.WatchSubdirs) == 0 {
 				if _, err := os.Stat(d); err == nil {
 					roots = append(
-						roots, watchRoot{d, d},
+						roots, watchRoot{d, d, def.ShallowWatch},
 					)
 				}
 				continue
@@ -535,7 +536,7 @@ func startFileWatcher(
 				watchDir := filepath.Join(d, sub)
 				if _, err := os.Stat(watchDir); err == nil {
 					roots = append(
-						roots, watchRoot{d, watchDir},
+						roots, watchRoot{d, watchDir, def.ShallowWatch},
 					)
 				}
 			}
@@ -543,7 +544,17 @@ func startFileWatcher(
 	}
 
 	var totalWatched int
+	var shallowWatched int
 	for _, r := range roots {
+		if r.shallow {
+			if watcher.WatchShallow(r.root) {
+				shallowWatched++
+				totalWatched++
+			} else {
+				unwatchedDirs = append(unwatchedDirs, r.dir)
+			}
+			continue
+		}
 		watched, uw, _ := watcher.WatchRecursive(r.root)
 		totalWatched += watched
 		if uw > 0 {
@@ -555,10 +566,17 @@ func startFileWatcher(
 		}
 	}
 
-	fmt.Printf(
-		"Watching %d directories for changes (%s)\n",
-		totalWatched, time.Since(t).Round(time.Millisecond),
-	)
+	if shallowWatched > 0 {
+		fmt.Printf(
+			"Watching %d directories for changes (%d shallow) (%s)\n",
+			totalWatched, shallowWatched, time.Since(t).Round(time.Millisecond),
+		)
+	} else {
+		fmt.Printf(
+			"Watching %d directories for changes (%s)\n",
+			totalWatched, time.Since(t).Round(time.Millisecond),
+		)
+	}
 	watcher.Start()
 	return watcher.Stop, unwatchedDirs
 }

--- a/frontend/src/lib/components/settings/AgentDirSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentDirSettings.svelte
@@ -8,6 +8,7 @@
     copilot: "Copilot",
     gemini: "Gemini",
     opencode: "OpenCode",
+    openhands: "OpenHands CLI",
     cursor: "Cursor",
     amp: "Amp",
     iflow: "iFlow",

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -14,6 +14,7 @@ describe("KNOWN_AGENTS", () => {
       "copilot",
       "gemini",
       "opencode",
+      "openhands",
       "cursor",
       "amp",
       "zencoder",
@@ -53,6 +54,9 @@ describe("agentColor", () => {
     expect(agentColor("opencode")).toBe(
       "var(--accent-purple)",
     );
+    expect(agentColor("openhands")).toBe(
+      "var(--accent-teal)",
+    );
     expect(agentColor("cursor")).toBe(
       "var(--accent-black)",
     );
@@ -83,6 +87,7 @@ describe("agentLabel", () => {
     expect(agentLabel("vscode-copilot")).toBe(
       "VS Code Copilot",
     );
+    expect(agentLabel("openhands")).toBe("OpenHands");
     expect(agentLabel("openclaw")).toBe("OpenClaw");
     expect(agentLabel("iflow")).toBe("iFlow");
   });
@@ -92,4 +97,3 @@ describe("agentLabel", () => {
     expect(agentLabel("gemini")).toBe("Gemini");
   });
 });
-

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -27,6 +27,7 @@ describe("KNOWN_AGENTS", () => {
       "chatgpt",
       "kiro",
       "kiro-ide",
+      "cortex",
     ]);
   });
 

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -10,6 +10,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "copilot", color: "var(--accent-amber)" },
   { name: "gemini", color: "var(--accent-rose)" },
   { name: "opencode", color: "var(--accent-purple)" },
+  { name: "openhands", color: "var(--accent-teal)", label: "OpenHands" },
   { name: "cursor", color: "var(--accent-black)" },
   { name: "amp", color: "var(--accent-coral)", label: "Amp" },
   { name: "zencoder", color: "var(--accent-red)", label: "Zencoder" },

--- a/internal/parser/openhands.go
+++ b/internal/parser/openhands.go
@@ -1,0 +1,756 @@
+package parser
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	openHandsMessageEvent     = "MessageEvent"
+	openHandsActionEvent      = "ActionEvent"
+	openHandsObservationEvent = "ObservationEvent"
+)
+
+// DiscoverOpenHandsSessions finds OpenHands CLI conversation
+// directories under ~/.openhands/conversations.
+func DiscoverOpenHandsSessions(
+	conversationsDir string,
+) []DiscoveredFile {
+	entries, err := os.ReadDir(conversationsDir)
+	if err != nil {
+		return nil
+	}
+
+	var files []DiscoveredFile
+	for _, entry := range entries {
+		if !entry.IsDir() || !IsValidSessionID(entry.Name()) {
+			continue
+		}
+		sessionDir := filepath.Join(
+			conversationsDir, entry.Name(),
+		)
+		if !isOpenHandsSessionDir(sessionDir) {
+			continue
+		}
+		files = append(files, DiscoveredFile{
+			Path:  sessionDir,
+			Agent: AgentOpenHands,
+		})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+// FindOpenHandsSourceFile locates an OpenHands conversation
+// directory by its raw session ID.
+func FindOpenHandsSourceFile(
+	conversationsDir, rawID string,
+) string {
+	if conversationsDir == "" || !IsValidSessionID(rawID) {
+		return ""
+	}
+
+	candidates := []string{rawID}
+	stripped := strings.ReplaceAll(rawID, "-", "")
+	if stripped != rawID {
+		candidates = append(candidates, stripped)
+	}
+
+	for _, cand := range candidates {
+		sessionDir := filepath.Join(conversationsDir, cand)
+		if isOpenHandsSessionDir(sessionDir) {
+			return sessionDir
+		}
+	}
+
+	entries, err := os.ReadDir(conversationsDir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionDir := filepath.Join(
+			conversationsDir, entry.Name(),
+		)
+		if !isOpenHandsSessionDir(sessionDir) {
+			continue
+		}
+		if normalizeOpenHandsSessionID(entry.Name()) == normalizeOpenHandsSessionID(rawID) {
+			return sessionDir
+		}
+	}
+	return ""
+}
+
+// OpenHandsSnapshot computes synthetic file metadata for an
+// OpenHands conversation directory by hashing the relevant
+// metadata of base_state.json, TASKS.json, and events/*.json.
+func OpenHandsSnapshot(path string) (FileInfo, error) {
+	sessionDir, err := normalizeOpenHandsSessionPath(path)
+	if err != nil {
+		return FileInfo{}, err
+	}
+
+	rootInfo, err := os.Stat(sessionDir)
+	if err != nil {
+		return FileInfo{}, fmt.Errorf("stat %s: %w", sessionDir, err)
+	}
+
+	var (
+		totalSize int64
+		maxMtime  = rootInfo.ModTime().UnixNano()
+		manifest  []string
+	)
+
+	addFile := func(rel string) error {
+		full := filepath.Join(sessionDir, rel)
+		info, err := os.Stat(full)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		mtime := info.ModTime().UnixNano()
+		totalSize += info.Size()
+		if mtime > maxMtime {
+			maxMtime = mtime
+		}
+		manifest = append(manifest, fmt.Sprintf(
+			"%s:%d:%d", rel, info.Size(), mtime,
+		))
+		return nil
+	}
+
+	for _, rel := range []string{
+		"base_state.json",
+		"TASKS.json",
+	} {
+		if err := addFile(rel); err != nil {
+			return FileInfo{}, fmt.Errorf(
+				"stat %s: %w", filepath.Join(sessionDir, rel), err,
+			)
+		}
+	}
+
+	eventsDir := filepath.Join(sessionDir, "events")
+	eventEntries, err := os.ReadDir(eventsDir)
+	if err != nil {
+		return FileInfo{}, fmt.Errorf("read %s: %w", eventsDir, err)
+	}
+	for _, entry := range eventEntries {
+		if entry.IsDir() ||
+			!strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		if err := addFile(filepath.Join(
+			"events", entry.Name(),
+		)); err != nil {
+			return FileInfo{}, fmt.Errorf(
+				"stat %s: %w",
+				filepath.Join(eventsDir, entry.Name()), err,
+			)
+		}
+	}
+
+	h := sha256.New()
+	for _, line := range manifest {
+		_, _ = h.Write([]byte(line))
+		_, _ = h.Write([]byte{'\n'})
+	}
+
+	return FileInfo{
+		Path:  sessionDir,
+		Size:  totalSize,
+		Mtime: maxMtime,
+		Hash:  hex.EncodeToString(h.Sum(nil)),
+	}, nil
+}
+
+// ParseOpenHandsSession parses a single OpenHands CLI
+// conversation directory into a session and messages.
+func ParseOpenHandsSession(
+	path, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	sessionDir, err := normalizeOpenHandsSessionPath(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, err
+	}
+
+	snapshot, err := OpenHandsSnapshot(sessionDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	baseState := readOpenHandsJSON(filepath.Join(
+		sessionDir, "base_state.json",
+	))
+	sessionID := baseState.Get("id").Str
+	if sessionID == "" {
+		sessionID = normalizeOpenHandsSessionID(
+			filepath.Base(sessionDir),
+		)
+	}
+
+	model := baseState.Get("agent.llm.model").Str
+	cwd := openHandsBaseStateCwd(baseState)
+
+	eventEntries, err := os.ReadDir(
+		filepath.Join(sessionDir, "events"),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"read %s: %w",
+			filepath.Join(sessionDir, "events"), err,
+		)
+	}
+
+	var (
+		messages      []ParsedMessage
+		firstMessage  string
+		startedAt     time.Time
+		endedAt       time.Time
+		ordinal       int
+		realUserCount int
+	)
+
+	for _, entry := range eventEntries {
+		if entry.IsDir() ||
+			!strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		eventPath := filepath.Join(
+			sessionDir, "events", entry.Name(),
+		)
+		data, err := os.ReadFile(eventPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"read %s: %w", eventPath, err,
+			)
+		}
+		if !gjson.ValidBytes(data) {
+			return nil, nil, fmt.Errorf(
+				"invalid JSON in %s", eventPath,
+			)
+		}
+
+		ev := gjson.ParseBytes(data)
+		ts := parseHermesTimestamp(
+			ev.Get("timestamp").Str,
+		)
+		if !ts.IsZero() {
+			if startedAt.IsZero() || ts.Before(startedAt) {
+				startedAt = ts
+			}
+			if ts.After(endedAt) {
+				endedAt = ts
+			}
+		}
+
+		var (
+			msg        ParsedMessage
+			ok         bool
+			discovered string
+		)
+		switch ev.Get("kind").Str {
+		case openHandsMessageEvent:
+			msg, ok, discovered = parseOpenHandsMessageEvent(
+				ev, ordinal, model, ts,
+			)
+			if ok && msg.Role == RoleUser &&
+				strings.TrimSpace(msg.Content) != "" {
+				realUserCount++
+				if firstMessage == "" {
+					firstMessage = truncate(
+						strings.ReplaceAll(
+							msg.Content, "\n", " ",
+						),
+						300,
+					)
+				}
+			}
+		case openHandsActionEvent:
+			msg, ok, discovered = parseOpenHandsActionEvent(
+				ev, ordinal, model, ts,
+			)
+		case openHandsObservationEvent:
+			msg, ok, discovered = parseOpenHandsObservationEvent(
+				ev, ordinal, ts,
+			)
+		}
+		if !ok {
+			continue
+		}
+		if cwd == "" && discovered != "" {
+			cwd = discovered
+		}
+
+		messages = append(messages, msg)
+		ordinal++
+	}
+
+	if len(messages) == 0 {
+		return nil, nil, nil
+	}
+
+	project := ""
+	if cwd != "" {
+		project = ExtractProjectFromCwd(cwd)
+	}
+	if project == "" {
+		project = "openhands"
+	}
+
+	sess := &ParsedSession{
+		ID:               "openhands:" + sessionID,
+		Project:          project,
+		Machine:          machine,
+		Agent:            AgentOpenHands,
+		Cwd:              cwd,
+		FirstMessage:     firstMessage,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     len(messages),
+		UserMessageCount: realUserCount,
+		File:             snapshot,
+	}
+	return sess, messages, nil
+}
+
+func parseOpenHandsMessageEvent(
+	ev gjson.Result,
+	ordinal int,
+	model string,
+	ts time.Time,
+) (ParsedMessage, bool, string) {
+	llmMessage := ev.Get("llm_message")
+	role := RoleType(llmMessage.Get("role").Str)
+	if role != RoleUser && role != RoleAssistant {
+		return ParsedMessage{}, false, ""
+	}
+
+	content, _, _, toolCalls, toolResults :=
+		ExtractTextContent(llmMessage.Get("content"))
+	content, hasThinking := openHandsAppendThinking(
+		content, ev,
+	)
+	content = strings.TrimSpace(content)
+	if content == "" &&
+		len(toolCalls) == 0 &&
+		len(toolResults) == 0 {
+		return ParsedMessage{}, false, ""
+	}
+
+	msg := ParsedMessage{
+		Ordinal:       ordinal,
+		Role:          role,
+		Content:       content,
+		Timestamp:     ts,
+		HasThinking:   hasThinking,
+		HasToolUse:    len(toolCalls) > 0,
+		ContentLength: len(content),
+		ToolCalls:     toolCalls,
+		ToolResults:   toolResults,
+	}
+	if role == RoleAssistant {
+		msg.Model = model
+	}
+	return msg, true, ""
+}
+
+func parseOpenHandsActionEvent(
+	ev gjson.Result,
+	ordinal int,
+	model string,
+	ts time.Time,
+) (ParsedMessage, bool, string) {
+	toolName := ev.Get("tool_name").Str
+	if toolName == "" {
+		toolName = ev.Get("tool_call.name").Str
+	}
+	if toolName == "" {
+		return ParsedMessage{}, false, ""
+	}
+
+	action := ev.Get("action")
+	inputJSON := strings.TrimSpace(
+		ev.Get("tool_call.arguments").Str,
+	)
+	if inputJSON == "" {
+		inputJSON = action.Raw
+	}
+
+	content := openHandsText(ev.Get("thought"))
+	content = joinOpenHandsParts(
+		content,
+		formatOpenHandsAction(
+			toolName, action, ev.Get("summary").Str,
+		),
+	)
+	content, hasThinking := openHandsAppendThinking(
+		content, ev,
+	)
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ParsedMessage{}, false, ""
+	}
+
+	msg := ParsedMessage{
+		Ordinal:       ordinal,
+		Role:          RoleAssistant,
+		Content:       content,
+		Timestamp:     ts,
+		HasThinking:   hasThinking,
+		HasToolUse:    true,
+		ContentLength: len(content),
+		Model:         model,
+		ToolCalls: []ParsedToolCall{{
+			ToolUseID: ev.Get("tool_call_id").Str,
+			ToolName:  toolName,
+			Category:  openHandsToolCategory(toolName, action),
+			InputJSON: inputJSON,
+		}},
+	}
+	return msg, true, openHandsActionCwd(toolName, action)
+}
+
+func parseOpenHandsObservationEvent(
+	ev gjson.Result,
+	ordinal int,
+	ts time.Time,
+) (ParsedMessage, bool, string) {
+	observation := ev.Get("observation")
+	raw, display := openHandsObservationContent(
+		observation,
+	)
+	display = strings.TrimSpace(display)
+	workingDir := observation.Get(
+		"metadata.working_dir",
+	).Str
+
+	toolUseID := ev.Get("tool_call_id").Str
+	if toolUseID == "" {
+		if display == "" {
+			return ParsedMessage{}, false, ""
+		}
+		return ParsedMessage{
+			Ordinal:       ordinal,
+			Role:          RoleUser,
+			Content:       display,
+			Timestamp:     ts,
+			ContentLength: len(display),
+		}, true, workingDir
+	}
+
+	if raw == "" {
+		b, _ := json.Marshal(display)
+		raw = string(b)
+	}
+	contentLength := len(display)
+	if contentLength == 0 {
+		contentLength = toolResultContentLength(
+			gjson.Parse(raw),
+		)
+	}
+
+	return ParsedMessage{
+		Ordinal:   ordinal,
+		Role:      RoleUser,
+		Timestamp: ts,
+		ToolResults: []ParsedToolResult{{
+			ToolUseID:     toolUseID,
+			ContentLength: contentLength,
+			ContentRaw:    raw,
+		}},
+	}, true, workingDir
+}
+
+func openHandsBaseStateCwd(base gjson.Result) string {
+	for _, path := range []string{
+		"workspace.cwd",
+		"workspace.path",
+		"workspace.mount_path",
+		"workspace.root",
+		"workspace.repo_path",
+		"workspace.repo_root",
+		"workspace.working_dir",
+	} {
+		if value := strings.TrimSpace(
+			base.Get(path).Str,
+		); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func openHandsText(content gjson.Result) string {
+	text, _, _, _, _ := ExtractTextContent(content)
+	return strings.TrimSpace(text)
+}
+
+func openHandsAppendThinking(
+	content string, ev gjson.Result,
+) (string, bool) {
+	thinking := openHandsThinkingText(ev)
+	if thinking == "" {
+		return content, false
+	}
+	block := "[Thinking]\n" + thinking + "\n[/Thinking]"
+	if strings.TrimSpace(content) == "" {
+		return block, true
+	}
+	return content + "\n" + block, true
+}
+
+func openHandsThinkingText(ev gjson.Result) string {
+	var parts []string
+	ev.Get("thinking_blocks").ForEach(func(_, block gjson.Result) bool {
+		if t := strings.TrimSpace(
+			block.Get("thinking").Str,
+		); t != "" {
+			parts = append(parts, t)
+		}
+		return true
+	})
+	if len(parts) > 0 {
+		return strings.Join(parts, "\n\n")
+	}
+	return strings.TrimSpace(
+		ev.Get("reasoning_content").Str,
+	)
+}
+
+func openHandsToolCategory(
+	toolName string, action gjson.Result,
+) string {
+	switch toolName {
+	case "file_editor":
+		switch action.Get("command").Str {
+		case "view":
+			return "Read"
+		case "create", "write":
+			return "Write"
+		case "str_replace", "insert", "append", "edit":
+			return "Edit"
+		default:
+			return "Tool"
+		}
+	case "delegate":
+		return "Task"
+	case "task_tracker":
+		return "Tool"
+	}
+	return NormalizeToolCategory(toolName)
+}
+
+func formatOpenHandsAction(
+	toolName string,
+	action gjson.Result,
+	summary string,
+) string {
+	switch toolName {
+	case "terminal":
+		cmd := action.Get("command").Str
+		if summary != "" {
+			return fmt.Sprintf(
+				"[Bash: %s]\n$ %s", summary, cmd,
+			)
+		}
+		return fmt.Sprintf("[Bash]\n$ %s", cmd)
+	case "file_editor":
+		path := action.Get("path").Str
+		switch action.Get("command").Str {
+		case "view":
+			return fmt.Sprintf("[Read: %s]", path)
+		case "create", "write":
+			return fmt.Sprintf("[Write: %s]", path)
+		case "str_replace", "insert", "append", "edit":
+			return fmt.Sprintf("[Edit: %s]", path)
+		default:
+			return fmt.Sprintf(
+				"[FileEditor: %s %s]",
+				action.Get("command").Str, path,
+			)
+		}
+	case "delegate":
+		cmd := action.Get("command").Str
+		ids := openHandsStringArray(action.Get("ids"))
+		if len(ids) > 0 {
+			return fmt.Sprintf(
+				"[Task: %s %s]",
+				cmd, strings.Join(ids, ", "),
+			)
+		}
+		if cmd != "" {
+			return fmt.Sprintf("[Task: %s]", cmd)
+		}
+		return "[Task]"
+	case "task_tracker":
+		if cmd := action.Get("command").Str; cmd != "" {
+			return fmt.Sprintf(
+				"[TaskTracker: %s]",
+				cmd,
+			)
+		}
+		return "[TaskTracker]"
+	default:
+		if summary != "" {
+			return fmt.Sprintf(
+				"[%s: %s]",
+				toolName, summary,
+			)
+		}
+		return fmt.Sprintf("[%s]", toolName)
+	}
+}
+
+func openHandsObservationContent(
+	observation gjson.Result,
+) (string, string) {
+	content := observation.Get("content")
+	if content.Exists() {
+		raw := content.Raw
+		return raw, DecodeContent(raw)
+	}
+
+	parts := []string{}
+	if cmd := observation.Get("command").Str; cmd != "" {
+		parts = append(parts, cmd)
+	}
+	if detail := observation.Get("detail").Str; detail != "" {
+		parts = append(parts, detail)
+	}
+	display := strings.TrimSpace(strings.Join(parts, "\n"))
+	if display == "" {
+		display = strings.TrimSpace(observation.Raw)
+	}
+	if display == "" {
+		return "", ""
+	}
+	raw, _ := json.Marshal(display)
+	return string(raw), display
+}
+
+func openHandsActionCwd(
+	toolName string, action gjson.Result,
+) string {
+	if toolName != "file_editor" {
+		return ""
+	}
+	path := strings.TrimSpace(action.Get("path").Str)
+	if path == "" || !filepath.IsAbs(path) {
+		return ""
+	}
+	return filepath.Dir(path)
+}
+
+func joinOpenHandsParts(parts ...string) string {
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+func openHandsStringArray(value gjson.Result) []string {
+	if !value.IsArray() {
+		return nil
+	}
+	var out []string
+	value.ForEach(func(_, item gjson.Result) bool {
+		if item.Type == gjson.String && item.Str != "" {
+			out = append(out, item.Str)
+		}
+		return true
+	})
+	return out
+}
+
+func readOpenHandsJSON(path string) gjson.Result {
+	data, err := os.ReadFile(path)
+	if err != nil || !gjson.ValidBytes(data) {
+		return gjson.Result{}
+	}
+	return gjson.ParseBytes(data)
+}
+
+func normalizeOpenHandsSessionPath(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return path, nil
+	}
+	name := filepath.Base(path)
+	switch name {
+	case "base_state.json", "TASKS.json":
+		return filepath.Dir(path), nil
+	}
+	if filepath.Base(filepath.Dir(path)) == "events" {
+		return filepath.Dir(filepath.Dir(path)), nil
+	}
+	return "", fmt.Errorf("openhands path is not a session dir: %s", path)
+}
+
+func isOpenHandsSessionDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	eventsDir := filepath.Join(path, "events")
+	eventsInfo, err := os.Stat(eventsDir)
+	return err == nil && eventsInfo.IsDir()
+}
+
+func normalizeOpenHandsSessionID(id string) string {
+	id = strings.TrimSpace(id)
+	if len(id) != 32 || !isHexString(id) {
+		return id
+	}
+	return fmt.Sprintf(
+		"%s-%s-%s-%s-%s",
+		id[0:8], id[8:12], id[12:16], id[16:20], id[20:32],
+	)
+}
+
+func isHexString(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/parser/openhands_test.go
+++ b/internal/parser/openhands_test.go
@@ -121,7 +121,7 @@ func TestParseOpenHandsSession(t *testing.T) {
 
 	assert.Equal(t, "openhands:"+sessionID, sess.ID)
 	assert.Equal(t, AgentOpenHands, sess.Agent)
-	assert.Equal(t, "demo-repo", sess.Project)
+	assert.Equal(t, "demo_repo", sess.Project)
 	assert.Equal(t, projectDir, sess.Cwd)
 	assert.Equal(t, "Help me debug the server", sess.FirstMessage)
 	assert.Equal(t, 4, sess.MessageCount)

--- a/internal/parser/openhands_test.go
+++ b/internal/parser/openhands_test.go
@@ -1,0 +1,159 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverAndFindOpenHandsSessions(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "086c7ecf-6cb7-46b6-9fbc-b900358d1247"
+	dirName := "086c7ecf6cb746b69fbcb900358d1247"
+	sessionDir := filepath.Join(root, dirName)
+
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(sessionDir, "events"), 0o755,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "base_state.json"),
+		[]byte(`{"id":"`+sessionID+`"}`),
+		0o644,
+	))
+
+	files := DiscoverOpenHandsSessions(root)
+	require.Len(t, files, 1)
+	assert.Equal(t, sessionDir, files[0].Path)
+	assert.Equal(t, AgentOpenHands, files[0].Agent)
+
+	assert.Equal(
+		t, sessionDir,
+		FindOpenHandsSourceFile(root, sessionID),
+	)
+	assert.Equal(
+		t, sessionDir,
+		FindOpenHandsSourceFile(root, dirName),
+	)
+}
+
+func TestParseOpenHandsSession(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "demo-repo")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	sessionID := "086c7ecf-6cb7-46b6-9fbc-b900358d1247"
+	sessionDir := filepath.Join(
+		root, "086c7ecf6cb746b69fbcb900358d1247",
+	)
+	eventsDir := filepath.Join(sessionDir, "events")
+	require.NoError(t, os.MkdirAll(eventsDir, 0o755))
+
+	baseState := `{
+		"id":"` + sessionID + `",
+		"agent":{"llm":{"model":"litellm_proxy/claude-sonnet-4-6"}}
+	}`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionDir, "base_state.json"),
+		[]byte(baseState), 0o644,
+	))
+
+	events := map[string]string{
+		"event-00000-user.json": `{
+			"id":"e0",
+			"timestamp":"2026-04-02T15:25:40.706887",
+			"source":"user",
+			"llm_message":{"role":"user","content":[{"type":"text","text":"Help me debug the server"}]},
+			"kind":"MessageEvent"
+		}`,
+		"event-00001-action.json": `{
+			"id":"e1",
+			"timestamp":"2026-04-02T15:25:41.706887",
+			"source":"agent",
+			"thought":[{"type":"text","text":"I'll inspect the logs first."}],
+			"thinking_blocks":[{"type":"thinking","thinking":"Start with the failing process and collect output."}],
+			"action":{"command":"tail -40 /tmp/server.log","kind":"TerminalAction"},
+			"tool_name":"terminal",
+			"tool_call_id":"toolu_123",
+			"tool_call":{"id":"toolu_123","name":"terminal","arguments":"{\"command\":\"tail -40 /tmp/server.log\",\"summary\":\"Inspect latest server logs\"}"},
+			"summary":"Inspect latest server logs",
+			"kind":"ActionEvent"
+		}`,
+		"event-00002-observation.json": `{
+			"id":"e2",
+			"timestamp":"2026-04-02T15:25:42.706887",
+			"source":"environment",
+			"tool_name":"terminal",
+			"tool_call_id":"toolu_123",
+			"observation":{
+				"content":[{"type":"text","text":"panic: boom"}],
+				"is_error":false,
+				"metadata":{"working_dir":"` + projectDir + `"},
+				"kind":"TerminalObservation"
+			},
+			"action_id":"e1",
+			"kind":"ObservationEvent"
+		}`,
+		"event-00003-assistant.json": `{
+			"id":"e3",
+			"timestamp":"2026-04-02T15:25:43.706887",
+			"source":"agent",
+			"llm_message":{"role":"assistant","content":[{"type":"text","text":"The panic happens during startup."}]},
+			"thinking_blocks":[{"type":"thinking","thinking":"The stack trace indicates a nil config path."}],
+			"kind":"MessageEvent"
+		}`,
+	}
+	for name, content := range events {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(eventsDir, name),
+			[]byte(content), 0o644,
+		))
+	}
+
+	sess, msgs, err := ParseOpenHandsSession(
+		sessionDir, "local",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 4)
+
+	assert.Equal(t, "openhands:"+sessionID, sess.ID)
+	assert.Equal(t, AgentOpenHands, sess.Agent)
+	assert.Equal(t, "demo-repo", sess.Project)
+	assert.Equal(t, projectDir, sess.Cwd)
+	assert.Equal(t, "Help me debug the server", sess.FirstMessage)
+	assert.Equal(t, 4, sess.MessageCount)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, sessionDir, sess.File.Path)
+	assert.NotEmpty(t, sess.File.Hash)
+	assert.NotZero(t, sess.File.Mtime)
+	assert.Greater(t, sess.File.Size, int64(0))
+
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "Help me debug the server", msgs[0].Content)
+
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.True(t, msgs[1].HasThinking)
+	assert.True(t, msgs[1].HasToolUse)
+	assert.Equal(t, "litellm_proxy/claude-sonnet-4-6", msgs[1].Model)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "terminal", msgs[1].ToolCalls[0].ToolName)
+	assert.Equal(t, "Bash", msgs[1].ToolCalls[0].Category)
+	assert.Equal(t, "toolu_123", msgs[1].ToolCalls[0].ToolUseID)
+	assert.Contains(t, msgs[1].Content, "[Bash: Inspect latest server logs]")
+
+	assert.Equal(t, RoleUser, msgs[2].Role)
+	require.Len(t, msgs[2].ToolResults, 1)
+	assert.Equal(t, "toolu_123", msgs[2].ToolResults[0].ToolUseID)
+	assert.Equal(
+		t, "panic: boom",
+		DecodeContent(msgs[2].ToolResults[0].ContentRaw),
+	)
+
+	assert.Equal(t, RoleAssistant, msgs[3].Role)
+	assert.True(t, msgs[3].HasThinking)
+	assert.Equal(t, "litellm_proxy/claude-sonnet-4-6", msgs[3].Model)
+	assert.Contains(t, msgs[3].Content, "The panic happens during startup.")
+}

--- a/internal/parser/openhands_test.go
+++ b/internal/parser/openhands_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,6 +61,9 @@ func TestParseOpenHandsSession(t *testing.T) {
 		[]byte(baseState), 0o644,
 	))
 
+	projectDirJSON, err := json.Marshal(projectDir)
+	require.NoError(t, err)
+
 	events := map[string]string{
 		"event-00000-user.json": `{
 			"id":"e0",
@@ -90,7 +94,7 @@ func TestParseOpenHandsSession(t *testing.T) {
 			"observation":{
 				"content":[{"type":"text","text":"panic: boom"}],
 				"is_error":false,
-				"metadata":{"working_dir":"` + projectDir + `"},
+				"metadata":{"working_dir":` + string(projectDirJSON) + `},
 				"kind":"TerminalObservation"
 			},
 			"action_id":"e1",

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -44,6 +44,7 @@ type AgentDef struct {
 	DefaultDirs  []string // paths relative to $HOME
 	IDPrefix     string   // session ID prefix ("" for Claude)
 	WatchSubdirs []string // subdirs to watch (nil = watch root)
+	ShallowWatch bool     // true = watch root only, rely on periodic sync for subdirs
 	FileBased    bool     // false for DB-backed agents
 
 	// DiscoverFunc finds session files under a root directory.

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -123,6 +123,7 @@ var Registry = []AgentDef{
 		DefaultDirs:    []string{".openhands/conversations"},
 		IDPrefix:       "openhands:",
 		FileBased:      true,
+		ShallowWatch:   true,
 		DiscoverFunc:   DiscoverOpenHandsSessions,
 		FindSourceFunc: FindOpenHandsSourceFile,
 	},

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -15,6 +15,7 @@ const (
 	AgentCopilot       AgentType = "copilot"
 	AgentGemini        AgentType = "gemini"
 	AgentOpenCode      AgentType = "opencode"
+	AgentOpenHands     AgentType = "openhands"
 	AgentCursor        AgentType = "cursor"
 	AgentIflow         AgentType = "iflow"
 	AgentAmp           AgentType = "amp"
@@ -112,6 +113,17 @@ var Registry = []AgentDef{
 		DefaultDirs: []string{".local/share/opencode"},
 		IDPrefix:    "opencode:",
 		FileBased:   false,
+	},
+	{
+		Type:           AgentOpenHands,
+		DisplayName:    "OpenHands CLI",
+		EnvVar:         "OPENHANDS_CONVERSATIONS_DIR",
+		ConfigKey:      "openhands_dirs",
+		DefaultDirs:    []string{".openhands/conversations"},
+		IDPrefix:       "openhands:",
+		FileBased:      true,
+		DiscoverFunc:   DiscoverOpenHandsSessions,
+		FindSourceFunc: FindOpenHandsSourceFile,
 	},
 	{
 		Type:           AgentCursor,

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -137,6 +137,7 @@ func TestAgentByType(t *testing.T) {
 		{AgentCopilot, true},
 		{AgentGemini, true},
 		{AgentOpenCode, true},
+		{AgentOpenHands, true},
 		{AgentCursor, true},
 		{AgentAmp, true},
 		{AgentVSCodeCopilot, true},
@@ -195,6 +196,12 @@ func TestAgentByPrefix(t *testing.T) {
 			"opencode prefix",
 			"opencode:sess-id",
 			AgentOpenCode,
+			true,
+		},
+		{
+			"openhands prefix",
+			"openhands:sess-id",
+			AgentOpenHands,
 			true,
 		},
 		{
@@ -260,6 +267,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentCopilot,
 		AgentGemini,
 		AgentOpenCode,
+		AgentOpenHands,
 		AgentCursor,
 		AgentAmp,
 		AgentVSCodeCopilot,

--- a/internal/sync/classify_openhands_test.go
+++ b/internal/sync/classify_openhands_test.go
@@ -1,0 +1,91 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/agentsview/internal/parser"
+)
+
+func TestClassifyOnePath_OpenHands(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(
+		root, "086c7ecf6cb746b69fbcb900358d1247",
+	)
+	eventsDir := filepath.Join(sessionDir, "events")
+	require.NoError(t, os.MkdirAll(eventsDir, 0o755))
+
+	baseStatePath := filepath.Join(sessionDir, "base_state.json")
+	tasksPath := filepath.Join(sessionDir, "TASKS.json")
+	eventPath := filepath.Join(
+		eventsDir, "event-00001-abc.json",
+	)
+	require.NoError(t, os.WriteFile(
+		baseStatePath, []byte(`{}`), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		tasksPath, []byte(`{}`), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		eventPath, []byte(`{}`), 0o644,
+	))
+
+	eng := &Engine{
+		agentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenHands: {root},
+		},
+	}
+	geminiMap := make(map[string]map[string]string)
+
+	tests := []struct {
+		name    string
+		path    string
+		want    bool
+		retPath string
+	}{
+		{
+			name:    "base_state remaps to session dir",
+			path:    baseStatePath,
+			want:    true,
+			retPath: sessionDir,
+		},
+		{
+			name:    "tasks remaps to session dir",
+			path:    tasksPath,
+			want:    true,
+			retPath: sessionDir,
+		},
+		{
+			name:    "event remaps to session dir",
+			path:    eventPath,
+			want:    true,
+			retPath: sessionDir,
+		},
+		{
+			name: "observations ignored",
+			path: filepath.Join(
+				sessionDir, "observations", "out.txt",
+			),
+			want: false,
+		},
+		{
+			name: "unrelated file ignored",
+			path: filepath.Join(root, "README.md"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := eng.classifyOnePath(tt.path, geminiMap)
+			assert.Equal(t, tt.want, ok)
+			if ok {
+				assert.Equal(t, parser.AgentOpenHands, got.Agent)
+				assert.Equal(t, tt.retPath, got.Path)
+			}
+		})
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1461,6 +1461,13 @@ func (e *Engine) processFile(
 	// Capture mtime once from the initial stat so all
 	// downstream cache operations use a consistent value.
 	mtime := info.ModTime().UnixNano()
+	if file.Agent == parser.AgentOpenHands {
+		snapshot, err := parser.OpenHandsSnapshot(file.Path)
+		if err != nil {
+			return processResult{err: err}
+		}
+		mtime = snapshot.Mtime
+	}
 
 	// Skip files cached from a previous sync (parse errors
 	// or non-interactive sessions) whose mtime is unchanged.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -347,6 +347,38 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
+	// OpenHands CLI:
+	//   <openhandsDir>/<conversation-id>/base_state.json
+	//   <openhandsDir>/<conversation-id>/TASKS.json
+	//   <openhandsDir>/<conversation-id>/events/*.json
+	for _, openHandsDir := range e.agentDirs[parser.AgentOpenHands] {
+		if openHandsDir == "" {
+			continue
+		}
+		if rel, ok := isUnder(openHandsDir, path); ok {
+			parts := strings.Split(rel, sep)
+			if len(parts) < 2 || !parser.IsValidSessionID(parts[0]) {
+				continue
+			}
+			switch {
+			case len(parts) == 2 &&
+				(parts[1] == "base_state.json" ||
+					parts[1] == "TASKS.json"):
+			case len(parts) == 3 &&
+				parts[1] == "events" &&
+				strings.HasSuffix(parts[2], ".json"):
+			default:
+				continue
+			}
+			return parser.DiscoveredFile{
+				Path: filepath.Join(
+					openHandsDir, parts[0],
+				),
+				Agent: parser.AgentOpenHands,
+			}, true
+		}
+	}
+
 	// Cursor:
 	//   <cursorDir>/<project>/agent-transcripts/<uuid>.{txt,jsonl}
 	//   <cursorDir>/<project>/agent-transcripts/<uuid>/<uuid>.{txt,jsonl}
@@ -1449,6 +1481,8 @@ func (e *Engine) processFile(
 		res = e.processCopilot(file, info)
 	case parser.AgentGemini:
 		res = e.processGemini(file, info)
+	case parser.AgentOpenHands:
+		res = e.processOpenHands(file, info)
 	case parser.AgentCursor:
 		res = e.processCursor(file, info)
 	case parser.AgentIflow:
@@ -2124,6 +2158,40 @@ func (e *Engine) processPositron(
 	hash, err := ComputeFileHash(file.Path)
 	if err == nil {
 		sess.File.Hash = hash
+	}
+
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: *sess, Messages: msgs},
+		},
+	}
+}
+
+func (e *Engine) processOpenHands(
+	file parser.DiscoveredFile, _ os.FileInfo,
+) processResult {
+	snapshot, err := parser.OpenHandsSnapshot(file.Path)
+	if err != nil {
+		return processResult{err: err}
+	}
+
+	storedSize, storedMtime, ok := e.db.GetFileInfoByPath(
+		file.Path,
+	)
+	if ok &&
+		storedSize == snapshot.Size &&
+		storedMtime == snapshot.Mtime {
+		return processResult{skip: true}
+	}
+
+	sess, msgs, err := parser.ParseOpenHandsSession(
+		file.Path, e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if sess == nil {
+		return processResult{}
 	}
 
 	return processResult{

--- a/internal/sync/openhands_retry_test.go
+++ b/internal/sync/openhands_retry_test.go
@@ -1,0 +1,68 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/agentsview/internal/dbtest"
+	"github.com/wesm/agentsview/internal/parser"
+)
+
+func TestProcessFileOpenHandsUsesSnapshotMtimeForRetryCache(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(
+		root, "086c7ecf6cb746b69fbcb900358d1247",
+	)
+	eventsDir := filepath.Join(sessionDir, "events")
+	require.NoError(t, os.MkdirAll(eventsDir, 0o755))
+
+	baseStatePath := filepath.Join(sessionDir, "base_state.json")
+	eventPath := filepath.Join(eventsDir, "event-00000-user.json")
+	dbtest.WriteTestFile(t, baseStatePath, []byte(`{
+		"id":"086c7ecf-6cb7-46b6-9fbc-b900358d1247",
+		"agent":{"llm":{"model":"openhands-test-model"}}
+	}`))
+	dbtest.WriteTestFile(t, eventPath, []byte(`{
+		"id":"e0",
+		"timestamp":"2026-04-02T15:25:40.706887",
+		"source":"user",
+		"llm_message":{"role":"user","content":[{"type":"text","text":"First version"}]},
+		"kind":"MessageEvent"
+	}`))
+
+	dirInfo, err := os.Stat(sessionDir)
+	require.NoError(t, err)
+	oldDirMtime := dirInfo.ModTime()
+
+	engine := &Engine{
+		db:        dbtest.OpenTestDB(t),
+		machine:   "local",
+		skipCache: map[string]int64{sessionDir: oldDirMtime.UnixNano()},
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	dbtest.WriteTestFile(t, eventPath, []byte(`{
+		"id":"e0",
+		"timestamp":"2026-04-02T15:25:41.706887",
+		"source":"user",
+		"llm_message":{"role":"user","content":[{"type":"text","text":"Updated version"}]},
+		"kind":"MessageEvent"
+	}`))
+	require.NoError(t, os.Chtimes(sessionDir, oldDirMtime, oldDirMtime))
+
+	snapshot, err := parser.OpenHandsSnapshot(sessionDir)
+	require.NoError(t, err)
+	require.NotEqual(t, oldDirMtime.UnixNano(), snapshot.Mtime)
+
+	res := engine.processFile(parser.DiscoveredFile{
+		Path:  sessionDir,
+		Agent: parser.AgentOpenHands,
+	})
+	require.False(t, res.skip)
+	require.NoError(t, res.err)
+	require.Len(t, res.results, 1)
+	require.Equal(t, snapshot.Mtime, res.mtime)
+}

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -83,6 +83,16 @@ func (w *Watcher) WatchRecursive(root string) (watched int, unwatched int, err e
 	return watched, unwatched, err
 }
 
+// WatchShallow adds only the root directory to the watch list,
+// without recursing into subdirectories. Use this for directories
+// with many subdirectories where periodic sync handles changes.
+// Returns true if the directory was successfully watched.
+func (w *Watcher) WatchShallow(root string) bool {
+	root = filepath.Clean(root)
+	w.addRoot(root)
+	return w.watcher.Add(root) == nil
+}
+
 // Start begins processing file events in a goroutine.
 func (w *Watcher) Start() {
 	go w.loop()


### PR DESCRIPTION
## Summary

Add support for parsing and syncing OpenHands CLI conversations, plus shallow-watch mode so conversation-based agents don't exhaust inotify file descriptor limits.

OpenHands stores local conversations as directories under
`~/.openhands/conversations`, with session metadata in `base_state.json`
and per-event JSON files under `events/`.

## Changes

### Backend

- **Parser** (`internal/parser/openhands.go`): add OpenHands session discovery and parsing
  - discovers OpenHands conversation directories
  - parses `base_state.json`
  - parses `events/*.json`
  - maps message, action, and observation events into the existing session/message model
  - derives cwd/project from workspace and observation metadata
  - computes synthetic file metadata for conversation directories

- **Types** (`internal/parser/types.go`): add `AgentOpenHands` constant, registry entry, and `ShallowWatch` field on `AgentDef`

- **Sync Engine** (`internal/sync/engine.go`): add OpenHands sync support
  - full discovery of OpenHands conversation directories
  - changed-path classification for `base_state.json`, `TASKS.json`, and `events/*.json`
  - remaps file watcher updates back to the owning conversation directory

- **Watcher** (`internal/sync/watcher.go`): add `WatchShallow()` for non-recursive directory watching

- **Startup** (`cmd/agentsview/main.go`): route agents with `ShallowWatch=true` through `WatchShallow` and report shallow counts in the "Watching N directories" message

### Frontend

- **Agent Definitions** (`frontend/src/lib/utils/agents.ts`): add OpenHands label/color
- **Settings UI** (`frontend/src/lib/components/settings/AgentDirSettings.svelte`): show OpenHands configured directory support

### Documentation / CLI

- **README.md**: add OpenHands CLI to supported agents table
- **CLI help** (`cmd/agentsview/main.go`): add `OPENHANDS_CONVERSATIONS_DIR`

## Session Discovery

- **Default directory**: `~/.openhands/conversations`
- **Environment variable**: `OPENHANDS_CONVERSATIONS_DIR`
- **Config key**: `openhands_dirs`
- **ID prefix**: `openhands:`

## Shallow Watch

OpenHands stores each conversation in its own subdirectory, so a recursive watch consumes one inotify watch per session and can exhaust file descriptor limits. `ShallowWatch=true` is set on the OpenHands agent def so only `~/.openhands/conversations` itself is watched via fsnotify; periodic sync (every 15 min) picks up changes inside existing conversations, and new conversation directories are still detected immediately via file system events.

The startup message indicates how many directories use shallow watch:
```
Watching 74 directories for changes (2 shallow) (76ms)
```

Closes #302. Supersedes #303 (shallow-watch commit cherry-picked here).

## Testing

- Added parser coverage in `internal/parser/openhands_test.go`
- Added sync path classification coverage in `internal/sync/classify_openhands_test.go`
- Updated registry / agent list coverage in existing tests

Validated with:

```bash
make frontend
go test -tags fts5 ./internal/parser ./internal/sync ./cmd/agentsview
cd frontend && npm test -- src/lib/utils/agents.test.ts
```

Also tested against real local OpenHands conversations using a temporary data dir:
- OpenHands sessions discovered successfully
- sessions synced into SQLite
- sessions displayed correctly in the UI

## Scope

This PR adds support for local OpenHands CLI conversations only.

It does not add OpenHands Cloud support.