### PR TITLE
feat: filter pinned messages by selected project (#305)

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1042,8 +1042,9 @@ export async function importChatGPT(
 
 /* Pins */
 
-export function listPins(): Promise<PinsResponse> {
-  return fetchJSON("/pins");
+export function listPins(project?: string): Promise<PinsResponse> {
+  const url = project ? `/pins?project=${encodeURIComponent(project)}` : "/pins";
+  return fetchJSON(url);
 }
 
 export function listSessionPins(

--- a/frontend/src/lib/components/pinned/PinnedPage.svelte
+++ b/frontend/src/lib/components/pinned/PinnedPage.svelte
@@ -51,6 +51,15 @@
         };
   }
 
+  const visiblePins = $derived(
+    sessions.filters.project
+      ? pins.pins.filter((p) => {
+          const proj = p.session_project ?? getSessionInfo(p).project;
+          return proj === sessions.filters.project;
+        })
+      : pins.pins,
+  );
+
   let copiedId: number | null = $state(null);
 
   async function handleCopy(pinId: number, content: string | null | undefined) {
@@ -80,12 +89,19 @@
     </svg>
     <h2>Pinned Messages</h2>
     {#if pins.pins.length > 0}
-      <span class="pin-count">{pins.pins.length}</span>
+      <span class="pin-count">{visiblePins.length}</span>
     {/if}
   </div>
 
   {#if pins.loading}
     <div class="loading-state">Loading pins...</div>
+  {:else if visiblePins.length === 0 && pins.pins.length > 0}
+    <div class="empty-state">
+      <p class="empty-title">No pinned messages for this project</p>
+      <p class="empty-desc">
+        Try selecting a different project or clear the project filter.
+      </p>
+    </div>
   {:else if pins.pins.length === 0}
     <div class="empty-state">
       <svg width="40" height="40" viewBox="0 0 16 16" fill="currentColor" class="empty-icon">
@@ -98,7 +114,7 @@
     </div>
   {:else}
     <div class="pin-list">
-      {#each pins.pins as pin (pin.id)}
+      {#each visiblePins as pin (pin.id)}
         {@const info = getSessionInfo(pin)}
         {@const isExpanded = expanded.has(pin.id)}
         {@const preview = previewContent(pin.content)}

--- a/frontend/src/lib/components/pinned/PinnedPage.svelte
+++ b/frontend/src/lib/components/pinned/PinnedPage.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { pins } from "../../stores/pins.svelte.js";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { router } from "../../stores/router.svelte.js";
@@ -8,8 +7,8 @@
   import { renderMarkdown } from "../../utils/markdown.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
 
-  onMount(() => {
-    pins.loadAll();
+  $effect(() => {
+    pins.loadAll(sessions.filters.project || undefined);
   });
 
   /** Set of expanded pin IDs. */
@@ -51,15 +50,6 @@
         };
   }
 
-  const visiblePins = $derived(
-    sessions.filters.project
-      ? pins.pins.filter((p) => {
-          const proj = p.session_project ?? getSessionInfo(p).project;
-          return proj === sessions.filters.project;
-        })
-      : pins.pins,
-  );
-
   let copiedId: number | null = $state(null);
 
   async function handleCopy(pinId: number, content: string | null | undefined) {
@@ -89,13 +79,13 @@
     </svg>
     <h2>Pinned Messages</h2>
     {#if pins.pins.length > 0}
-      <span class="pin-count">{visiblePins.length}</span>
+      <span class="pin-count">{pins.pins.length}</span>
     {/if}
   </div>
 
   {#if pins.loading}
     <div class="loading-state">Loading pins...</div>
-  {:else if visiblePins.length === 0 && pins.pins.length > 0}
+  {:else if pins.pins.length === 0 && sessions.filters.project}
     <div class="empty-state">
       <p class="empty-title">No pinned messages for this project</p>
       <p class="empty-desc">
@@ -114,7 +104,7 @@
     </div>
   {:else}
     <div class="pin-list">
-      {#each visiblePins as pin (pin.id)}
+      {#each pins.pins as pin (pin.id)}
         {@const info = getSessionInfo(pin)}
         {@const isExpanded = expanded.has(pin.id)}
         {@const preview = previewContent(pin.content)}

--- a/frontend/src/lib/stores/pins.svelte.ts
+++ b/frontend/src/lib/stores/pins.svelte.ts
@@ -16,8 +16,16 @@ class PinsStore {
   #loadAllVersion = 0;
   /** Incremented on every mutation so loads can detect staleness. */
   #mutationVersion = 0;
+  /** Project that the current this.pins was fetched for. */
+  #loadedProject: string | undefined = undefined;
 
   async loadAll(project?: string) {
+    // Clear immediately when switching projects to prevent stale
+    // pins from the previous filter remaining visible while the
+    // new request is in-flight or if it fails.
+    if (project !== this.#loadedProject) {
+      this.pins = [];
+    }
     this.loading = true;
     const loadVer = ++this.#loadAllVersion;
     const mutVer = this.#mutationVersion;
@@ -28,6 +36,7 @@ class PinsStore {
       // this response stale relative to the optimistic state).
       if (this.#loadAllVersion === loadVer && this.#mutationVersion === mutVer) {
         this.pins = res.pins;
+        this.#loadedProject = project;
       }
     } catch {
       // Silently ignore — pins are non-critical.
@@ -148,4 +157,8 @@ class PinsStore {
   }
 }
 
-export const pins = new PinsStore();
+export function createPinsStore(): PinsStore {
+  return new PinsStore();
+}
+
+export const pins = createPinsStore();

--- a/frontend/src/lib/stores/pins.svelte.ts
+++ b/frontend/src/lib/stores/pins.svelte.ts
@@ -17,12 +17,12 @@ class PinsStore {
   /** Incremented on every mutation so loads can detect staleness. */
   #mutationVersion = 0;
 
-  async loadAll() {
+  async loadAll(project?: string) {
     this.loading = true;
     const loadVer = ++this.#loadAllVersion;
     const mutVer = this.#mutationVersion;
     try {
-      const res = await api.listPins();
+      const res = await api.listPins(project);
       // Apply only if this is the latest load AND no mutation
       // occurred since the request started (which would make
       // this response stale relative to the optimistic state).

--- a/frontend/src/lib/stores/pins.test.ts
+++ b/frontend/src/lib/stores/pins.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import * as api from "../api/client.js";
+import { createPinsStore } from "./pins.svelte.js";
+
+vi.mock("../api/client.js", () => ({
+  listPins: vi.fn().mockResolvedValue({ pins: [] }),
+  listSessionPins: vi.fn().mockResolvedValue({ message_ids: [] }),
+  pinMessage: vi.fn().mockResolvedValue(undefined),
+  unpinMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+const PIN_ALPHA = { id: 1, session_id: "s1", message_id: 10, ordinal: 1, content: "alpha pin", role: "user", created_at: "", session_project: "alpha", session_title: "alpha session" };
+const PIN_BETA  = { id: 2, session_id: "s2", message_id: 20, ordinal: 1, content: "beta pin",  role: "user", created_at: "", session_project: "beta",  session_title: "beta session"  };
+
+describe("PinsStore.loadAll project filtering", () => {
+  let store: ReturnType<typeof createPinsStore>;
+
+  beforeEach(() => {
+    store = createPinsStore();
+    vi.mocked(api.listPins).mockResolvedValue({ pins: [] });
+  });
+
+  it("populates pins on successful load", async () => {
+    vi.mocked(api.listPins).mockResolvedValue({ pins: [PIN_ALPHA] });
+    await store.loadAll("alpha");
+    expect(store.pins).toEqual([PIN_ALPHA]);
+  });
+
+  it("clears pins immediately when project changes before fetch resolves", async () => {
+    // Load project alpha successfully first.
+    vi.mocked(api.listPins).mockResolvedValue({ pins: [PIN_ALPHA] });
+    await store.loadAll("alpha");
+    expect(store.pins).toEqual([PIN_ALPHA]);
+
+    // Switch to project beta — the fetch hangs; capture the in-flight call.
+    let resolveBeta!: (v: { pins: typeof PIN_BETA[] }) => void;
+    vi.mocked(api.listPins).mockReturnValue(
+      new Promise((r) => { resolveBeta = r; })
+    );
+    const betaLoad = store.loadAll("beta");
+
+    // Before beta resolves, pins must already be empty.
+    expect(store.pins).toHaveLength(0);
+
+    // Resolve the beta fetch normally.
+    resolveBeta({ pins: [PIN_BETA] });
+    await betaLoad;
+    expect(store.pins).toEqual([PIN_BETA]);
+  });
+
+  it("keeps pins empty after a failed load when project changes (regression)", async () => {
+    // Load project alpha successfully.
+    vi.mocked(api.listPins).mockResolvedValue({ pins: [PIN_ALPHA] });
+    await store.loadAll("alpha");
+    expect(store.pins).toEqual([PIN_ALPHA]);
+
+    // Switch to beta — the fetch fails.
+    vi.mocked(api.listPins).mockRejectedValue(new Error("network error"));
+    await store.loadAll("beta");
+
+    // Must not fall back to alpha's pins.
+    expect(store.pins).toHaveLength(0);
+    expect(store.loading).toBe(false);
+  });
+
+  it("preserves stale pins during re-fetch for the same project", async () => {
+    vi.mocked(api.listPins).mockResolvedValue({ pins: [PIN_ALPHA] });
+    await store.loadAll("alpha");
+
+    // Re-fetch the same project — fetch hangs.
+    let resolve!: (v: { pins: typeof PIN_ALPHA[] }) => void;
+    vi.mocked(api.listPins).mockReturnValue(
+      new Promise((r) => { resolve = r; })
+    );
+    const refetch = store.loadAll("alpha");
+
+    // Pins must still be visible while the same-project refresh is in-flight.
+    expect(store.pins).toEqual([PIN_ALPHA]);
+
+    resolve({ pins: [PIN_ALPHA] });
+    await refetch;
+  });
+
+  it("shows correct project pins after failed then successful project switch", async () => {
+    // Load alpha.
+    vi.mocked(api.listPins).mockResolvedValue({ pins: [PIN_ALPHA] });
+    await store.loadAll("alpha");
+
+    // Switch to beta — fails.
+    vi.mocked(api.listPins).mockRejectedValue(new Error("network error"));
+    await store.loadAll("beta");
+    expect(store.pins).toHaveLength(0);
+
+    // Switch back to alpha — succeeds.
+    vi.mocked(api.listPins).mockResolvedValue({ pins: [PIN_ALPHA] });
+    await store.loadAll("alpha");
+    expect(store.pins).toEqual([PIN_ALPHA]);
+  });
+
+  it("does not apply a superseded load response after project changes", async () => {
+    // Start a slow alpha load.
+    let resolveAlpha!: (v: { pins: typeof PIN_ALPHA[] }) => void;
+    vi.mocked(api.listPins).mockReturnValueOnce(
+      new Promise((r) => { resolveAlpha = r; })
+    );
+    const alphaLoad = store.loadAll("alpha");
+
+    // Before alpha resolves, switch to beta (fast, succeeds).
+    vi.mocked(api.listPins).mockResolvedValue({ pins: [PIN_BETA] });
+    await store.loadAll("beta");
+    expect(store.pins).toEqual([PIN_BETA]);
+
+    // Now the stale alpha response arrives — must be discarded.
+    resolveAlpha({ pins: [PIN_ALPHA] });
+    await alphaLoad;
+    expect(store.pins).toEqual([PIN_BETA]);
+  });
+});

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1246,7 +1246,7 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 	}
 
 	// Record created_at before replace so we can verify it is preserved.
-	prePins, err := d.ListPinnedMessages(ctx, "s1")
+	prePins, err := d.ListPinnedMessages(ctx, "s1", "")
 	if err != nil {
 		t.Fatalf("ListPinnedMessages before replace: %v", err)
 	}
@@ -1273,7 +1273,7 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 		t.Fatalf("want 3 messages after replace, got %d", len(newMsgs))
 	}
 
-	pins, err := d.ListPinnedMessages(ctx, "s1")
+	pins, err := d.ListPinnedMessages(ctx, "s1", "")
 	if err != nil {
 		t.Fatalf("ListPinnedMessages: %v", err)
 	}
@@ -1352,7 +1352,7 @@ func TestReplaceSessionMessagesDropsPinsForRemovedOrdinals(t *testing.T) {
 		t.Fatalf("ReplaceSessionMessages: %v", err)
 	}
 
-	pins, err := d.ListPinnedMessages(ctx, "s1")
+	pins, err := d.ListPinnedMessages(ctx, "s1", "")
 	if err != nil {
 		t.Fatalf("ListPinnedMessages: %v", err)
 	}
@@ -4373,7 +4373,7 @@ func TestCopySessionMetadataFrom(t *testing.T) {
 	if s.DeletedAt != nil {
 		t.Errorf("deleted_at before = %v, want nil", *s.DeletedAt)
 	}
-	pins, err := dstDB.ListPinnedMessages(ctx, "s1")
+	pins, err := dstDB.ListPinnedMessages(ctx, "s1", "")
 	requireNoError(t, err, "ListPins before")
 	if len(pins) != 0 {
 		t.Errorf("pins before = %d, want 0", len(pins))
@@ -4405,7 +4405,7 @@ func TestCopySessionMetadataFrom(t *testing.T) {
 	if sf.DeletedAt == nil {
 		t.Error("deleted_at should be set after copy")
 	}
-	pins, err = dstDB.ListPinnedMessages(ctx, "s1")
+	pins, err = dstDB.ListPinnedMessages(ctx, "s1", "")
 	requireNoError(t, err, "ListPins after")
 	if len(pins) != 1 {
 		t.Fatalf("pins after = %d, want 1", len(pins))

--- a/internal/db/pins.go
+++ b/internal/db/pins.go
@@ -100,11 +100,12 @@ func (db *DB) UnpinMessage(sessionID string, messageID int64) error {
 	return err
 }
 
-// ListPinnedMessages returns all pins, optionally filtered by session.
+// ListPinnedMessages returns all pins, optionally filtered by session or project.
 // Pass empty sessionID for all pins across all sessions.
 // When listing all pins, message content and role are included.
+// project is only applied when sessionID is empty.
 func (db *DB) ListPinnedMessages(
-	ctx context.Context, sessionID string,
+	ctx context.Context, sessionID string, project string,
 ) ([]PinnedMessage, error) {
 	var query string
 	var args []any
@@ -122,8 +123,12 @@ func (db *DB) ListPinnedMessages(
 				s.project, s.agent, s.display_name, s.first_message
 			FROM pinned_messages p
 			JOIN sessions s ON p.session_id = s.id AND s.deleted_at IS NULL
-			LEFT JOIN messages m ON p.message_id = m.id
-			ORDER BY p.created_at DESC LIMIT 500`
+			LEFT JOIN messages m ON p.message_id = m.id`
+		if project != "" {
+			query += " WHERE s.project = ?"
+			args = []any{project}
+		}
+		query += " ORDER BY p.created_at DESC LIMIT 500"
 	}
 
 	rows, err := db.getReader().QueryContext(ctx, query, args...)

--- a/internal/db/pins_test.go
+++ b/internal/db/pins_test.go
@@ -1,0 +1,128 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// pinFirstMessage pins the first message of a session and returns
+// the message ID. Fails the test if no messages exist.
+func pinFirstMessage(t *testing.T, d *DB, sessionID string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	msgs, err := d.GetMessages(ctx, sessionID, 0, 1, true)
+	requireNoError(t, err, "GetMessages")
+	if len(msgs) == 0 {
+		t.Fatalf("no messages in session %s", sessionID)
+	}
+	id, err := d.PinMessage(sessionID, msgs[0].ID, nil)
+	requireNoError(t, err, "PinMessage")
+	if id == 0 {
+		t.Fatalf("PinMessage returned 0 for session %s msg %d", sessionID, msgs[0].ID)
+	}
+	return msgs[0].ID
+}
+
+func TestListPinnedMessages_NoFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "s1", "alpha")
+	insertSession(t, d, "s2", "beta")
+	insertMessages(t, d, userMsg("s1", 0, "hello from alpha"))
+	insertMessages(t, d, userMsg("s2", 0, "hello from beta"))
+	pinFirstMessage(t, d, "s1")
+	pinFirstMessage(t, d, "s2")
+
+	pins, err := d.ListPinnedMessages(ctx, "", "")
+	requireNoError(t, err, "ListPinnedMessages no filter")
+	if len(pins) != 2 {
+		t.Fatalf("got %d pins, want 2", len(pins))
+	}
+}
+
+func TestListPinnedMessages_ProjectFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "s1", "alpha")
+	insertSession(t, d, "s2", "alpha")
+	insertSession(t, d, "s3", "beta")
+	insertMessages(t, d, userMsg("s1", 0, "alpha msg 1"))
+	insertMessages(t, d, userMsg("s2", 0, "alpha msg 2"))
+	insertMessages(t, d, userMsg("s3", 0, "beta msg"))
+	pinFirstMessage(t, d, "s1")
+	pinFirstMessage(t, d, "s2")
+	pinFirstMessage(t, d, "s3")
+
+	tests := []struct {
+		project   string
+		wantCount int
+	}{
+		{"alpha", 2},
+		{"beta", 1},
+		{"unknown", 0},
+		{"", 3},
+	}
+	for _, tc := range tests {
+		t.Run("project="+tc.project, func(t *testing.T) {
+			pins, err := d.ListPinnedMessages(ctx, "", tc.project)
+			requireNoError(t, err, "ListPinnedMessages")
+			if len(pins) != tc.wantCount {
+				t.Errorf("got %d pins, want %d", len(pins), tc.wantCount)
+			}
+			// Verify project metadata on returned pins matches filter.
+			for _, p := range pins {
+				if tc.project != "" && p.SessionProject != nil &&
+					*p.SessionProject != tc.project {
+					t.Errorf("pin session_project = %q, want %q",
+						*p.SessionProject, tc.project)
+				}
+			}
+		})
+	}
+}
+
+func TestListPinnedMessages_ProjectFilterExcludesTrashed(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "live", "alpha")
+	insertSession(t, d, "trashed", "alpha")
+	insertMessages(t, d, userMsg("live", 0, "live msg"))
+	insertMessages(t, d, userMsg("trashed", 0, "trashed msg"))
+	pinFirstMessage(t, d, "live")
+	pinFirstMessage(t, d, "trashed")
+
+	// Soft-delete the trashed session.
+	_, err := d.getWriter().Exec(
+		"UPDATE sessions SET deleted_at = ? WHERE id = ?",
+		tsZeroS1, "trashed",
+	)
+	requireNoError(t, err, "soft-delete session")
+
+	pins, err := d.ListPinnedMessages(ctx, "", "alpha")
+	requireNoError(t, err, "ListPinnedMessages")
+	if len(pins) != 1 {
+		t.Fatalf("got %d pins, want 1 (trashed session excluded)", len(pins))
+	}
+	if pins[0].SessionID != "live" {
+		t.Errorf("expected pin from live session, got session_id %q", pins[0].SessionID)
+	}
+}
+
+func TestListPinnedMessages_SessionFilterIgnoresProject(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "s1", "alpha")
+	insertMessages(t, d, userMsg("s1", 0, "msg"))
+	pinFirstMessage(t, d, "s1")
+
+	// project param is ignored when sessionID is set.
+	pins, err := d.ListPinnedMessages(ctx, "s1", "beta")
+	requireNoError(t, err, "ListPinnedMessages by session")
+	if len(pins) != 1 {
+		t.Fatalf("got %d pins, want 1", len(pins))
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -64,7 +64,7 @@ type Store interface {
 	// Pins (local-only; PG returns ErrReadOnly).
 	PinMessage(sessionID string, messageID int64, note *string) (int64, error)
 	UnpinMessage(sessionID string, messageID int64) error
-	ListPinnedMessages(ctx context.Context, sessionID string) ([]PinnedMessage, error)
+	ListPinnedMessages(ctx context.Context, sessionID string, project string) ([]PinnedMessage, error)
 
 	// Insights (local-only; PG returns ErrReadOnly).
 	ListInsights(ctx context.Context, f InsightFilter) ([]Insight, error)

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -107,7 +107,7 @@ func (s *Store) UnpinMessage(_ string, _ int64) error {
 
 // ListPinnedMessages returns an empty slice.
 func (s *Store) ListPinnedMessages(
-	_ context.Context, _ string,
+	_ context.Context, _ string, _ string,
 ) ([]db.PinnedMessage, error) {
 	return []db.PinnedMessage{}, nil
 }

--- a/internal/server/pins.go
+++ b/internal/server/pins.go
@@ -76,7 +76,8 @@ func (s *Server) handleUnpinMessage(
 func (s *Server) handleListPins(
 	w http.ResponseWriter, r *http.Request,
 ) {
-	pins, err := s.db.ListPinnedMessages(r.Context(), "")
+	project := r.URL.Query().Get("project")
+	pins, err := s.db.ListPinnedMessages(r.Context(), "", project)
 	if err != nil {
 		if handleContextError(w, err) {
 			return
@@ -95,7 +96,7 @@ func (s *Server) handleListSessionPins(
 	w http.ResponseWriter, r *http.Request,
 ) {
 	sessionID := r.PathValue("id")
-	pins, err := s.db.ListPinnedMessages(r.Context(), sessionID)
+	pins, err := s.db.ListPinnedMessages(r.Context(), sessionID, "")
 	if err != nil {
 		if handleContextError(w, err) {
 			return

--- a/internal/server/pins_test.go
+++ b/internal/server/pins_test.go
@@ -1,0 +1,89 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+// pinSessionMessage pins the first message of a session via the DB
+// directly and returns the message ID used.
+func pinSessionMessage(t *testing.T, te *testEnv, sessionID string) {
+	t.Helper()
+	msgs, err := te.db.GetMessages(context.Background(), sessionID, 0, 1, true)
+	if err != nil || len(msgs) == 0 {
+		t.Fatalf("pinSessionMessage: no messages in session %s (err=%v)", sessionID, err)
+	}
+	id, err := te.db.PinMessage(sessionID, msgs[0].ID, nil)
+	if err != nil || id == 0 {
+		t.Fatalf("pinSessionMessage: PinMessage failed for session %s (id=%d, err=%v)", sessionID, id, err)
+	}
+}
+
+func TestHandleListPins_NoFilter(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "alpha", 2)
+	te.seedSession(t, "s2", "beta", 2)
+	te.seedMessages(t, "s1", 2)
+	te.seedMessages(t, "s2", 2)
+	pinSessionMessage(t, te, "s1")
+	pinSessionMessage(t, te, "s2")
+
+	w := te.get(t, "/api/v1/pins")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/pins: status %d, want 200", w.Code)
+	}
+	var resp struct {
+		Pins []db.PinnedMessage `json:"pins"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if len(resp.Pins) != 2 {
+		t.Errorf("got %d pins, want 2", len(resp.Pins))
+	}
+}
+
+func TestHandleListPins_ProjectFilter(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "a1", "alpha", 2)
+	te.seedSession(t, "a2", "alpha", 2)
+	te.seedSession(t, "b1", "beta", 2)
+	te.seedMessages(t, "a1", 2)
+	te.seedMessages(t, "a2", 2)
+	te.seedMessages(t, "b1", 2)
+	pinSessionMessage(t, te, "a1")
+	pinSessionMessage(t, te, "a2")
+	pinSessionMessage(t, te, "b1")
+
+	tests := []struct {
+		query     string
+		wantCount int
+	}{
+		{"?project=alpha", 2},
+		{"?project=beta", 1},
+		{"?project=unknown", 0},
+		{"", 3},
+	}
+	for _, tc := range tests {
+		t.Run("query="+tc.query, func(t *testing.T) {
+			w := te.get(t, "/api/v1/pins"+tc.query)
+			if w.Code != http.StatusOK {
+				t.Fatalf("GET /api/v1/pins%s: status %d, want 200", tc.query, w.Code)
+			}
+			var resp struct {
+				Pins []db.PinnedMessage `json:"pins"`
+			}
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decoding response: %v", err)
+			}
+			if len(resp.Pins) != tc.wantCount {
+				t.Errorf("query %q: got %d pins, want %d",
+					tc.query, len(resp.Pins), tc.wantCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a project is selected in the header dropdown, the pinned messages page now filters to only show pins from sessions in that project. The count badge reflects the filtered count, and a dedicated empty state is shown when the filter yields no results.