### PR TITLE
feat: add markdown session export

### DIFF
--- a/docs/plans/2026-04-13-session-markdown-export-design.md
+++ b/docs/plans/2026-04-13-session-markdown-export-design.md
@@ -1,0 +1,629 @@
+# Session markdown export design
+
+## Summary
+
+Add `GET /api/v1/sessions/{id}/md` to serve session content as markdown for
+reuse as agent context. Output should favor machine ingestion over visual
+rendering while staying readable to humans.
+
+This export is separate from existing HTML export and GitHub Gist publish flow.
+Current system already supports:
+
+- SPA links to `/sessions/{id}`
+- HTML export at `GET /api/v1/sessions/{id}/export`
+- HTML gist publish at `POST /api/v1/sessions/{id}/publish`
+
+Current system does **not** support a markdown transcript endpoint or a stable
+URL that serves session content as markdown.
+
+## Goals
+
+- Provide stable local URL for markdown transcript access
+- Keep transcript readable by humans
+- Keep structure easy for downstream agents to parse
+- Preserve thinking and tool blocks with explicit XML tags
+- Inline subagent descendants at logical spawn points when exact anchors exist
+- Support optional descendant inclusion through query params
+
+## Non-goals
+
+- No new persistence or schema changes
+- No public share or gist flow for markdown in this change
+- No attempt to define or adopt an external universal transcript standard
+- No frontend rendering work required for first implementation
+- No change to existing HTML export behavior
+
+## Standards and ecosystem findings
+
+There is no broadly accepted standard for AI coding-agent transcripts serialized
+as markdown with XML tags.
+
+Closest references:
+
+- **OpenInference** provides semantic conventions for agent, LLM, and tool
+  tracing. Relevant field names include tool call identifiers, tool/function
+  names, arguments, and tool-call/result linking.
+- **MCP** defines structured concepts such as `tool_use` and `tool_result`, but
+  not a markdown transcript format.
+- **Anthropic** documents XML tags as a good way to structure prompts and notes
+  there is no canonical tag vocabulary.
+- **CommonMark** permits raw HTML/XML tags, but semantics for custom tags are
+  application-defined.
+
+Design implication: use standard markdown as container plus custom XML tags with
+names influenced by OpenInference and MCP semantics.
+
+## User-facing API
+
+### Route
+
+`GET /api/v1/sessions/{id}/md`
+
+### Query params
+
+- no `depth` param: current session only
+- `depth=1`: include direct child sessions
+- `depth=all`: include full descendant tree recursively
+
+### Invalid params
+
+If `depth` is present and not one of `1` or `all`, return `400 Bad Request`
+with a clear error message.
+
+### Handler behavior
+
+Unlike existing HTML export, markdown export should use normal timeout-wrapped
+route registration. Large recursive exports should still operate within regular
+API timeout behavior for this first implementation.
+
+### Error response shape
+
+Error responses should reuse existing server JSON error behavior rather than
+introducing a markdown-specific error body.
+
+### Response headers
+
+- `Content-Type: text/markdown; charset=utf-8`
+- `Content-Disposition: inline; filename="<sanitized>.md"`
+
+Reason: endpoint should be directly usable as URL-fed context without forced
+attachment download.
+
+## Export model
+
+Implementation should build a normalized export tree before rendering markdown.
+This keeps child placement logic, anchor resolution, and escaping in one place.
+
+Suggested internal model:
+
+- session metadata
+- ordered messages
+- ordered per-message segment stream
+  - text segments
+  - thinking segments
+  - tool segments
+  - code segments
+  - skill segments
+- anchored child sessions
+- appended child sessions without anchors
+
+Renderer contract for each message:
+
+- include system messages rather than filtering them out
+- derive ordered message segments using backend logic that matches frontend
+  `parseContent()` plus `enrichSegments()` behavior from
+  `frontend/src/lib/utils/content-parser.ts`
+- when a tool segment has no usable inline body text, generate equivalent
+  fallback body content using the same precedence as frontend tool rendering,
+  including Task/Agent prompt handling and `generateFallbackContent()`-style
+  behavior from `frontend/src/lib/utils/tool-params.ts`
+- render segments in that exact order
+- emit escaped text nodes for `text` segments
+- emit `<code_block language="...">...</code_block>` for `code` segments
+- emit `<skill name="...">...</skill>` for `skill` segments
+- emit structured XML blocks for `thinking` and `tool` segments
+- do not separately dump full raw `message.content` before or after the segment
+  stream
+
+This can later support multiple renderers if HTML export is migrated onto same
+model, but initial scope only requires markdown rendering.
+
+## Markdown structure
+
+Top-level document remains markdown, but machine-significant structure is
+expressed through XML tags.
+
+Example skeleton:
+
+```md
+# Session: my-project
+
+<session id="s1" project="my-project" agent="claude" started_at="2026-04-13T10:00:00Z">
+
+<message role="user" ordinal="0" timestamp="2026-04-13T10:01:00Z">
+How parser handle tool calls?
+</message>
+
+<message role="assistant" ordinal="1" timestamp="2026-04-13T10:01:05Z">
+<thinking>
+Need inspect export path first.
+</thinking>
+
+<tool_call id="toolu_123" name="Task" category="Task">
+<arguments><![CDATA[
+{"description":"inspect export path","subagent_type":"general-purpose"}
+]]></arguments>
+</tool_call>
+
+<subagent_anchor session_id="agent-abc" tool_call_id="toolu_123" depth="1">
+<subagent_session id="agent-abc" parent_session_id="s1" relationship="subagent">
+...
+</subagent_session>
+</subagent_anchor>
+
+Answer body here.
+</message>
+
+<child_session id="fork-1" parent_session_id="s1" relationship="fork">
+...
+</child_session>
+
+</session>
+```
+
+## Tag vocabulary
+
+### Required tags
+
+- `<session ...>`
+- `<message ...>`
+- `<thinking>`
+- `<tool_call ...>`
+- `<tool_body>`
+- `<arguments><![CDATA[...]]></arguments>`
+- `<tool_result ...><![CDATA[...]]></tool_result>`
+- `<subagent_anchor ...>`
+- `<subagent_session ...>`
+- `<child_session ...>`
+
+### Optional tags
+
+- `<skill ...>` for parsed skill segments
+- `<code_block ...>` for parsed code segments
+
+### Attributes
+
+#### `session`
+
+- `id`
+- `project`
+- `agent`
+- `started_at` when available
+- `ended_at` when available
+- `message_count`
+
+#### `message`
+
+- `role`
+- `ordinal`
+- `timestamp` when available
+- `is_system="true"` when persisted flag is set
+- `has_thinking="true"` when applicable
+- `has_tool_use="true"` when applicable
+
+#### `tool_call`
+
+- `id` from `tool_use_id` when available
+- `name` from `tool_name`
+- `category` from normalized category
+- `subagent_session_id` when available
+
+#### `tool_result`
+
+- `tool_call_id` when available
+- `source` when available
+- `status` when available
+- `agent_id` when available
+- `subagent_session_id` when available
+- `timestamp` when available
+
+#### `subagent_anchor`
+
+- `session_id`
+- `tool_call_id` when available
+- `depth` reflecting effective nesting level in export
+
+#### `subagent_session` / `child_session`
+
+Required:
+
+- `id`
+- `parent_session_id`
+
+Optional:
+
+- `relationship` when non-empty
+- `project` when available
+- `agent` when available
+- `started_at` when available
+- `ended_at` when available
+- `message_count` when available
+
+### Attribute serialization rule
+
+For all tags, omit attributes whose values are absent or empty. Do not emit
+empty-string attributes as placeholders. XML-escape all emitted attribute values.
+
+## Placement rules
+
+### Ordering source of truth
+
+Markdown export should mirror the logical presentation order of the session
+screen at `/sessions/{id}`, not invent a separate ordering model.
+
+Concretely:
+
+- message order follows stored `ordinal`
+- within each message, ordering follows the same segment ordering derived from
+  `frontend/src/lib/utils/content-parser.ts`
+- within each tool block, ordering follows the same structure used by
+  `frontend/src/lib/components/content/ToolBlock.svelte`
+
+### Current session only
+
+Without `depth`, export only requested session and its messages.
+
+### Direct children
+
+With `depth=1`, include direct children only.
+
+### Full tree
+
+With `depth=all`, recurse through descendants.
+
+## Child session anchoring
+
+### Anchored subagents
+
+When a child session is linked from a tool call via
+`tool_calls.subagent_session_id`, inline that child at the same logical point
+where the session screen shows the inline subagent for that tool block, using:
+
+```md
+<subagent_anchor ...>
+<subagent_session ...>
+...
+</subagent_session>
+</subagent_anchor>
+```
+
+This is preferred because repository data already captures:
+
+- `tool_calls.subagent_session_id`
+- parent message containing the tool call
+- tool call ordering within message
+- tool result history for that call
+
+In practice, this means anchored subagent content appears after the rest of that
+rendered tool block, matching session screen behavior.
+
+### Unanchored children
+
+If a child has `parent_session_id` but no exact tool-call anchor, append it
+after parent transcript in a `<child_session ...>` block ordered by
+`started_at` ascending, then `id` ascending as tie-breaker.
+
+This covers non-subagent descendants such as forks, continuations, or other
+future relationship types.
+
+### Recursive nesting
+
+For `depth=all`, nested subagents should be recursively inlined at each child’s
+own spawn point whenever anchors exist.
+
+Traversal must maintain a visited set by session ID. Each session is emitted at
+most once. If corrupt or unexpected archive data creates a cycle or duplicate
+reachability, skip re-emitting already visited sessions.
+
+## Message content formatting
+
+### Plain text
+
+Render `text` segments from the parsed segment stream as markdown/plain text in
+place.
+
+This export should include system messages too. They are not filtered out for
+markdown export; instead they remain in transcript order and are explicitly
+marked with `is_system="true"` on the enclosing `<message>` tag.
+
+### Thinking blocks
+
+Thinking content should be wrapped as:
+
+```md
+<thinking>
+...
+</thinking>
+```
+
+Thinking detection must follow backend logic that matches
+`frontend/src/lib/utils/content-parser.ts`, including avoidance of false
+positives inside inline-code spans.
+
+### Tool calls
+
+Each `tool` segment should render as a structured block in the same position as
+its corresponding tool block on the session screen:
+
+```md
+<tool_call id="..." name="..." category="...">
+<arguments><![CDATA[
+...
+]]></arguments>
+</tool_call>
+<tool_body><![CDATA[
+...
+]]></tool_body>
+```
+
+Use raw `input_json` when available rather than lossy prettified summaries.
+
+Tool body source precedence must match session screen behavior:
+
+1. for Task/Agent-style tools, use prompt/task body equivalent to UI
+   `taskPrompt` when present
+2. otherwise use enriched segment body text from backend logic matching
+   `enrichSegments()` when present
+3. otherwise generate fallback body equivalent to frontend
+   `generateFallbackContent()` behavior
+4. if none of the above yield content, omit `<tool_body>`
+
+For legacy/text-only tool segments without structured `toolCall` data:
+
+- derive `name` from the parsed segment label
+- derive `category` from normalized parsed tool name when possible
+- omit `<arguments>` because no structured `input_json` exists
+- still emit `<tool_body>` when the parsed segment contains body text
+
+### Tool results
+
+Tool results and result history should render as one or more tagged blocks:
+
+```md
+<tool_result tool_call_id="..." source="..." status="..."><![CDATA[
+...
+]]></tool_result>
+```
+
+If a tool has both main `result_content` and structured `result_events`, emit
+both. No dedupe. Duplicate content is acceptable.
+
+Ordering rule inside a rendered tool segment:
+
+- tool call metadata first
+- tool body next when present
+- main `result_content` next when present
+- `result_events` next in stored chronological order
+- anchored subagent block last, matching session screen behavior
+
+### Code segments
+
+Render `code` segments as:
+
+```md
+<code_block language="go"><![CDATA[
+...
+]]></code_block>
+```
+
+If the language label is empty, omit the `language` attribute.
+
+### Skill segments
+
+Render `skill` segments as:
+
+```md
+<skill name="skill-name"><![CDATA[
+...
+]]></skill>
+```
+
+If the parsed skill label is empty, omit the `name` attribute.
+
+### Escaping and CDATA
+
+Use CDATA for:
+
+- code block bodies
+- skill bodies
+- raw JSON arguments
+- tool bodies
+- command output
+- diffs
+- multi-line tool result content
+- any content likely to contain markdown/XML special characters
+
+If content contains `]]>` and would break CDATA, fall back to escaped text
+inside the tag instead of CDATA.
+
+Serialization matrix:
+
+- `text` segment body: escaped text node inside `<message>`
+- `thinking` body: CDATA when safe, else escaped text inside `<thinking>`
+- `code_block` body: CDATA when safe, else escaped text inside `<code_block>`
+- `skill` body: CDATA when safe, else escaped text inside `<skill>`
+- `tool_body`: CDATA when safe, else escaped text inside `<tool_body>`
+- `arguments`: CDATA when safe, else escaped text inside `<arguments>`
+- `tool_result`: CDATA when safe, else escaped text inside `<tool_result>`
+
+Plain message body text should still be XML-escaped as needed so malformed text
+cannot break surrounding tags.
+
+This endpoint prioritizes machine-ingestible structure over perfect markdown
+viewer rendering. Raw XML blocks may not render like ordinary markdown in all
+CommonMark viewers; that tradeoff is intentional.
+
+## Ordering
+
+### Sessions
+
+- root session first
+- anchored children inline at anchor point, matching session screen ordering
+- anchored child sessions must not also be emitted later as appended
+  `<child_session>` blocks
+- unanchored children appended after parent transcript by `started_at`, then
+  `id`
+- top-level markdown heading (`# Session: ...`) appears only for root export,
+  not nested child session containers
+
+### Messages
+
+Use stored message order (`ordinal` ascending).
+
+If a persisted message is empty after segment derivation, still emit an empty
+`<message ...></message>` block so transcript ordinals remain stable.
+
+### Child session container shape
+
+`<subagent_session>` and `<child_session>` contain:
+
+- only the attributes explicitly listed in the tag attribute section above
+- nested `<message>` blocks for that child session transcript
+- nested descendant `<subagent_anchor>`, `<subagent_session>`, and
+  `<child_session>` blocks as needed by depth and anchoring rules
+
+They do not contain a repeated top-level markdown heading.
+
+### Message segments
+
+Render message segments in the same order produced by backend logic matching
+`frontend/src/lib/utils/content-parser.ts`.
+
+### Tool segments
+
+Within a tool segment, mirror `ToolBlock.svelte` ordering:
+
+- tool call block
+- tool content/body
+- main output (`result_content`) when present
+- history/result events
+- inline subagent block when `subagent_session_id` resolves and depth allows
+
+## Data sources in current codebase
+
+Existing data already supports this feature without schema changes:
+
+- session and message retrieval via `getSessionWithMessages()` in
+  `internal/server/export.go`
+- child session retrieval via `GetChildSessions()` in DB and server layers
+- subagent links through `tool_calls.subagent_session_id`
+- tool result history through `tool_result_events`
+- child relationship via `sessions.parent_session_id`
+
+Likely implementation files:
+
+- `internal/server/server.go` for new route registration
+- `internal/server/export.go` for handler and markdown generator
+- `internal/server/server_test.go` for endpoint tests
+- `internal/server/export_test.go` for markdown formatting tests
+- `frontend/src/lib/utils/content-parser.ts` as semantic reference for
+  `parseContent()` and `enrichSegments()` behavior only; no frontend changes
+  required for this first implementation
+- `frontend/src/lib/utils/tool-params.ts` as semantic reference for fallback
+  tool-body generation only; no frontend changes required for this first
+  implementation
+
+## Error handling
+
+- unknown session ID: `404 Not Found`
+- invalid `depth` value: `400 Bad Request`
+- DB failures: `500 Internal Server Error`
+- empty child list: export succeeds without child blocks
+- malformed timestamps: preserve raw string where existing helpers already do so
+- CDATA-unsafe content: fall back to escaped text content inside XML tags
+
+## Security and safety
+
+- Keep existing escaping discipline from HTML export logic, adapted for
+  markdown/XML output
+- Ensure arbitrary message content cannot inject fake structural tags
+- Do not expose auth tokens or remote credentials in generated URL shape
+- Preserve existing local-only behavior; this endpoint is not a public publish
+  mechanism
+
+## Test plan
+
+Add focused unit and handler tests for:
+
+1. route exists at `/api/v1/sessions/{id}/md`
+2. content type is `text/markdown`
+3. route uses normal timeout-wrapped registration
+4. default export returns current session only
+5. `depth=1` includes direct children only
+6. `depth=all` includes recursive descendants
+7. anchored subagent child is inserted under matching `<subagent_anchor>` in
+   same relative position as session screen inline subagent rendering
+8. anchored child is not also duplicated as appended `<child_session>`
+9. unanchored child is appended as `<child_session>` after transcript
+10. thinking blocks render as `<thinking>` tags
+11. inline-code text that mentions `[Thinking]` or tool markers does not create
+    false structured blocks
+12. tool calls include arguments block with preserved raw JSON
+13. tool results render in same order as session screen semantics
+14. code segments render as `<code_block>` and skill segments render as
+    `<skill>` in segment order
+15. empty relationship type omits `relationship` attribute rather than
+    inventing a value
+16. empty optional attributes are omitted and emitted attributes are escaped
+17. empty persisted messages still emit empty `<message>` blocks
+18. system messages are included with `is_system="true"`
+19. invalid `depth` returns `400`
+20. missing session returns `404`
+21. invalid `input_json` falls back without dropping tool segment
+22. legacy tool segment without structured `toolCall` still emits deterministic
+    `<tool_call>` shape without `<arguments>`
+23. missing `subagent_session_id` target does not break export
+24. children with absent or equal `started_at` values use deterministic fallback
+    ordering
+25. text containing XML-like content is safely escaped
+26. cyclic or duplicate descendant references do not recurse forever or re-emit
+    same session twice
+
+## Open questions resolved
+
+- Endpoint path: `/api/v1/sessions/{id}/md`
+- Descendant control: `depth` query param
+- Default depth: current session only
+- Descendant strategy: inline anchored subagents; append unanchored children
+- Nested subagents with `depth=all`: recurse inline
+- Tag style: custom XML tags in markdown, not fenced-only representation
+- System messages: include them and tag with `is_system="true"`
+- Message ordering: mirror session screen segment ordering rather than dumping
+  full raw message content separately
+- Tool output merge: emit both `result_content` and `result_events`; no dedupe
+- Anchor ordering: same as session screen inline subagent ordering
+- CDATA failure: fall back to escaped text instead of CDATA
+- Route wiring: use normal timeout wrapper
+- Code segments: render as `<code_block>`
+- Skill segments: render as `<skill>`
+- Empty relationship type: omit `relationship` attribute
+- Empty persisted messages: still emit empty `<message>` blocks
+
+## Recommended implementation sequence
+
+1. add route and request validation
+2. build recursive session export tree with anchor resolution
+3. add markdown renderer
+4. add endpoint tests
+5. add formatter tests for thinking, tool calls, tool results, and child session
+   placement
+
+## Planning handoff
+
+Implementation plan should focus on:
+
+- handler and query parsing
+- export tree construction
+- markdown rendering helpers
+- recursive descendant loading
+- tests for route, formatting, and tree placement

--- a/docs/plans/2026-04-13-session-markdown-export-implementation-plan.md
+++ b/docs/plans/2026-04-13-session-markdown-export-implementation-plan.md
@@ -1,0 +1,399 @@
+# Session Markdown Export Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use `/skill:orchestrator-implements` (in-session, orchestrator implements), `/skill:subagent-driven-development` (in-session, subagents implement), or `/skill:executing-plans` (parallel session) to implement this plan. Steps use checkbox syntax for tracking.
+
+**Goal:** Add `GET /api/v1/sessions/{id}/md` that exports session transcripts as markdown with structured XML tags, optional descendant inclusion, and session-screen ordering semantics.
+
+**Architecture:** Extend server export support with a markdown-specific handler and renderer in `internal/server/export.go`. Build markdown output from session/message data using backend logic that mirrors frontend content segmentation and tool-body fallback rules, then recurse through child sessions with anchored subagent placement or appended child-session blocks.
+
+**Tech Stack:** Go, net/http, existing server/db layers, Go tests in `internal/server`, frontend parser semantics used as backend reference only.
+
+---
+
+### Task 1: Finalize spec + plan artifacts
+
+**TDD scenario:** Trivial change — use judgment
+
+**Files:**
+- Modify: `docs/plans/2026-04-13-session-markdown-export-design.md`
+- Create: `docs/plans/2026-04-13-session-markdown-export-implementation-plan.md`
+
+- [ ] **Step 1: Re-read final spec and ensure implementation tasks cover every requirement**
+
+Read:
+- `docs/plans/2026-04-13-session-markdown-export-design.md`
+- `internal/server/export.go`
+- `frontend/src/lib/utils/content-parser.ts`
+- `frontend/src/lib/utils/tool-params.ts`
+
+Expected: clear mapping from spec requirements to implementation tasks below.
+
+- [ ] **Step 2: Sanity-check docs formatting**
+
+Run:
+```bash
+git diff --check -- docs/plans/2026-04-13-session-markdown-export-design.md docs/plans/2026-04-13-session-markdown-export-implementation-plan.md
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 3: Commit docs-only planning artifacts**
+
+Run:
+```bash
+git add docs/plans/2026-04-13-session-markdown-export-design.md docs/plans/2026-04-13-session-markdown-export-implementation-plan.md
+git commit -m "docs: finalize markdown export spec and plan"
+```
+
+Expected: planning docs committed before source changes.
+
+### Task 2: Add failing markdown export formatter tests
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Modify: `internal/server/export_test.go`
+- Modify: `internal/server/server_test.go`
+- Reference: `internal/server/export.go`, `frontend/src/lib/utils/content-parser.ts`, `frontend/src/lib/utils/tool-params.ts`
+
+- [ ] **Step 1: Write failing formatter tests for segment rendering**
+
+Add table-driven tests covering:
+- text segment escaping
+- `<thinking>` rendering
+- `<tool_call>`, `<tool_body>`, `<arguments>`, `<tool_result>` ordering
+- Task/Agent prompt precedence over generic tool body
+- legacy tool segment without structured `toolCall`
+- `<code_block>` rendering
+- `<skill>` rendering
+- CDATA fallback on `]]>`
+- omission of empty optional attributes
+
+Example skeleton:
+
+```go
+func TestGenerateExportMarkdown_ToolOrdering(t *testing.T) {
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID: "test-id",
+		Ordinal:   0,
+		Role:      "assistant",
+		Content:   "[Task]\nbody",
+		HasToolUse: true,
+		ToolCalls: []db.ToolCall{{
+			ToolName:  "Task",
+			Category:  "Task",
+			ToolUseID: "toolu_1",
+			InputJSON: `{"prompt":"inspect repo"}`,
+			ResultContent: "done",
+		}},
+	}}
+
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertOrdered(t, out,
+		`<tool_call id="toolu_1" name="Task" category="Task">`,
+		`<tool_body><![CDATA[`+"\ninspect repo\n"+`]]></tool_body>`,
+		`<tool_result><![CDATA[`+"\ndone\n"+`]]></tool_result>`,
+	)
+}
+```
+
+- [ ] **Step 2: Write failing handler tests for route/query/header behavior**
+
+Add tests for:
+- `GET /api/v1/sessions/{id}/md`
+- `Content-Type: text/markdown`
+- inline `Content-Disposition` filename
+- invalid `depth` => `400`
+- not found => `404`
+- route reachable through normal timeout-wrapped server registration
+
+Example skeleton:
+
+```go
+func TestMarkdownSessionExport(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "my-app", 1)
+	te.seedMessages(t, "s1", 1)
+
+	w := te.get(t, "/api/v1/sessions/s1/md")
+	assertStatus(t, w, http.StatusOK)
+	assertHeaderContains(t, w, "Content-Type", "text/markdown")
+	assertHeaderContains(t, w, "Content-Disposition", "inline")
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify they fail for feature-missing reasons**
+
+Run:
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/server -run 'Test(MarkdownSessionExport|GenerateExportMarkdown)' -count=1
+```
+
+Expected: FAIL with undefined handler/renderer behavior or missing assertions for markdown export, not syntax/import errors.
+
+- [ ] **Step 4: Commit failing tests**
+
+Run:
+```bash
+git add internal/server/export_test.go internal/server/server_test.go
+git commit -m "test: add markdown export coverage"
+```
+
+Expected: red tests captured in history.
+
+### Task 3: Implement markdown segment parsing and rendering
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Modify: `internal/server/export.go`
+- Reference: `frontend/src/lib/utils/content-parser.ts`
+- Reference: `frontend/src/lib/utils/tool-params.ts`
+- Test: `internal/server/export_test.go`
+
+- [ ] **Step 1: Add backend markdown export options and route-facing renderer entrypoints**
+
+Implement minimal types/helpers, for example:
+
+```go
+type exportMarkdownOptions struct {
+	Depth string
+}
+
+type markdownRenderState struct {
+	visited map[string]bool
+}
+
+func generateExportMarkdown(
+	session *db.Session,
+	msgs []db.Message,
+	opts exportMarkdownOptions,
+) string {
+	// build root heading + session container + rendered messages
+}
+```
+
+- [ ] **Step 2: Port frontend segment parsing semantics needed by export**
+
+Add backend helpers in `internal/server/export.go` for:
+- thinking detection with marked + legacy forms
+- skill block detection
+- tool block detection with alias normalization
+- code block detection
+- inline-code false-positive avoidance
+- overlap resolution and segment building
+- structured tool-call enrichment including appended structured-only tools
+
+Suggested helper names:
+
+```go
+func parseMarkdownExportSegments(m db.Message) []exportSegment
+func enrichMarkdownToolSegments(segs []exportSegment, calls []db.ToolCall) []exportSegment
+```
+
+- [ ] **Step 3: Add safe XML/CDATA serialization helpers**
+
+Implement helpers such as:
+
+```go
+func escapeXMLText(s string) string
+func escapeXMLAttr(s string) string
+func wrapXMLText(tag string, attrs map[string]string, body string) string
+func wrapXMLCDATAOrEscaped(tag string, attrs map[string]string, body string) string
+```
+
+Rules:
+- omit empty attrs
+- CDATA when safe
+- escaped text fallback on `]]>`
+- keep top-level heading root-only
+
+- [ ] **Step 4: Implement segment rendering in session-screen order**
+
+For each `<message>`:
+- emit empty block even when no visible segments remain
+- `text` => escaped text node
+- `thinking` => `<thinking>`
+- `code` => `<code_block>`
+- `skill` => `<skill>`
+- `tool` => `<tool_call>`, optional `<arguments>`, optional `<tool_body>`, optional `<tool_result>` main output, optional result history, optional trailing `<subagent_anchor>` placeholder to be filled by recursion task
+
+Tool body precedence must match spec:
+1. Task/Agent prompt
+2. enriched segment content
+3. generated fallback body
+4. omit when empty
+
+- [ ] **Step 5: Run focused formatter tests and verify they pass**
+
+Run:
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/server -run 'TestGenerateExportMarkdown' -count=1
+```
+
+Expected: PASS for formatter-focused tests.
+
+- [ ] **Step 6: Commit renderer implementation**
+
+Run:
+```bash
+git add internal/server/export.go internal/server/export_test.go
+git commit -m "feat: add markdown export renderer"
+```
+
+Expected: renderer work committed separately from routing.
+
+### Task 4: Implement recursive child-session export and HTTP handler
+
+**TDD scenario:** Modifying tested code — run existing tests first
+
+**Files:**
+- Modify: `internal/server/export.go`
+- Modify: `internal/server/server.go`
+- Modify: `internal/server/server_test.go`
+- Reference: `internal/db/sessions.go`, `internal/db/messages.go`
+
+- [ ] **Step 1: Run existing server tests touching export routes before changing handler wiring**
+
+Run:
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/server -run 'Test(ExportSession|ExportSession_NotFound|ExportSession_HTMLContent)' -count=1
+```
+
+Expected: PASS before routing changes.
+
+- [ ] **Step 2: Add markdown handler and depth validation**
+
+Implement:
+
+```go
+func (s *Server) handleMarkdownSession(
+	w http.ResponseWriter, r *http.Request,
+) {
+	// validate depth, fetch root, render markdown,
+	// set inline markdown headers, write body
+}
+```
+
+Wire in `internal/server/server.go` using normal timeout wrapper:
+
+```go
+s.mux.Handle(
+	"GET /api/v1/sessions/{id}/md",
+	s.withTimeout(s.handleMarkdownSession),
+)
+```
+
+- [ ] **Step 3: Implement descendant loading + placement rules**
+
+Add helpers roughly like:
+
+```go
+func (s *Server) loadMarkdownExportTree(
+	ctx context.Context,
+	rootID string,
+	depth string,
+) (*exportSessionTree, error)
+```
+
+Rules:
+- default: no descendants
+- `depth=1`: direct children only
+- `depth=all`: recurse with visited set
+- anchored child: match by `toolCall.subagent_session_id`, inline once only
+- unanchored child: append as `<child_session>` after transcript ordered by `started_at`, then `id`
+- missing child target: skip safely
+
+- [ ] **Step 4: Run handler-focused tests and verify they pass**
+
+Run:
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/server -run 'TestMarkdownSessionExport' -count=1
+```
+
+Expected: PASS for route/query/header behavior and descendant export tests.
+
+- [ ] **Step 5: Commit route + recursion work**
+
+Run:
+```bash
+git add internal/server/export.go internal/server/server.go internal/server/server_test.go
+git commit -m "feat: add markdown session export endpoint"
+```
+
+Expected: endpoint and recursion behavior committed.
+
+### Task 5: Verify full server package and prepare PR
+
+**TDD scenario:** Modifying tested code — run existing tests before and after
+
+**Files:**
+- Modify: any review-fix files from previous tasks
+- Test: `internal/server/export_test.go`, `internal/server/server_test.go`
+
+- [ ] **Step 1: Run full relevant test suite**
+
+Run:
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/server/... -count=1
+```
+
+Expected: PASS with 0 failures.
+
+- [ ] **Step 2: Run lightweight diff verification**
+
+Run:
+```bash
+git diff --check
+```
+
+Expected: no whitespace or conflict-marker issues.
+
+- [ ] **Step 3: Review final diff for PR summary inputs**
+
+Run:
+```bash
+git status --short
+git diff --stat HEAD~3..HEAD
+```
+
+Expected: only markdown export–related files changed.
+
+- [ ] **Step 4: Commit any final review-driven fixes**
+
+Run:
+```bash
+git add -A
+git commit -m "fix: polish markdown session export"
+```
+
+Expected: only if post-test/review fixes exist.
+
+- [ ] **Step 5: Push branch and open PR**
+
+Run:
+```bash
+git push -u origin abiding-almanac
+gh pr create --title "feat: add markdown session export" --body "## Summary
+- add /api/v1/sessions/{id}/md markdown export endpoint
+- render session-screen ordered markdown/XML transcript with optional descendants
+- cover route, formatting, and recursion with server tests
+
+## Validation
+- CGO_ENABLED=1 go test -tags fts5 ./internal/server/... -count=1
+- git diff --check"
+```
+
+Expected: branch pushed, PR URL returned.
+
+## Self-review
+
+- Spec coverage: route, headers, depth handling, ordering, descendant placement,
+  escaping, CDATA fallback, optional attrs, system messages, and recursion
+  safety are all mapped into Tasks 2-5.
+- Placeholder scan: no TODO/TBD steps; each task has concrete files and
+  commands.
+- Consistency: plan uses one renderer in `internal/server/export.go`, one route
+  in `internal/server/server.go`, and one verification command family in
+  `internal/server` tests.

--- a/frontend/src/lib/api/client-markdown-export.test.ts
+++ b/frontend/src/lib/api/client-markdown-export.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getMarkdownExportUrl } from "./client.js";
+
+const storage = {
+  getItem: vi.fn().mockReturnValue(""),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+
+describe("markdown export URLs", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", storage);
+    storage.getItem.mockReturnValue("");
+    document.head.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("builds markdown export URL with optional depth", () => {
+    expect(getMarkdownExportUrl("sess-123")).toBe(
+      "/api/v1/sessions/sess-123/md",
+    );
+    expect(getMarkdownExportUrl("sess-123", "all")).toBe(
+      "/api/v1/sessions/sess-123/md?depth=all",
+    );
+    expect(getMarkdownExportUrl("sess-123", 1)).toBe(
+      "/api/v1/sessions/sess-123/md?depth=1",
+    );
+  });
+});

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -441,6 +441,21 @@ export function getExportUrl(sessionId: string): string {
   return `${getBase()}/sessions/${sessionId}/export`;
 }
 
+/** Get markdown export URL for a session, with optional child depth. */
+export function getMarkdownExportUrl(
+  sessionId: string,
+  depth?: 1 | "all",
+): string {
+  const url = new URL(
+    `${getBase()}/sessions/${sessionId}/md`,
+    window.location.origin,
+  );
+  if (depth !== undefined) {
+    url.searchParams.set("depth", String(depth));
+  }
+  return `${url.pathname}${url.search}`;
+}
+
 /** Download a session export using fetch with auth headers,
  *  avoiding token leakage in the URL for remote connections. */
 export async function downloadExport(sessionId: string): Promise<void> {

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -8,7 +8,11 @@
   import { sessions } from "../../stores/sessions.svelte.js";
   import { sync } from "../../stores/sync.svelte.js";
   import { router } from "../../stores/router.svelte.js";
-  import { downloadExport } from "../../api/client.js";
+  import {
+    downloadExport,
+    getMarkdownExportUrl,
+  } from "../../api/client.js";
+  import { copyToClipboard } from "../../utils/clipboard.js";
   import ProjectTypeahead from "./ProjectTypeahead.svelte";
   import ImportModal from "../import/ImportModal.svelte";
 
@@ -17,11 +21,20 @@
 
   let showImportModal = $state(false);
   let showBlockFilter = $state(false);
+  let showExportMenu = $state(false);
   let showOverflow = $state(false);
+  let copiedMarkdownLink = $state(false);
+  let copiedMarkdownLinkTimer:
+    | ReturnType<typeof setTimeout>
+    | undefined;
   let moreOpen = $state(false);
   let filterBtnRef: HTMLButtonElement | undefined =
     $state(undefined);
   let filterDropRef: HTMLDivElement | undefined =
+    $state(undefined);
+  let exportBtnRef: HTMLButtonElement | undefined =
+    $state(undefined);
+  let exportDropRef: HTMLDivElement | undefined =
     $state(undefined);
   let overflowBtnRef: HTMLButtonElement | undefined =
     $state(undefined);
@@ -58,6 +71,23 @@
     }
   }
 
+  async function handleCopyMarkdownExportLink() {
+    if (!sessions.activeSessionId) return;
+    const url = new URL(
+      getMarkdownExportUrl(sessions.activeSessionId),
+      window.location.origin,
+    ).toString();
+    const ok = await copyToClipboard(url);
+    if (!ok) return;
+    copiedMarkdownLink = true;
+    clearTimeout(copiedMarkdownLinkTimer);
+    copiedMarkdownLinkTimer = setTimeout(() => {
+      copiedMarkdownLink = false;
+    }, 1500);
+    showExportMenu = false;
+    showOverflow = false;
+  }
+
   const hasActiveSession = $derived(
     sessions.activeSessionId !== null,
   );
@@ -73,6 +103,27 @@
       )
         return;
       showBlockFilter = false;
+    }
+    document.addEventListener("click", onClickOutside, true);
+    return () =>
+      document.removeEventListener(
+        "click",
+        onClickOutside,
+        true,
+      );
+  });
+
+  // Close export menu on outside click
+  $effect(() => {
+    if (!showExportMenu) return;
+    function onClickOutside(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        exportBtnRef?.contains(target) ||
+        exportDropRef?.contains(target)
+      )
+        return;
+      showExportMenu = false;
     }
     document.addEventListener("click", onClickOutside, true);
     return () =>
@@ -367,18 +418,59 @@
         {/if}
       </button>
 
-      <button
-        class="header-btn collapsible"
-        onclick={handleExport}
-        disabled={!sessions.activeSessionId}
-        title="Export session (e)"
-        aria-label="Export session"
-      >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-          <path d="M4.406 1.342A5.53 5.53 0 018 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10a.5.5 0 010-1h2.688C13.979 10 15 8.988 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 00-2.941 1.1c-.757.652-1.153 1.438-1.153 2.055v.448l-.445.049C2.064 4.805 1 5.952 1 7.318 1 8.785 2.23 10 3.781 10H6a.5.5 0 010 1H3.781C1.708 11 0 9.366 0 7.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383z"/>
-          <path d="M7.646 4.146a.5.5 0 01.708 0l3 3a.5.5 0 01-.708.708L8.5 5.707V14.5a.5.5 0 01-1 0V5.707L5.354 7.854a.5.5 0 11-.708-.708l3-3z"/>
-        </svg>
-      </button>
+      <div class="export-wrap collapsible">
+        <button
+          class="header-btn"
+          bind:this={exportBtnRef}
+          onclick={() => {
+            showExportMenu = !showExportMenu;
+            showOverflow = false;
+          }}
+          disabled={!sessions.activeSessionId}
+          title="Export session options"
+          aria-label="Export session"
+          aria-expanded={showExportMenu}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M4.406 1.342A5.53 5.53 0 018 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10a.5.5 0 010-1h2.688C13.979 10 15 8.988 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 00-2.941 1.1c-.757.652-1.153 1.438-1.153 2.055v.448l-.445.049C2.064 4.805 1 5.952 1 7.318 1 8.785 2.23 10 3.781 10H6a.5.5 0 010 1H3.781C1.708 11 0 9.366 0 7.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383z"/>
+            <path d="M7.646 4.146a.5.5 0 01.708 0l3 3a.5.5 0 01-.708.708L8.5 5.707V14.5a.5.5 0 01-1 0V5.707L5.354 7.854a.5.5 0 11-.708-.708l3-3z"/>
+          </svg>
+        </button>
+
+        {#if showExportMenu}
+          <div class="export-dropdown" bind:this={exportDropRef}>
+            <button
+              class="overflow-item"
+              onclick={() => {
+                handleExport();
+                showExportMenu = false;
+              }}
+            >
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M4.406 1.342A5.53 5.53 0 018 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10a.5.5 0 010-1h2.688C13.979 10 15 8.988 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 00-2.941 1.1c-.757.652-1.153 1.438-1.153 2.055v.448l-.445.049C2.064 4.805 1 5.952 1 7.318 1 8.785 2.23 10 3.781 10H6a.5.5 0 010 1H3.781C1.708 11 0 9.366 0 7.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383z"/>
+                <path d="M7.646 4.146a.5.5 0 01.708 0l3 3a.5.5 0 01-.708.708L8.5 5.707V14.5a.5.5 0 01-1 0V5.707L5.354 7.854a.5.5 0 11-.708-.708l3-3z"/>
+              </svg>
+              <span>Download HTML export</span>
+            </button>
+            <button
+              class="overflow-item"
+              onclick={handleCopyMarkdownExportLink}
+            >
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M4.5 2A2.5 2.5 0 002 4.5v7A2.5 2.5 0 004.5 14h5A2.5 2.5 0 0012 11.5v-1a.5.5 0 011 0v1A3.5 3.5 0 019.5 15h-5A3.5 3.5 0 011 11.5v-7A3.5 3.5 0 014.5 1h1a.5.5 0 010 1h-1z"/>
+                <path d="M6.854 1.146a.5.5 0 010 .708L5.707 3H11.5A3.5 3.5 0 0115 6.5v5a3.5 3.5 0 01-3.5 3.5h-1a.5.5 0 010-1h1A2.5 2.5 0 0014 11.5v-5A2.5 2.5 0 0011.5 4H5.707l1.147 1.146a.5.5 0 11-.708.708l-2-2a.5.5 0 010-.708l2-2a.5.5 0 01.708 0z"/>
+              </svg>
+              <span>
+                {#if copiedMarkdownLink}
+                  Copied markdown link
+                {:else}
+                  Copy markdown export link
+                {/if}
+              </span>
+            </button>
+          </div>
+        {/if}
+      </div>
 
       <button
         class="header-btn collapsible"
@@ -434,7 +526,23 @@
                 <path d="M4.406 1.342A5.53 5.53 0 018 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10a.5.5 0 010-1h2.688C13.979 10 15 8.988 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 00-2.941 1.1c-.757.652-1.153 1.438-1.153 2.055v.448l-.445.049C2.064 4.805 1 5.952 1 7.318 1 8.785 2.23 10 3.781 10H6a.5.5 0 010 1H3.781C1.708 11 0 9.366 0 7.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383z"/>
                 <path d="M7.646 4.146a.5.5 0 01.708 0l3 3a.5.5 0 01-.708.708L8.5 5.707V14.5a.5.5 0 01-1 0V5.707L5.354 7.854a.5.5 0 11-.708-.708l3-3z"/>
               </svg>
-              <span>Export session</span>
+              <span>Download HTML export</span>
+            </button>
+            <button
+              class="overflow-item"
+              onclick={handleCopyMarkdownExportLink}
+            >
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M4.5 2A2.5 2.5 0 002 4.5v7A2.5 2.5 0 004.5 14h5A2.5 2.5 0 0012 11.5v-1a.5.5 0 011 0v1A3.5 3.5 0 019.5 15h-5A3.5 3.5 0 011 11.5v-7A3.5 3.5 0 014.5 1h1a.5.5 0 010 1h-1z"/>
+                <path d="M6.854 1.146a.5.5 0 010 .708L5.707 3H11.5A3.5 3.5 0 0115 6.5v5a3.5 3.5 0 01-3.5 3.5h-1a.5.5 0 010-1h1A2.5 2.5 0 0014 11.5v-5A2.5 2.5 0 0011.5 4H5.707l1.147 1.146a.5.5 0 11-.708.708l-2-2a.5.5 0 010-.708l2-2a.5.5 0 01.708 0z"/>
+              </svg>
+              <span>
+                {#if copiedMarkdownLink}
+                  Copied markdown link
+                {:else}
+                  Copy markdown export link
+                {/if}
+              </span>
             </button>
             <button
               class="overflow-item"
@@ -929,6 +1037,27 @@
     background: var(--border-muted);
     margin: 0 2px;
     flex-shrink: 0;
+  }
+
+  .export-wrap {
+    position: relative;
+    display: flex;
+  }
+
+  .export-dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 4px;
+    width: 220px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    padding: 4px 0;
+    z-index: 100;
+    animation: dropdown-in 0.12s ease-out;
+    transform-origin: top right;
   }
 
   @keyframes spin {

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mount, tick, unmount } from "svelte";
+const mocks = vi.hoisted(() => ({
+  downloadExport: vi.fn().mockResolvedValue(undefined),
+  getMarkdownExportUrl: vi
+    .fn()
+    .mockReturnValue("/api/v1/sessions/sess-123/md"),
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../../api/client.js", () => ({
+  downloadExport: mocks.downloadExport,
+  getMarkdownExportUrl: mocks.getMarkdownExportUrl,
+}));
+
+vi.mock("../../utils/clipboard.js", () => ({
+  copyToClipboard: mocks.copyToClipboard,
+}));
+
+import { sessions } from "../../stores/sessions.svelte.js";
+import { ui } from "../../stores/ui.svelte.js";
+
+// @ts-ignore
+import AppHeader from "./AppHeader.svelte";
+
+describe("AppHeader export actions", () => {
+  let component: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessions.activeSessionId = "sess-123";
+    ui.isMobileViewport = false;
+  });
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = undefined;
+    }
+    document.body.innerHTML = "";
+  });
+
+  it("copies markdown export link from export menu", async () => {
+    component = mount(AppHeader, { target: document.body });
+    await tick();
+
+    const exportButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Export session"]',
+    );
+    expect(exportButton).not.toBeNull();
+
+    exportButton!.click();
+    await tick();
+
+    const copyButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) =>
+      button.textContent?.includes("Copy markdown export link"),
+    );
+    expect(copyButton).not.toBeNull();
+
+    copyButton!.click();
+    await tick();
+
+    expect(mocks.getMarkdownExportUrl).toHaveBeenCalledWith("sess-123");
+    expect(mocks.copyToClipboard).toHaveBeenCalledWith(
+      "http://localhost:3000/api/v1/sessions/sess-123/md",
+    );
+  });
+});

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -905,6 +905,14 @@ func TestGetChildSessions(t *testing.T) {
 		s.EndedAt = Ptr("2024-06-01T10:15:00Z")
 		s.MessageCount = 4
 	})
+	insertSession(t, d, "child-deleted", "proj", func(s *Session) {
+		s.ParentSessionID = Ptr("parent-1")
+		s.RelationshipType = "subagent"
+		s.StartedAt = Ptr("2024-06-01T10:07:00Z")
+		s.EndedAt = Ptr("2024-06-01T10:08:00Z")
+		s.MessageCount = 1
+	})
+	requireNoError(t, d.SoftDeleteSession("child-deleted"), "SoftDeleteSession")
 
 	// Insert an unrelated session (no parent).
 	insertSession(t, d, "unrelated", "proj", func(s *Session) {
@@ -918,7 +926,7 @@ func TestGetChildSessions(t *testing.T) {
 		)
 		requireNoError(t, err, "GetChildSessions")
 		if len(children) != 3 {
-			t.Fatalf("expected 3 children, got %d", len(children))
+			t.Fatalf("expected 3 visible children, got %d", len(children))
 		}
 		// Ordered by started_at ascending.
 		wantIDs := []string{"child-sub", "child-cont", "child-fork"}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -608,6 +608,7 @@ func (db *DB) GetChildSessions(
 ) ([]Session, error) {
 	query := "SELECT " + sessionBaseCols +
 		" FROM sessions WHERE parent_session_id = ?" +
+		" AND deleted_at IS NULL" +
 		" ORDER BY started_at"
 	rows, err := db.getReader().QueryContext(ctx, query, parentID)
 	if err != nil {

--- a/internal/server/export_markdown.go
+++ b/internal/server/export_markdown.go
@@ -1,0 +1,1150 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/wesm/agentsview/internal/db"
+	"github.com/wesm/agentsview/internal/parser"
+)
+
+type exportMarkdownOptions struct {
+	Depth string
+}
+
+type exportSessionTree struct {
+	Session          *db.Session
+	Messages         []db.Message
+	AnchoredChildren map[string]*exportSessionTree
+	AppendedChildren []*exportSessionTree
+}
+
+type markdownSegmentType string
+
+const (
+	markdownSegmentText     markdownSegmentType = "text"
+	markdownSegmentThinking markdownSegmentType = "thinking"
+	markdownSegmentTool     markdownSegmentType = "tool"
+	markdownSegmentCode     markdownSegmentType = "code"
+	markdownSegmentSkill    markdownSegmentType = "skill"
+)
+
+type markdownSegment struct {
+	Type     markdownSegmentType
+	Content  string
+	Label    string
+	ToolName string
+	ToolCall *db.ToolCall
+}
+
+type markdownMatch struct {
+	Start   int
+	End     int
+	Segment markdownSegment
+}
+
+func (s *Server) handleMarkdownSession(
+	w http.ResponseWriter, r *http.Request,
+) {
+	depth := strings.TrimSpace(r.URL.Query().Get("depth"))
+	if depth != "" && depth != "1" && depth != "all" {
+		writeError(w, http.StatusBadRequest, "invalid depth")
+		return
+	}
+	tree, err := s.loadExportSessionTree(r.Context(), r.PathValue("id"), depth, map[string]bool{}, 0)
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if tree == nil || tree.Session == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	md := generateExportMarkdownTree(tree, exportMarkdownOptions{Depth: depth})
+	filename := sanitizeFilename(
+		tree.Session.Project + "-" + formatDateShort(tree.Session.StartedAt) + ".md",
+	)
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set(
+		"Content-Disposition",
+		fmt.Sprintf(`inline; filename="%s"`, filename),
+	)
+	_, _ = io.WriteString(w, md)
+}
+
+func (s *Server) loadExportSessionTree(
+	ctx context.Context,
+	sessionID string,
+	depth string,
+	visited map[string]bool,
+	level int,
+) (*exportSessionTree, error) {
+	if visited[sessionID] {
+		return nil, nil
+	}
+	visited[sessionID] = true
+
+	sess, err := s.db.GetSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if sess == nil {
+		return nil, nil
+	}
+	msgs, err := s.db.GetAllMessages(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	tree := &exportSessionTree{
+		Session:          sess,
+		Messages:         msgs,
+		AnchoredChildren: map[string]*exportSessionTree{},
+	}
+	if !shouldLoadMarkdownChildren(depth, level) {
+		return tree, nil
+	}
+	children, err := s.db.GetChildSessions(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	anchored := markdownAnchoredChildIDs(msgs)
+	for _, child := range children {
+		childTree, err := s.loadExportSessionTree(ctx, child.ID, depth, visited, level+1)
+		if err != nil {
+			return nil, err
+		}
+		if childTree == nil || childTree.Session == nil {
+			continue
+		}
+		if anchored[child.ID] {
+			tree.AnchoredChildren[child.ID] = childTree
+			continue
+		}
+		tree.AppendedChildren = append(tree.AppendedChildren, childTree)
+	}
+	return tree, nil
+}
+
+func shouldLoadMarkdownChildren(depth string, level int) bool {
+	switch depth {
+	case "1":
+		return level == 0
+	case "all":
+		return true
+	default:
+		return false
+	}
+}
+
+func markdownAnchoredChildIDs(msgs []db.Message) map[string]bool {
+	ids := map[string]bool{}
+	for _, msg := range msgs {
+		for _, tc := range msg.ToolCalls {
+			if tc.SubagentSessionID != "" {
+				ids[tc.SubagentSessionID] = true
+			}
+		}
+	}
+	return ids
+}
+
+var (
+	mdThinkingMarkedRe = regexp.MustCompile(`(?s)\[Thinking\]\n?(.*?)\n?\[/Thinking\]`)
+	mdSkillRe          = regexp.MustCompile(`(?s)\[Skill: (.+?)\]\n?(.*?)\n?\[/Skill\]`)
+	mdCodeBlockRe      = regexp.MustCompile("(?s)```(\\w*)\\n(.*?)```")
+)
+
+const markdownToolNames = "Tool|Read|Write|Edit|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Agent|Skill|" +
+	"SendMessage|Question|Todo List|Entering Plan Mode|" +
+	"Exiting Plan Mode|exec_command|shell_command|" +
+	"write_stdin|apply_patch|shell|parallel|view_image|" +
+	"request_user_input|update_plan"
+
+var (
+	mdToolAliases = map[string]string{
+		"Agent":         "Task",
+		"exec_command":  "Bash",
+		"shell_command": "Bash",
+		"write_stdin":   "Bash",
+		"shell":         "Bash",
+		"apply_patch":   "Edit",
+		"str_replace":   "Edit",
+		"run_command":   "Bash",
+		"create_file":   "Write",
+		"read_file":     "Read",
+		"bash":          "Bash",
+		"read":          "Read",
+		"write":         "Write",
+		"edit":          "Edit",
+		"grep":          "Grep",
+		"glob":          "Glob",
+		"find":          "Read",
+	}
+	mdToolStartRe = regexp.MustCompile(`^\[(` + markdownToolNames + `)([^\]]*)\]`)
+)
+
+func generateExportMarkdown(
+	session *db.Session,
+	msgs []db.Message,
+	opts exportMarkdownOptions,
+) string {
+	return generateExportMarkdownTree(&exportSessionTree{
+		Session:          session,
+		Messages:         msgs,
+		AnchoredChildren: map[string]*exportSessionTree{},
+	}, opts)
+}
+
+func generateExportMarkdownTree(
+	tree *exportSessionTree,
+	opts exportMarkdownOptions,
+) string {
+	if tree == nil || tree.Session == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("# Session: ")
+	b.WriteString(markdownHeadingText(tree.Session.Project))
+	b.WriteString("\n\n")
+	renderMarkdownSession(&b, tree, opts, true)
+	return b.String()
+}
+
+func renderMarkdownSession(
+	b *strings.Builder,
+	tree *exportSessionTree,
+	opts exportMarkdownOptions,
+	root bool,
+) {
+	if tree == nil || tree.Session == nil {
+		return
+	}
+	tag := "session"
+	if !root {
+		tag = "child_session"
+	}
+	attrs := markdownSessionAttrs(tree.Session, root)
+	b.WriteString(openTag(tag, attrs))
+	b.WriteString("\n")
+
+	renderedAnchors := map[string]bool{}
+	for i := range tree.Messages {
+		renderMarkdownMessage(b, tree, &tree.Messages[i], opts, renderedAnchors)
+	}
+
+	children := sortedExportChildren(tree.AppendedChildren)
+	for _, child := range children {
+		if child == nil || child.Session == nil {
+			continue
+		}
+		if renderedAnchors[child.Session.ID] {
+			continue
+		}
+		renderMarkdownChildSession(b, child, opts, false)
+	}
+
+	b.WriteString(closeTag(tag))
+	b.WriteString("\n")
+}
+
+func renderMarkdownChildSession(
+	b *strings.Builder,
+	child *exportSessionTree,
+	opts exportMarkdownOptions,
+	anchored bool,
+) {
+	if child == nil || child.Session == nil {
+		return
+	}
+	tag := "child_session"
+	if anchored {
+		tag = "subagent_session"
+	}
+	b.WriteString(openTag(tag, markdownSessionAttrs(child.Session, false)))
+	b.WriteString("\n")
+	renderedAnchors := map[string]bool{}
+	for i := range child.Messages {
+		renderMarkdownMessage(b, child, &child.Messages[i], opts, renderedAnchors)
+	}
+	for _, appended := range sortedExportChildren(child.AppendedChildren) {
+		if appended == nil || appended.Session == nil {
+			continue
+		}
+		if renderedAnchors[appended.Session.ID] {
+			continue
+		}
+		renderMarkdownChildSession(b, appended, opts, false)
+	}
+	b.WriteString(closeTag(tag))
+	b.WriteString("\n")
+}
+
+func renderMarkdownMessage(
+	b *strings.Builder,
+	tree *exportSessionTree,
+	msg *db.Message,
+	opts exportMarkdownOptions,
+	renderedAnchors map[string]bool,
+) {
+	attrs := map[string]string{
+		"role":    msg.Role,
+		"ordinal": fmt.Sprintf("%d", msg.Ordinal),
+	}
+	if msg.Timestamp != "" {
+		attrs["timestamp"] = msg.Timestamp
+	}
+	if msg.IsSystem {
+		attrs["is_system"] = "true"
+	}
+	if msg.HasThinking {
+		attrs["has_thinking"] = "true"
+	}
+	if msg.HasToolUse {
+		attrs["has_tool_use"] = "true"
+	}
+	b.WriteString(openTag("message", attrs))
+
+	segments := parseMarkdownSegments(*msg)
+	if len(segments) == 0 {
+		b.WriteString(closeTag("message"))
+		b.WriteString("\n")
+		return
+	}
+	b.WriteString("\n")
+	for _, seg := range segments {
+		switch seg.Type {
+		case markdownSegmentText:
+			b.WriteString(escapeXMLText(seg.Content))
+			b.WriteString("\n")
+		case markdownSegmentThinking:
+			b.WriteString(renderXMLBodyTag("thinking", nil, seg.Content))
+			b.WriteString("\n")
+		case markdownSegmentCode:
+			codeAttrs := map[string]string{}
+			if seg.Label != "" {
+				codeAttrs["language"] = seg.Label
+			}
+			b.WriteString(renderXMLBodyTag("code_block", codeAttrs, seg.Content))
+			b.WriteString("\n")
+		case markdownSegmentSkill:
+			skillAttrs := map[string]string{}
+			if seg.Label != "" {
+				skillAttrs["name"] = seg.Label
+			}
+			b.WriteString(renderXMLBodyTag("skill", skillAttrs, seg.Content))
+			b.WriteString("\n")
+		case markdownSegmentTool:
+			renderMarkdownToolSegment(b, tree, seg, opts, renderedAnchors)
+		}
+	}
+	b.WriteString(closeTag("message"))
+	b.WriteString("\n")
+}
+
+func renderMarkdownToolSegment(
+	b *strings.Builder,
+	tree *exportSessionTree,
+	seg markdownSegment,
+	opts exportMarkdownOptions,
+	renderedAnchors map[string]bool,
+) {
+	name, category := markdownToolIdentity(seg)
+	attrs := map[string]string{}
+	if name != "" {
+		attrs["name"] = name
+	}
+	if category != "" {
+		attrs["category"] = category
+	}
+	if seg.ToolCall != nil {
+		if seg.ToolCall.ToolUseID != "" {
+			attrs["id"] = seg.ToolCall.ToolUseID
+		}
+		if seg.ToolCall.SubagentSessionID != "" {
+			attrs["subagent_session_id"] = seg.ToolCall.SubagentSessionID
+		}
+	}
+	b.WriteString(openTag("tool_call", attrs))
+	b.WriteString("\n")
+	if seg.ToolCall != nil && seg.ToolCall.InputJSON != "" {
+		b.WriteString(renderXMLBodyTag("arguments", nil, seg.ToolCall.InputJSON))
+		b.WriteString("\n")
+	}
+	b.WriteString(closeTag("tool_call"))
+	b.WriteString("\n")
+
+	if body := markdownToolBody(seg); body != "" {
+		b.WriteString(renderXMLBodyTag("tool_body", nil, body))
+		b.WriteString("\n")
+	}
+	if seg.ToolCall != nil && seg.ToolCall.ResultContent != "" {
+		b.WriteString(renderXMLBodyTag("tool_result", nil, seg.ToolCall.ResultContent))
+		b.WriteString("\n")
+	}
+	if seg.ToolCall != nil {
+		for _, ev := range seg.ToolCall.ResultEvents {
+			evAttrs := map[string]string{}
+			if ev.ToolUseID != "" {
+				evAttrs["tool_call_id"] = ev.ToolUseID
+			}
+			if ev.Source != "" {
+				evAttrs["source"] = ev.Source
+			}
+			if ev.Status != "" {
+				evAttrs["status"] = ev.Status
+			}
+			if ev.AgentID != "" {
+				evAttrs["agent_id"] = ev.AgentID
+			}
+			if ev.SubagentSessionID != "" {
+				evAttrs["subagent_session_id"] = ev.SubagentSessionID
+			}
+			if ev.Timestamp != "" {
+				evAttrs["timestamp"] = ev.Timestamp
+			}
+			b.WriteString(renderXMLBodyTag("tool_result", evAttrs, ev.Content))
+			b.WriteString("\n")
+		}
+	}
+
+	if seg.ToolCall != nil && seg.ToolCall.SubagentSessionID != "" && opts.Depth != "" {
+		if child := tree.AnchoredChildren[seg.ToolCall.SubagentSessionID]; child != nil {
+			if renderedAnchors[child.Session.ID] {
+				return
+			}
+			renderedAnchors[child.Session.ID] = true
+			anchorAttrs := map[string]string{
+				"session_id": child.Session.ID,
+			}
+			if seg.ToolCall.ToolUseID != "" {
+				anchorAttrs["tool_call_id"] = seg.ToolCall.ToolUseID
+			}
+			if opts.Depth != "" {
+				anchorAttrs["depth"] = opts.Depth
+			}
+			b.WriteString(openTag("subagent_anchor", anchorAttrs))
+			b.WriteString("\n")
+			renderMarkdownChildSession(b, child, opts, true)
+			b.WriteString(closeTag("subagent_anchor"))
+			b.WriteString("\n")
+		}
+	}
+}
+
+func markdownToolIdentity(seg markdownSegment) (string, string) {
+	if seg.ToolCall != nil {
+		name := seg.ToolCall.ToolName
+		if name == "" {
+			name = seg.Label
+		}
+		category := seg.ToolCall.Category
+		if category == "" {
+			category = normalizeMarkdownToolName(name)
+		}
+		return name, category
+	}
+	name := strings.TrimSpace(seg.ToolName)
+	if name == "" {
+		name = strings.TrimSpace(seg.Label)
+	}
+	if name == "" {
+		return "Tool", "Tool"
+	}
+	return name, normalizeMarkdownToolName(name)
+}
+
+func markdownToolBody(seg markdownSegment) string {
+	if seg.ToolCall != nil {
+		if prompt := markdownToolPrompt(seg.ToolCall); prompt != "" {
+			return prompt
+		}
+	}
+	if strings.TrimSpace(seg.Content) != "" {
+		return seg.Content
+	}
+	if seg.ToolCall != nil {
+		return markdownToolFallback(seg.ToolCall)
+	}
+	return ""
+}
+
+func markdownToolPrompt(tc *db.ToolCall) string {
+	if tc == nil || tc.InputJSON == "" {
+		return ""
+	}
+	var params map[string]any
+	if json.Unmarshal([]byte(tc.InputJSON), &params) != nil {
+		return ""
+	}
+	if tc.ToolName == "Task" || tc.ToolName == "Agent" || tc.Category == "Task" {
+		if prompt, ok := params["prompt"].(string); ok {
+			return prompt
+		}
+	}
+	return ""
+}
+
+func markdownToolFallback(tc *db.ToolCall) string {
+	if tc == nil || tc.InputJSON == "" {
+		return ""
+	}
+	var params map[string]any
+	if json.Unmarshal([]byte(tc.InputJSON), &params) != nil {
+		return ""
+	}
+	toolName := normalizeMarkdownToolName(tc.ToolName)
+	if toolName == "Task" {
+		return ""
+	}
+	isEdit := toolName == "Edit" || stringValue(params["command"]) == "strReplace"
+	if isEdit {
+		if diff := stringValue(params["diff"]); diff != "" {
+			return capLines(diff, 200)
+		}
+		oldText := firstString(params, "old_string", "old_str", "oldString", "oldStr")
+		newText := firstString(params, "new_string", "new_str", "newString", "newStr")
+		if oldText != "" || newText != "" {
+			oldLines := strings.Split(oldText, "\n")
+			newLines := strings.Split(newText, "\n")
+			lines := []string{fmt.Sprintf("@@ -1,%d +1,%d @@", len(oldLines), len(newLines))}
+			for _, line := range oldLines {
+				lines = append(lines, "-"+line)
+			}
+			for _, line := range newLines {
+				lines = append(lines, "+"+line)
+			}
+			return capLines(strings.Join(lines, "\n"), 200)
+		}
+	}
+	if toolName == "Write" {
+		if text := stringValue(params["content"]); text != "" {
+			allLines := strings.Split(text, "\n")
+			show := allLines
+			if len(show) > 200 {
+				show = show[:200]
+			}
+			body := make([]string, 0, len(show)+1)
+			body = append(body, fmt.Sprintf("@@ -0,0 +1,%d @@", len(allLines)))
+			for _, line := range show {
+				body = append(body, "+"+line)
+			}
+			if len(show) != len(allLines) {
+				body = append(body, fmt.Sprintf("... (%d lines total)", len(allLines)))
+			}
+			return strings.Join(body, "\n")
+		}
+	}
+	if toolName == "Read" {
+		if path := firstString(params, "path", "file_path"); path != "" {
+			return path
+		}
+	}
+	if toolName == "Bash" {
+		if cmd := firstString(params, "command", "cmd"); cmd != "" {
+			return "$ " + cmd
+		}
+	}
+	lines := []string{}
+	for _, key := range sortedJSONKeys(params) {
+		if key == "agent__intent" || key == "_i" {
+			continue
+		}
+		value := params[key]
+		if value == nil {
+			continue
+		}
+		str := stringValue(value)
+		if str == "" {
+			raw, _ := json.Marshal(value)
+			str = string(raw)
+		}
+		if str == "" {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%s: %s", key, truncateMarkdownFallback(str, 200)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func stringValue(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func firstString(params map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if s := stringValue(params[key]); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func truncateMarkdownFallback(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}
+
+func capLines(text string, max int) string {
+	lines := strings.Split(text, "\n")
+	if len(lines) <= max {
+		return text
+	}
+	return strings.Join(lines[:max], "\n") + fmt.Sprintf("\n... (%d lines total)", len(lines))
+}
+
+func sortedJSONKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func markdownSessionAttrs(s *db.Session, root bool) map[string]string {
+	attrs := map[string]string{
+		"id":      s.ID,
+		"project": s.Project,
+		"agent":   markdownAgentDisplay(s.Agent),
+	}
+	if !root && s.ParentSessionID != nil {
+		attrs["parent_session_id"] = *s.ParentSessionID
+	}
+	if s.RelationshipType != "" && !root {
+		attrs["relationship"] = s.RelationshipType
+	}
+	if s.StartedAt != nil && *s.StartedAt != "" {
+		attrs["started_at"] = *s.StartedAt
+	}
+	if s.EndedAt != nil && *s.EndedAt != "" {
+		attrs["ended_at"] = *s.EndedAt
+	}
+	if s.MessageCount > 0 {
+		attrs["message_count"] = fmt.Sprintf("%d", s.MessageCount)
+	}
+	return attrs
+}
+
+func markdownHeadingText(s string) string {
+	replacer := strings.NewReplacer("\r", " ", "\n", " ")
+	escaped := html.EscapeString(sanitizeXMLText(strings.TrimSpace(replacer.Replace(s))))
+	mdEscaper := strings.NewReplacer(
+		"\\", "\\\\",
+		"`", "\\`",
+		"*", "\\*",
+		"_", "\\_",
+		"[", "\\[",
+		"]", "\\]",
+		"(", "\\(",
+		")", "\\)",
+	)
+	return mdEscaper.Replace(escaped)
+}
+
+func markdownAgentDisplay(agent string) string {
+	if def, ok := parser.AgentByType(parser.AgentType(agent)); ok {
+		if def.Type == parser.AgentClaude {
+			return "Claude"
+		}
+		return def.DisplayName
+	}
+	return agent
+}
+
+func parseMarkdownSegments(msg db.Message) []markdownSegment {
+	matches := extractMarkdownMatches(msg.Content, msg.HasToolUse)
+	segments := buildMarkdownSegments(msg.Content, matches)
+	segments = mergeThinkingSegments(segments)
+	return enrichMarkdownSegments(segments, msg.ToolCalls)
+}
+
+func extractMarkdownMatches(text string, parseTools bool) []markdownMatch {
+	spans := scanInlineCodeSpans(text)
+	codeBlockSpans := scanCodeBlockSpans(text)
+	matches := []markdownMatch{}
+
+	for _, m := range mdThinkingMarkedRe.FindAllStringSubmatchIndex(text, -1) {
+		start, end := m[0], m[1]
+		if insideInlineCodeSpan(start, spans) || insideCodeBlockSpan(start, codeBlockSpans) {
+			continue
+		}
+		matches = append(matches, markdownMatch{Start: start, End: end, Segment: markdownSegment{Type: markdownSegmentThinking, Content: strings.TrimSpace(text[m[2]:m[3]])}})
+	}
+	matches = append(matches, extractLegacyThinkingMatches(text, spans, codeBlockSpans, matches)...)
+	for _, m := range mdSkillRe.FindAllStringSubmatchIndex(text, -1) {
+		start, end := m[0], m[1]
+		if insideInlineCodeSpan(start, spans) || insideCodeBlockSpan(start, codeBlockSpans) || overlapsMarkdownMatch(start, end, matches) {
+			continue
+		}
+		matches = append(matches, markdownMatch{Start: start, End: end, Segment: markdownSegment{Type: markdownSegmentSkill, Label: text[m[2]:m[3]], Content: strings.TrimSpace(text[m[4]:m[5]])}})
+	}
+	if parseTools {
+		matches = append(matches, extractLegacyToolMatches(text, spans, codeBlockSpans, matches)...)
+	}
+	for _, m := range mdCodeBlockRe.FindAllStringSubmatchIndex(text, -1) {
+		start, end := m[0], m[1]
+		if overlapsMarkdownMatch(start, end, matches) {
+			continue
+		}
+		label := ""
+		if m[2] >= 0 {
+			label = text[m[2]:m[3]]
+		}
+		content := strings.TrimSuffix(text[m[4]:m[5]], "\n")
+		matches = append(matches, markdownMatch{Start: start, End: end, Segment: markdownSegment{Type: markdownSegmentCode, Label: label, Content: content}})
+	}
+	return resolveMarkdownMatches(matches)
+}
+
+func extractLegacyThinkingMatches(
+	text string,
+	inlineSpans [][2]int,
+	codeBlockSpans [][2]int,
+	existing []markdownMatch,
+) []markdownMatch {
+	matches := []markdownMatch{}
+	for search := 0; search < len(text); {
+		idx := strings.Index(text[search:], "[Thinking]")
+		if idx < 0 {
+			break
+		}
+		start := search + idx
+		if insideInlineCodeSpan(start, inlineSpans) || insideCodeBlockSpan(start, codeBlockSpans) {
+			search = start + len("[Thinking]")
+			continue
+		}
+		contentStart := start + len("[Thinking]")
+		if contentStart < len(text) && text[contentStart] == '\n' {
+			contentStart++
+		}
+		end := findLegacyBlockEnd(text, contentStart)
+		if overlapsMarkdownMatch(start, end, existing) || overlapsMarkdownMatch(start, end, matches) {
+			search = start + len("[Thinking]")
+			continue
+		}
+		matches = append(matches, markdownMatch{
+			Start: start,
+			End:   end,
+			Segment: markdownSegment{
+				Type:    markdownSegmentThinking,
+				Content: strings.TrimSpace(text[contentStart:end]),
+			},
+		})
+		search = end
+	}
+	return matches
+}
+
+func extractLegacyToolMatches(
+	text string,
+	inlineSpans [][2]int,
+	codeBlockSpans [][2]int,
+	existing []markdownMatch,
+) []markdownMatch {
+	matches := []markdownMatch{}
+	for search := 0; search < len(text); {
+		next := strings.IndexByte(text[search:], '[')
+		if next < 0 {
+			break
+		}
+		start := search + next
+		if insideInlineCodeSpan(start, inlineSpans) || insideCodeBlockSpan(start, codeBlockSpans) {
+			search = start + 1
+			continue
+		}
+		loc := mdToolStartRe.FindStringSubmatchIndex(text[start:])
+		if loc == nil || loc[0] != 0 {
+			search = start + 1
+			continue
+		}
+		name := text[start+loc[2] : start+loc[3]]
+		args := strings.TrimSpace(text[start+loc[4] : start+loc[5]])
+		contentStart := start + loc[1]
+		if contentStart < len(text) && text[contentStart] == '\n' {
+			contentStart++
+		}
+		end := findLegacyBlockEnd(text, contentStart)
+		if overlapsMarkdownMatch(start, end, existing) || overlapsMarkdownMatch(start, end, matches) {
+			search = start + 1
+			continue
+		}
+		normalized := normalizeMarkdownToolName(name)
+		label := normalized
+		if args != "" {
+			label += " " + args
+		}
+		matches = append(matches, markdownMatch{
+			Start: start,
+			End:   end,
+			Segment: markdownSegment{
+				Type:     markdownSegmentTool,
+				Label:    label,
+				ToolName: normalized,
+				Content:  strings.TrimSpace(text[contentStart:end]),
+			},
+		})
+		search = end
+	}
+	return matches
+}
+
+func findLegacyBlockEnd(text string, contentStart int) int {
+	if contentStart >= len(text) {
+		return contentStart
+	}
+	if strings.HasPrefix(text[contentStart:], "```") ||
+		strings.HasPrefix(text[contentStart:], "[") {
+		return contentStart
+	}
+	end := len(text)
+	for _, marker := range []string{"\n```", "\n[", "\n\n"} {
+		if idx := strings.Index(text[contentStart:], marker); idx >= 0 {
+			cand := contentStart + idx
+			if cand < end {
+				end = cand
+			}
+		}
+	}
+	return end
+}
+
+func overlapsMarkdownMatch(start, end int, matches []markdownMatch) bool {
+	for _, m := range matches {
+		if start < m.End && end > m.Start {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveMarkdownMatches(matches []markdownMatch) []markdownMatch {
+	sort.Slice(matches, func(i, j int) bool { return matches[i].Start < matches[j].Start })
+	out := make([]markdownMatch, 0, len(matches))
+	lastEnd := 0
+	for _, m := range matches {
+		if m.Start < lastEnd {
+			continue
+		}
+		out = append(out, m)
+		lastEnd = m.End
+	}
+	return out
+}
+
+func buildMarkdownSegments(text string, matches []markdownMatch) []markdownSegment {
+	if len(matches) == 0 {
+		trimmed := strings.TrimRight(text, "\n")
+		if trimmed == "" {
+			return nil
+		}
+		return []markdownSegment{{Type: markdownSegmentText, Content: trimmed}}
+	}
+	segments := []markdownSegment{}
+	pos := 0
+	for _, m := range matches {
+		if m.Start > pos {
+			gap := strings.TrimRight(strings.TrimLeft(text[pos:m.Start], "\n"), "\n")
+			if gap != "" {
+				segments = append(segments, markdownSegment{Type: markdownSegmentText, Content: gap})
+			}
+		}
+		segments = append(segments, m.Segment)
+		pos = m.End
+	}
+	if pos < len(text) {
+		tail := strings.TrimRight(strings.TrimLeft(text[pos:], "\n"), "\n")
+		if tail != "" {
+			segments = append(segments, markdownSegment{Type: markdownSegmentText, Content: tail})
+		}
+	}
+	return segments
+}
+
+func mergeThinkingSegments(segments []markdownSegment) []markdownSegment {
+	out := []markdownSegment{}
+	for _, seg := range segments {
+		if len(out) > 0 && seg.Type == markdownSegmentThinking && out[len(out)-1].Type == markdownSegmentThinking {
+			out[len(out)-1].Content += "\n\n" + seg.Content
+			continue
+		}
+		out = append(out, seg)
+	}
+	return out
+}
+
+func enrichMarkdownSegments(segments []markdownSegment, calls []db.ToolCall) []markdownSegment {
+	if len(calls) == 0 {
+		return segments
+	}
+	result := make([]markdownSegment, 0, len(segments)+len(calls))
+	tcIdx := 0
+	for i := 0; i < len(segments); i++ {
+		seg := segments[i]
+		if seg.Type == markdownSegmentTool && tcIdx < len(calls) {
+			tc := calls[tcIdx]
+			tcIdx++
+			seg.ToolCall = &tc
+			if tc.Category == "Bash" && tc.InputJSON != "" {
+				var input map[string]any
+				if json.Unmarshal([]byte(tc.InputJSON), &input) == nil {
+					if cmd, ok := input["command"].(string); ok && strings.Contains(cmd, "\n") {
+						rendered := "$ " + cmd
+						origContent := strings.TrimSpace(seg.Content)
+						prefix := origContent
+						for i+1 < len(segments) && segments[i+1].Type == markdownSegmentText {
+							next := strings.TrimSpace(segments[i+1].Content)
+							if shouldAbsorbBashText(rendered, prefix, next) {
+								if next != "" && prefix != "" {
+									prefix += "\n\n" + next
+								}
+								i++
+								continue
+							}
+							break
+						}
+						seg.Content = rendered
+					}
+					if cmd, ok := input["cmd"].(string); ok && strings.Contains(cmd, "\n") {
+						rendered := "$ " + cmd
+						origContent := strings.TrimSpace(seg.Content)
+						prefix := origContent
+						for i+1 < len(segments) && segments[i+1].Type == markdownSegmentText {
+							next := strings.TrimSpace(segments[i+1].Content)
+							if shouldAbsorbBashText(rendered, prefix, next) {
+								if next != "" && prefix != "" {
+									prefix += "\n\n" + next
+								}
+								i++
+								continue
+							}
+							break
+						}
+						seg.Content = rendered
+					}
+				}
+			}
+			result = append(result, seg)
+			continue
+		}
+		result = append(result, seg)
+	}
+	for tcIdx < len(calls) {
+		tc := calls[tcIdx]
+		tcIdx++
+		normalized := normalizeMarkdownToolName(tc.ToolName)
+		result = append(result, markdownSegment{
+			Type:     markdownSegmentTool,
+			Label:    normalized,
+			ToolName: normalized,
+			Content:  markdownToolFallback(&tc),
+			ToolCall: &tc,
+		})
+	}
+	return result
+}
+
+func shouldAbsorbBashText(rendered, prefix, next string) bool {
+	if next == "" {
+		return true
+	}
+	trimmedRendered := strings.TrimSpace(rendered)
+	if next == trimmedRendered {
+		return true
+	}
+	if prefix == "" {
+		return false
+	}
+	candidate := prefix + "\n\n" + next
+	return strings.HasPrefix(trimmedRendered, candidate)
+}
+
+func normalizeMarkdownToolName(name string) string {
+	if alias, ok := mdToolAliases[name]; ok {
+		return alias
+	}
+	return name
+}
+
+func sortedExportChildren(children []*exportSessionTree) []*exportSessionTree {
+	out := append([]*exportSessionTree(nil), children...)
+	sort.SliceStable(out, func(i, j int) bool {
+		ai, aj := out[i], out[j]
+		if ai == nil || ai.Session == nil {
+			return false
+		}
+		if aj == nil || aj.Session == nil {
+			return true
+		}
+		asi, asj := "", ""
+		if ai.Session.StartedAt != nil {
+			asi = *ai.Session.StartedAt
+		}
+		if aj.Session.StartedAt != nil {
+			asj = *aj.Session.StartedAt
+		}
+		if asi != asj {
+			return asi < asj
+		}
+		return ai.Session.ID < aj.Session.ID
+	})
+	return out
+}
+
+func renderXMLBodyTag(tag string, attrs map[string]string, body string) string {
+	body = sanitizeXMLText(body)
+	if strings.Contains(body, "]]>") {
+		return openTag(tag, attrs) + escapeXMLText(body) + closeTag(tag)
+	}
+	return openTag(tag, attrs) + "<![CDATA[\n" + body + "\n]]>" + closeTag(tag)
+}
+
+func openTag(tag string, attrs map[string]string) string {
+	preferred := preferredTagAttrOrder(tag)
+	seen := map[string]bool{}
+	keys := make([]string, 0, len(attrs))
+	for _, k := range preferred {
+		if v := attrs[k]; v != "" {
+			keys = append(keys, k)
+			seen[k] = true
+		}
+	}
+	for k, v := range attrs {
+		if v == "" || seen[k] {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	var b strings.Builder
+	b.WriteString("<")
+	b.WriteString(tag)
+	for _, k := range keys {
+		b.WriteString(" ")
+		b.WriteString(k)
+		b.WriteString(`="`)
+		b.WriteString(escapeXMLAttr(attrs[k]))
+		b.WriteString(`"`)
+	}
+	b.WriteString(">")
+	return b.String()
+}
+
+func preferredTagAttrOrder(tag string) []string {
+	switch tag {
+	case "session":
+		return []string{"id", "project", "agent", "started_at", "ended_at", "message_count"}
+	case "message":
+		return []string{"role", "ordinal", "timestamp", "is_system", "has_thinking", "has_tool_use"}
+	case "tool_call":
+		return []string{"id", "name", "category", "subagent_session_id"}
+	case "subagent_anchor":
+		return []string{"session_id", "tool_call_id", "depth"}
+	case "subagent_session", "child_session":
+		return []string{"id", "parent_session_id", "relationship", "project", "agent", "started_at", "ended_at", "message_count"}
+	case "tool_result":
+		return []string{"tool_call_id", "source", "status", "agent_id", "subagent_session_id", "timestamp"}
+	case "skill":
+		return []string{"name"}
+	case "code_block":
+		return []string{"language"}
+	default:
+		return nil
+	}
+}
+
+func closeTag(tag string) string {
+	return "</" + tag + ">"
+}
+
+func sanitizeXMLText(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return r
+		}
+		if r < 0x20 {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+func escapeXMLText(s string) string {
+	return html.EscapeString(sanitizeXMLText(s))
+}
+
+func escapeXMLAttr(s string) string {
+	return html.EscapeString(sanitizeXMLText(s))
+}
+
+func scanCodeBlockSpans(text string) [][2]int {
+	spans := make([][2]int, 0)
+	for _, m := range mdCodeBlockRe.FindAllStringSubmatchIndex(text, -1) {
+		spans = append(spans, [2]int{m[0], m[1]})
+	}
+	return spans
+}
+
+func scanInlineCodeSpans(text string) [][2]int {
+	spans := [][2]int{}
+	for i := 0; i < len(text); {
+		if text[i] != '`' {
+			i++
+			continue
+		}
+		open := i
+		for i < len(text) && text[i] == '`' {
+			i++
+		}
+		runLen := i - open
+		found := false
+		for j := i; j < len(text); j++ {
+			if text[j] != '`' {
+				continue
+			}
+			closeStart := j
+			for j < len(text) && text[j] == '`' {
+				j++
+			}
+			if j-closeStart == runLen {
+				spans = append(spans, [2]int{open, j})
+				i = j
+				found = true
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+	}
+	return spans
+}
+
+func insideCodeBlockSpan(pos int, spans [][2]int) bool {
+	for _, span := range spans {
+		if pos >= span[0] && pos < span[1] {
+			return true
+		}
+	}
+	return false
+}
+
+func insideInlineCodeSpan(pos int, spans [][2]int) bool {
+	for _, span := range spans {
+		if pos > span[0] && pos < span[1] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -465,6 +465,322 @@ func TestGenerateExportHTML_NilStartedAt(t *testing.T) {
 	}
 }
 
+func TestGenerateExportMarkdown_Structure(t *testing.T) {
+	t.Parallel()
+	session := testSession(func(s *db.Session) {
+		s.Project = "my-project"
+		s.MessageCount = 2
+	})
+	msgs := []db.Message{
+		{
+			SessionID: "test-id",
+			Ordinal:   0,
+			Role:      "user",
+			Content:   "Hello <agent>",
+			Timestamp: "2025-01-15T10:00:00Z",
+		},
+		{
+			SessionID:   "test-id",
+			Ordinal:     1,
+			Role:        "assistant",
+			Content:     "[Thinking]\nNeed inspect.\n\n[Task]\nworking",
+			Timestamp:   "2025-01-15T10:00:05Z",
+			HasThinking: true,
+			HasToolUse:  true,
+			ToolCalls: []db.ToolCall{{
+				ToolName:      "Task",
+				Category:      "Task",
+				ToolUseID:     "toolu_1",
+				InputJSON:     `{"prompt":"inspect repo"}`,
+				ResultContent: "done",
+			}},
+		},
+	}
+
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		"# Session: my-project",
+		`<session id="test-id" project="my-project" agent="Claude"`,
+		`<message role="user" ordinal="0"`,
+		"Hello &lt;agent&gt;",
+		`<thinking><![CDATA[` + "\nNeed inspect.\n" + `]]></thinking>`,
+		`<tool_call id="toolu_1" name="Task" category="Task">`,
+		`<arguments><![CDATA[` + "\n{\"prompt\":\"inspect repo\"}\n" + `]]></arguments>`,
+		`<tool_body><![CDATA[` + "\ninspect repo\n" + `]]></tool_body>`,
+		`<tool_result><![CDATA[` + "\ndone\n" + `]]></tool_result>`,
+	})
+}
+
+func TestGenerateExportMarkdown_SerializesCodeSkillAndCDATAFallback(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID: "test-id",
+		Ordinal:   0,
+		Role:      "assistant",
+		Content: "```go\nfmt.Println(\"hi\")\n```\n\n" +
+			"[Skill: planner]\nuse ]]> carefully\n[/Skill]",
+		Timestamp: "2025-01-15T10:00:00Z",
+	}}
+
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<code_block language="go"><![CDATA[` + "\nfmt.Println(\"hi\")\n" + `]]></code_block>`,
+		`<skill name="planner">use ]]&gt; carefully</skill>`,
+	})
+}
+
+func TestGenerateExportMarkdown_OmitsEmptyOptionalAttributes(t *testing.T) {
+	t.Parallel()
+	session := testSession(func(s *db.Session) {
+		s.StartedAt = nil
+	})
+	childStarted := "2025-01-15T10:05:00Z"
+	out := generateExportMarkdownTree(&exportSessionTree{
+		Session: session,
+		Messages: []db.Message{{
+			SessionID:  "test-id",
+			Ordinal:    0,
+			Role:       "assistant",
+			Content:    "[Read file.go]\nbody",
+			HasToolUse: true,
+			ToolCalls: []db.ToolCall{{
+				ToolName:  "Read",
+				Category:  "Read",
+				ToolUseID: "toolu_1",
+			}},
+		}},
+		AppendedChildren: []*exportSessionTree{{
+			Session: &db.Session{
+				ID:              "child-1",
+				Project:         "proj",
+				Agent:           "claude",
+				ParentSessionID: dbtest.Ptr("test-id"),
+				StartedAt:       &childStarted,
+			},
+		}},
+	}, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<tool_call id="toolu_1" name="Read" category="Read">`,
+		`<child_session id="child-1" parent_session_id="test-id" project="proj" agent="Claude" started_at="2025-01-15T10:05:00Z">`,
+	})
+	assertContainsNone(t, out, []string{
+		`relationship=""`,
+		`started_at=""`,
+	})
+}
+
+func TestGenerateExportMarkdown_PreservesMultiWordToolNamesAndResultEvents(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID:   "test-id",
+		Ordinal:     0,
+		Role:        "assistant",
+		Content:     "[Todo List]\nplan work",
+		HasToolUse:  true,
+		Timestamp:   "2025-01-15T10:00:00Z",
+		ToolCalls:   nil,
+		HasThinking: false,
+	}}
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<tool_call name="Todo List" category="Todo List">`,
+		`<tool_body><![CDATA[` + "\nplan work\n" + `]]></tool_body>`,
+	})
+
+	msgs[0].Content = "[Bash]\n$ echo hi"
+	msgs[0].ToolCalls = []db.ToolCall{{
+		ToolName:  "Bash",
+		Category:  "Bash",
+		ToolUseID: "toolu_bash",
+		ResultEvents: []db.ToolResultEvent{{
+			ToolUseID: "toolu_bash",
+			Source:    "subagent_notification",
+			Status:    "running",
+			Content:   "still working",
+		}},
+	}}
+	out = generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<tool_result tool_call_id="toolu_bash" source="subagent_notification" status="running"><![CDATA[` + "\nstill working\n" + `]]></tool_result>`,
+	})
+}
+
+func TestGenerateExportMarkdown_EmitsEmptyMessages(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID: "test-id",
+		Ordinal:   0,
+		Role:      "assistant",
+		Content:   "",
+	}}
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<message role="assistant" ordinal="0"></message>`,
+	})
+}
+
+func TestGenerateExportMarkdown_SanitizesHeadingAndAvoidsDuplicateAnchors(t *testing.T) {
+	t.Parallel()
+	session := testSession(func(s *db.Session) {
+		s.Project = "proj\n<script>alert(1)</script>"
+	})
+	child := &exportSessionTree{
+		Session: &db.Session{
+			ID:               "child-a",
+			Project:          "proj",
+			Agent:            "claude",
+			ParentSessionID:  dbtest.Ptr("test-id"),
+			RelationshipType: "subagent",
+		},
+		Messages: []db.Message{{
+			SessionID: "child-a",
+			Ordinal:   0,
+			Role:      "assistant",
+			Content:   "child message",
+		}},
+	}
+	msgs := []db.Message{{
+		SessionID:  "test-id",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "[Task]\none\n\n[Task]\ntwo",
+		HasToolUse: true,
+		ToolCalls: []db.ToolCall{
+			{ToolName: "Task", Category: "Task", ToolUseID: "toolu_1", SubagentSessionID: "child-a"},
+			{ToolName: "Task", Category: "Task", ToolUseID: "toolu_2", SubagentSessionID: "child-a"},
+		},
+	}}
+	out := generateExportMarkdownTree(&exportSessionTree{
+		Session:          session,
+		Messages:         msgs,
+		AnchoredChildren: map[string]*exportSessionTree{"child-a": child},
+	}, exportMarkdownOptions{Depth: "all"})
+	assertContainsNone(t, out, []string{"# Session: proj\n<script>alert(1)</script>"})
+	if strings.Count(out, `<subagent_session id="child-a"`) != 1 {
+		t.Fatalf("expected child session once, got:\n%s", out)
+	}
+}
+
+func TestGenerateExportMarkdown_DoesNotParseToolMarkersInsideCodeBlocks(t *testing.T) {
+	t.Parallel()
+	session := testSession(func(s *db.Session) {
+		s.Project = "proj\\[link]\x00"
+	})
+	msgs := []db.Message{{
+		SessionID: "test-id",
+		Ordinal:   0,
+		Role:      "assistant",
+		Content:   "```txt\n[Task]\nnot tool\n```",
+	}}
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<code_block language="txt"><![CDATA[` + "\n[Task]\nnot tool\n" + `]]></code_block>`,
+	})
+	assertContainsNone(t, out, []string{`<tool_call`, "\x00", "# Session: proj\\[link]"})
+}
+
+func TestGenerateExportMarkdown_StripsXMLInvalidControlChars(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID:  "test-id",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "[Bash]\n$ printf hi",
+		HasToolUse: true,
+		ToolCalls: []db.ToolCall{{
+			ToolName:      "Bash",
+			Category:      "Bash",
+			ResultContent: "ok\x1b[31mred\x00",
+		}},
+	}}
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsNone(t, out, []string{"\x1b", "\x00"})
+}
+
+func TestGenerateExportMarkdown_SeparatesAdjacentLegacyBlocks(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID:  "test-id",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "[Read file-a.go]\nbody one\n[Grep TODO]\nbody two\n```txt\n[Task]\ncode only\n```",
+		HasToolUse: true,
+	}}
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<tool_call name="Read" category="Read">`,
+		`<tool_body><![CDATA[` + "\nbody one\n" + `]]></tool_body>`,
+		`<tool_call name="Grep" category="Grep">`,
+		`<tool_body><![CDATA[` + "\nbody two\n" + `]]></tool_body>`,
+		`<code_block language="txt"><![CDATA[` + "\n[Task]\ncode only\n" + `]]></code_block>`,
+	})
+}
+
+func TestGenerateExportMarkdown_PreservesFollowingTextAfterMultilineBash(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	cmd := "for x in a; do\n  echo done\ndone"
+	msgs := []db.Message{{
+		SessionID:  "test-id",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "[Bash]\n$ " + cmd + "\n\ndone",
+		HasToolUse: true,
+		ToolCalls: []db.ToolCall{{
+			ToolName:  "Bash",
+			Category:  "Bash",
+			InputJSON: `{"command":"` + "for x in a; do\\n  echo done\\ndone" + `"}`,
+		}},
+	}}
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<tool_body><![CDATA[` + "\n$ " + cmd + "\n" + `]]></tool_body>`,
+		"\ndone\n</message>",
+	})
+}
+
+func TestGenerateExportMarkdown_SeparatesEmptyLegacyBlocks(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID:  "test-id",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "[Task]\n[Grep TODO]\nbody two\n[Thinking]\n```txt\ncode only\n```",
+		HasToolUse: true,
+	}}
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<tool_call name="Task" category="Task">`,
+		`<tool_call name="Grep" category="Grep">`,
+		`<tool_body><![CDATA[` + "\nbody two\n" + `]]></tool_body>`,
+		`<thinking><![CDATA[` + "\n\n" + `]]></thinking>`,
+		`<code_block language="txt"><![CDATA[` + "\ncode only\n" + `]]></code_block>`,
+	})
+}
+
+func TestGenerateExportMarkdown_PreservesInlineBracketsInLegacyBodies(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID:  "test-id",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "[Bash]\n$ test [ -f foo ] && echo ```not fence```",
+		HasToolUse: true,
+	}}
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<tool_call name="Bash" category="Bash">`,
+		`<tool_body><![CDATA[` + "\n$ test [ -f foo ] && echo ```not fence```\n" + `]]></tool_body>`,
+	})
+}
+
 func TestSanitizeFilename(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -176,6 +176,9 @@ func (s *Server) routes() {
 		"GET /api/v1/sessions/{id}/export", http.HandlerFunc(s.handleExportSession),
 	)
 	s.mux.Handle(
+		"GET /api/v1/sessions/{id}/md", http.HandlerFunc(s.handleMarkdownSession),
+	)
+	s.mux.Handle(
 		"POST /api/v1/sessions/{id}/publish", s.withTimeout(s.handlePublishSession),
 	)
 	s.mux.Handle(

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1950,6 +1950,138 @@ func TestExportSession_NotFound(t *testing.T) {
 	assertStatus(t, w, http.StatusNotFound)
 }
 
+func TestMarkdownSessionExport(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "my-app", 3)
+	te.seedMessages(t, "s1", 3)
+
+	w := te.get(t, "/api/v1/sessions/s1/md")
+	assertStatus(t, w, http.StatusOK)
+
+	ct := w.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/markdown") {
+		t.Fatalf("expected text/markdown content type, got %q", ct)
+	}
+	cd := w.Header().Get("Content-Disposition")
+	if !strings.Contains(cd, "inline") {
+		t.Fatalf("expected inline disposition, got %q", cd)
+	}
+	assertBodyContains(t, w, "# Session: my-app")
+}
+
+func TestMarkdownSessionExport_NotFound(t *testing.T) {
+	te := setup(t)
+
+	w := te.get(t, "/api/v1/sessions/nonexistent/md")
+	assertStatus(t, w, http.StatusNotFound)
+}
+
+func TestMarkdownSessionExport_InvalidDepth(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "my-app", 1)
+
+	w := te.get(t, "/api/v1/sessions/s1/md?depth=2")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestMarkdownSessionExport_DepthOneIncludesChildSessions(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "parent", "my-app", 1)
+	te.seedMessages(t, "parent", 1, func(i int, m *db.Message) {
+		m.Role = "assistant"
+		m.Content = "[Task]\nchild work"
+		m.HasToolUse = true
+		m.ToolCalls = []db.ToolCall{{
+			ToolName:          "Task",
+			Category:          "Task",
+			ToolUseID:         "toolu_child",
+			InputJSON:         `{"prompt":"inspect child"}`,
+			SubagentSessionID: "child-a",
+		}}
+	})
+	te.seedSession(t, "child-a", "my-app", 1, func(s *db.Session) {
+		s.ParentSessionID = dbtest.Ptr("parent")
+		s.RelationshipType = "subagent"
+	})
+	te.seedMessages(t, "child-a", 1)
+
+	w := te.get(t, "/api/v1/sessions/parent/md?depth=1")
+	assertStatus(t, w, http.StatusOK)
+	assertBodyContains(t, w, `<subagent_anchor session_id="child-a" tool_call_id="toolu_child" depth="1">`)
+	assertBodyContains(t, w, `<subagent_session id="child-a" parent_session_id="parent" relationship="subagent"`)
+}
+
+func TestMarkdownSessionExport_DefaultOmitsChildSessions(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "parent", "my-app", 1)
+	te.seedMessages(t, "parent", 1, func(i int, m *db.Message) {
+		m.Role = "assistant"
+		m.Content = "[Task]\nchild work"
+		m.HasToolUse = true
+		m.ToolCalls = []db.ToolCall{{
+			ToolName:          "Task",
+			Category:          "Task",
+			ToolUseID:         "toolu_child",
+			InputJSON:         `{"prompt":"inspect child"}`,
+			SubagentSessionID: "child-a",
+		}}
+	})
+	te.seedSession(t, "child-a", "my-app", 1, func(s *db.Session) {
+		s.ParentSessionID = dbtest.Ptr("parent")
+		s.RelationshipType = "subagent"
+	})
+	te.seedMessages(t, "child-a", 1)
+
+	w := te.get(t, "/api/v1/sessions/parent/md")
+	assertStatus(t, w, http.StatusOK)
+	if strings.Contains(w.Body.String(), `<subagent_session id="child-a"`) {
+		t.Fatalf("expected default markdown export to omit child session, got:\n%s", w.Body.String())
+	}
+}
+
+func TestMarkdownSessionExport_DepthAllRecurses(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "root", "my-app", 1)
+	te.seedMessages(t, "root", 1, func(i int, m *db.Message) {
+		m.Role = "assistant"
+		m.Content = "[Task]\nchild work"
+		m.HasToolUse = true
+		m.ToolCalls = []db.ToolCall{{
+			ToolName:          "Task",
+			Category:          "Task",
+			ToolUseID:         "toolu_child",
+			InputJSON:         `{"prompt":"inspect child"}`,
+			SubagentSessionID: "child-a",
+		}}
+	})
+	te.seedSession(t, "child-a", "my-app", 1, func(s *db.Session) {
+		s.ParentSessionID = dbtest.Ptr("root")
+		s.RelationshipType = "subagent"
+	})
+	te.seedMessages(t, "child-a", 1, func(i int, m *db.Message) {
+		m.Role = "assistant"
+		m.Content = "[Task]\ngrandchild work"
+		m.HasToolUse = true
+		m.ToolCalls = []db.ToolCall{{
+			ToolName:          "Task",
+			Category:          "Task",
+			ToolUseID:         "toolu_grandchild",
+			InputJSON:         `{"prompt":"inspect grandchild"}`,
+			SubagentSessionID: "child-b",
+		}}
+	})
+	te.seedSession(t, "child-b", "my-app", 1, func(s *db.Session) {
+		s.ParentSessionID = dbtest.Ptr("child-a")
+		s.RelationshipType = "subagent"
+	})
+	te.seedMessages(t, "child-b", 1)
+
+	w := te.get(t, "/api/v1/sessions/root/md?depth=all")
+	assertStatus(t, w, http.StatusOK)
+	assertBodyContains(t, w, `<subagent_session id="child-a" parent_session_id="root" relationship="subagent"`)
+	assertBodyContains(t, w, `<subagent_session id="child-b" parent_session_id="child-a" relationship="subagent"`)
+}
+
 func TestPublishSession_NoToken(t *testing.T) {
 	te := setup(t)
 	te.seedSession(t, "s1", "my-app", 3)


### PR DESCRIPTION
## Summary
- add `/api/v1/sessions/{id}/md` markdown export endpoint
- render session transcripts as markdown with structured XML tags, tool/subagent context, and optional descendant depth
- add export-menu action to copy markdown export links for agent handoff
- add regression coverage for markdown parsing edge cases, child-session export behavior, and soft-deleted child filtering
- address open roborev findings for this branch and close reviewed jobs

## Related
- Docs PR: https://github.com/wesm/agentsview-docs/pull/25

## Validation
- `CGO_ENABLED=1 go test -tags fts5 ./internal/db ./internal/server/... -count=1`
- `cd frontend && npx vitest run src/lib/api/client-markdown-export.test.ts src/lib/components/layout/AppHeader.test.ts`
- `cd frontend && npm run build`
- `roborev fix --open --list` → `No open jobs found.`
- `git diff --check`