### PR TITLE
feat: add PostgreSQL usage support; rename remote_access to require_auth

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -11,9 +11,9 @@ Key assumptions reviewers MUST account for:
 1. AUTH MODEL: In local-only mode, loopback bind is the access
    boundary — no auth tokens needed. In proxy mode, validateServeConfig
    forces the backend to loopback; Caddy enforces CIDR subnet
-   allowlisting. When remote access is enabled (`remote_access: true`),
-   a bearer token is required for all API requests (including
-   localhost, to prevent bypass via reverse proxy). An auth token is
+   allowlisting. When auth is required (`require_auth: true`), a
+   bearer token is required for all API requests (including localhost,
+   to prevent bypass via reverse proxy). An auth token is
    auto-generated at startup if missing. Do not flag missing auth on
    local-only code paths. DO flag any path that lets the backend bind
    non-loopback in proxy mode, or missing subnet checks for

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -131,10 +131,12 @@ func runServe(cfg config.Config) {
 	// background LiteLLM refresh follows immediately.
 	seedPricing(database)
 
-	// When auth is required, ensure a token exists and auto-bind to
-	// 0.0.0.0 so the server is reachable from the network.
+	// When auth is required, ensure a token exists. Auto-bind to
+	// 0.0.0.0 unless the user set --host explicitly or a managed
+	// proxy is active (Caddy requires a loopback backend).
 	if cfg.RequireAuth {
-		if !cfg.HostExplicit && cfg.Host == "127.0.0.1" {
+		if !cfg.HostExplicit && cfg.Host == "127.0.0.1" &&
+			cfg.Proxy.Mode == "" {
 			cfg.Host = "0.0.0.0"
 		}
 		if err := cfg.EnsureAuthToken(); err != nil {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -131,14 +131,8 @@ func runServe(cfg config.Config) {
 	// background LiteLLM refresh follows immediately.
 	seedPricing(database)
 
-	// When auth is required, ensure a token exists. Auto-bind to
-	// 0.0.0.0 unless the user set --host explicitly or a managed
-	// proxy is active (Caddy requires a loopback backend).
+	// When auth is required, ensure a token exists.
 	if cfg.RequireAuth {
-		if !cfg.HostExplicit && cfg.Host == "127.0.0.1" &&
-			cfg.Proxy.Mode == "" {
-			cfg.Host = "0.0.0.0"
-		}
 		if err := cfg.EnsureAuthToken(); err != nil {
 			log.Fatalf("Failed to generate auth token: %v", err)
 		}

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -131,21 +131,17 @@ func runServe(cfg config.Config) {
 	// background LiteLLM refresh follows immediately.
 	seedPricing(database)
 
-	// Auto-bind to 0.0.0.0 when remote access is enabled so the
-	// server is reachable from the network. Only override if the
-	// user hasn't explicitly set --host via the CLI flag.
-	if cfg.RemoteAccess && !cfg.HostExplicit && cfg.Host == "127.0.0.1" {
-		cfg.Host = "0.0.0.0"
-	}
-
-	// When remote access is enabled, ensure an auth token exists so
-	// the API is never exposed on the network without authentication.
-	if cfg.RemoteAccess {
+	// When auth is required, ensure a token exists and auto-bind to
+	// 0.0.0.0 so the server is reachable from the network.
+	if cfg.RequireAuth {
+		if !cfg.HostExplicit && cfg.Host == "127.0.0.1" {
+			cfg.Host = "0.0.0.0"
+		}
 		if err := cfg.EnsureAuthToken(); err != nil {
 			log.Fatalf("Failed to generate auth token: %v", err)
 		}
 		if cfg.AuthToken != "" {
-			fmt.Printf("Remote access enabled. Auth token: %s\n", cfg.AuthToken)
+			fmt.Printf("Auth enabled. Token: %s\n", cfg.AuthToken)
 		}
 	}
 

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -205,15 +205,11 @@ func loadPGServeConfig(cmd *cobra.Command) (config.Config, string, error) {
 
 func runPGServe(appCfg config.Config, basePath string) {
 	setupLogFile(appCfg.DataDir)
-	// Enable remote access with auth when binding to a
-	// non-loopback address; keep it off for localhost.
-	if !isLoopbackHost(appCfg.Host) {
-		appCfg.RemoteAccess = true
+	// Generate auth token when auth is explicitly required.
+	if appCfg.RequireAuth {
 		if err := appCfg.EnsureAuthToken(); err != nil {
 			fatal("pg serve: generating auth token: %v", err)
 		}
-	} else {
-		appCfg.RemoteAccess = false
 	}
 
 	if err := validateServeConfig(appCfg); err != nil {
@@ -300,7 +296,7 @@ func runPGServe(appCfg config.Config, basePath string) {
 		fatal("pg serve: %v", err)
 	}
 
-	if rt.Cfg.RemoteAccess && rt.Cfg.AuthToken != "" {
+	if rt.Cfg.RequireAuth && rt.Cfg.AuthToken != "" {
 		fmt.Printf("Auth token: %s\n", rt.Cfg.AuthToken)
 	}
 	if rt.PublicURL == rt.LocalURL {

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -122,7 +122,16 @@ func runPGPush(cfg PGPushConfig) {
 	if err := ps.EnsureSchema(ctx); err != nil {
 		fatal("pg push schema: %v", err)
 	}
-	result, err := ps.Push(ctx, forceFull)
+	result, err := ps.Push(ctx, forceFull,
+		func(p postgres.PushProgress) {
+			fmt.Printf(
+				"\rPushing... %d/%d sessions, %d messages",
+				p.SessionsDone, p.SessionsTotal,
+				p.MessagesDone,
+			)
+		},
+	)
+	fmt.Print("\r\033[K") // clear progress line
 	if err != nil {
 		fatal("pg push: %v", err)
 	}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -649,7 +649,7 @@ export interface AppSettings {
   host: string;
   port: number;
   auth_token?: string;
-  remote_access?: boolean;
+  require_auth?: boolean;
 }
 
 export function getSettings(): Promise<AppSettings> {

--- a/frontend/src/lib/components/settings/RemoteSettings.svelte
+++ b/frontend/src/lib/components/settings/RemoteSettings.svelte
@@ -71,7 +71,7 @@
   async function handleToggleRemote() {
     remoteToggling = true;
     try {
-      await settings.save({ remote_access: !settings.remoteAccess });
+      await settings.save({ require_auth: !settings.requireAuth });
     } finally {
       remoteToggling = false;
     }
@@ -92,22 +92,22 @@
   {#if !isRemote}
     <div class="subsection">
       <div class="toggle-row">
-        <span class="toggle-label">Allow remote connections</span>
+        <span class="toggle-label">Require auth token</span>
         <button
           class="toggle-btn"
-          class:active={settings.remoteAccess}
+          class:active={settings.requireAuth}
           disabled={remoteToggling}
           onclick={handleToggleRemote}
         >
-          {settings.remoteAccess ? "Enabled" : "Disabled"}
+          {settings.requireAuth ? "Enabled" : "Disabled"}
         </button>
       </div>
 
       <p class="restart-note">
-        Note: Toggling remote access requires a server restart to take effect.
+        Note: Toggling auth requires a server restart to take effect.
       </p>
 
-      {#if settings.remoteAccess && settings.authToken}
+      {#if settings.requireAuth && settings.authToken}
         <div class="security-warning">
           Warning: Remote connections use unencrypted HTTP. Use a secure
           tunnel (Tailscale, SSH tunnel, or a reverse proxy with TLS) to

--- a/frontend/src/lib/stores/settings.svelte.ts
+++ b/frontend/src/lib/stores/settings.svelte.ts
@@ -16,7 +16,7 @@ class SettingsStore {
   host: string = $state("");
   port: number = $state(0);
   authToken: string = $state("");
-  remoteAccess: boolean = $state(false);
+  requireAuth: boolean = $state(false);
   loading: boolean = $state(false);
   saving: boolean = $state(false);
   error: string | null = $state(null);
@@ -36,7 +36,7 @@ class SettingsStore {
       this.host = data.host;
       this.port = data.port;
       this.authToken = data.auth_token ?? "";
-      this.remoteAccess = data.remote_access ?? false;
+      this.requireAuth = data.require_auth ?? false;
       // When the server returns an auth token (localhost only), persist
       // it so the client stays authenticated after remote access is
       // toggled on (which starts requiring auth for all requests).
@@ -66,7 +66,7 @@ class SettingsStore {
       this.host = data.host;
       this.port = data.port;
       this.authToken = data.auth_token ?? "";
-      this.remoteAccess = data.remote_access ?? false;
+      this.requireAuth = data.require_auth ?? false;
       if (data.auth_token && !isRemoteConnection()) {
         setAuthToken(data.auth_token);
       }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,7 @@ type Config struct {
 	GithubToken          string         `json:"github_token,omitempty" toml:"github_token"`
 	Terminal             TerminalConfig `json:"terminal,omitempty" toml:"terminal"`
 	AuthToken            string         `json:"auth_token,omitempty" toml:"auth_token"`
-	RemoteAccess         bool           `json:"remote_access" toml:"remote_access"`
+	RequireAuth          bool           `json:"require_auth" toml:"require_auth"`
 	NoBrowser            bool           `json:"no_browser" toml:"no_browser"`
 	DisableUpdateCheck   bool           `json:"disable_update_check" toml:"disable_update_check"`
 	NoSync               bool           `json:"-" toml:"-"`
@@ -242,7 +242,7 @@ func loadPGServeBase() (Config, error) {
 	cfg.PublicURL = ""
 	cfg.PublicOrigins = nil
 	cfg.Proxy = ProxyConfig{}
-	cfg.RemoteAccess = false
+	cfg.RequireAuth = false
 	cfg.NoBrowser = false
 	cfg.HostExplicit = false
 	return cfg, nil
@@ -335,6 +335,7 @@ func (c *Config) loadFile() error {
 		ResultContentBlockedCategories []string       `toml:"result_content_blocked_categories"`
 		Terminal                       TerminalConfig `toml:"terminal"`
 		AuthToken                      string         `toml:"auth_token"`
+		RequireAuth                    bool           `toml:"require_auth"`
 		RemoteAccess                   bool           `toml:"remote_access"`
 		DisableUpdateCheck             bool           `toml:"disable_update_check"`
 		PG                             PGConfig       `toml:"pg"`
@@ -372,7 +373,7 @@ func (c *Config) loadFile() error {
 	if file.AuthToken != "" {
 		c.AuthToken = file.AuthToken
 	}
-	c.RemoteAccess = file.RemoteAccess
+	c.RequireAuth = file.RequireAuth || file.RemoteAccess
 	c.DisableUpdateCheck = file.DisableUpdateCheck
 	// Merge pg field-by-field so env vars override only
 	// the fields they set, preserving config-file settings.
@@ -1139,16 +1140,16 @@ func (c *Config) SaveSettings(patch map[string]any) error {
 			c.AuthToken = s
 		}
 	}
-	if v, ok := patch["remote_access"]; ok {
+	if v, ok := patch["require_auth"]; ok {
 		if b, ok := v.(bool); ok {
-			c.RemoteAccess = b
+			c.RequireAuth = b
 		}
 	}
 	return nil
 }
 
 // EnsureAuthToken generates and persists an auth token if one does
-// not already exist. Called when remote_access is enabled.
+// not already exist. Called when require_auth is enabled.
 func (c *Config) EnsureAuthToken() error {
 	if c.AuthToken != "" {
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,7 +242,6 @@ func loadPGServeBase() (Config, error) {
 	cfg.PublicURL = ""
 	cfg.PublicOrigins = nil
 	cfg.Proxy = ProxyConfig{}
-	cfg.RequireAuth = false
 	cfg.NoBrowser = false
 	cfg.HostExplicit = false
 	return cfg, nil
@@ -596,6 +595,10 @@ func RegisterServeFlags(fs *flag.FlagSet) {
 		"no-update-check", false,
 		"Disable the update check API endpoint",
 	)
+	fs.Bool(
+		"require-auth", false,
+		"Require a bearer token for all API requests",
+	)
 }
 
 // RegisterServePFlags registers serve-command flags on fs.
@@ -652,6 +655,10 @@ func RegisterServePFlags(fs *pflag.FlagSet) {
 		"no-update-check", false,
 		"Disable the update check API endpoint",
 	)
+	fs.Bool(
+		"require-auth", false,
+		"Require a bearer token for all API requests",
+	)
 }
 
 // applyFlags copies explicitly-set flags from fs into cfg.
@@ -705,6 +712,8 @@ func applyFlagValue(cfg *Config, name, value string) {
 		cfg.NoSync = value == "true"
 	case "no-update-check":
 		cfg.DisableUpdateCheck = value == "true"
+	case "require-auth":
+		cfg.RequireAuth = value == "true"
 	}
 }
 
@@ -1109,6 +1118,12 @@ func (c *Config) SaveSettings(patch map[string]any) error {
 	}
 
 	maps.Copy(existing, patch)
+
+	// When require_auth is written, remove the legacy
+	// remote_access key so it cannot override on next load.
+	if _, ok := patch["require_auth"]; ok {
+		delete(existing, "remote_access")
+	}
 
 	if err := c.writeConfigMap(existing); err != nil {
 		return err

--- a/internal/db/pricing_list.go
+++ b/internal/db/pricing_list.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"context"
+	"fmt"
+)
+
+// ListModelPricing returns every pricing row, including sentinel
+// metadata rows (for example `_fallback_version`).
+func (db *DB) ListModelPricing(
+	ctx context.Context,
+) ([]ModelPricing, error) {
+	rows, err := db.getReader().QueryContext(
+		ctx,
+		`SELECT model_pattern, input_per_mtok,
+			output_per_mtok, cache_creation_per_mtok,
+			cache_read_per_mtok, updated_at
+		 FROM model_pricing
+		 ORDER BY model_pattern`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"listing model pricing: %w", err,
+		)
+	}
+	defer rows.Close()
+
+	var out []ModelPricing
+	for rows.Next() {
+		var p ModelPricing
+		if err := rows.Scan(
+			&p.ModelPattern,
+			&p.InputPerMTok,
+			&p.OutputPerMTok,
+			&p.CacheCreationPerMTok,
+			&p.CacheReadPerMTok,
+			&p.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"scanning model pricing: %w", err,
+			)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"iterating model pricing: %w", err,
+		)
+	}
+	if out == nil {
+		out = []ModelPricing{}
+	}
+	return out, nil
+}

--- a/internal/postgres/integration_test.go
+++ b/internal/postgres/integration_test.go
@@ -85,7 +85,7 @@ func TestPGPushCycle(t *testing.T) {
 		t.Fatalf("insert message: %v", err)
 	}
 
-	pushResult, err := ps.Push(ctx, false)
+	pushResult, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}

--- a/internal/postgres/pricing.go
+++ b/internal/postgres/pricing.go
@@ -1,0 +1,180 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wesm/agentsview/internal/db"
+	"github.com/wesm/agentsview/internal/pricing"
+)
+
+type modelRates struct {
+	input         float64
+	output        float64
+	cacheCreation float64
+	cacheRead     float64
+}
+
+func fallbackPricingRows() []db.ModelPricing {
+	src := pricing.FallbackPricing()
+	out := make([]db.ModelPricing, len(src))
+	for i, p := range src {
+		out[i] = db.ModelPricing{
+			ModelPattern:         p.ModelPattern,
+			InputPerMTok:         p.InputPerMTok,
+			OutputPerMTok:        p.OutputPerMTok,
+			CacheCreationPerMTok: p.CacheCreationPerMTok,
+			CacheReadPerMTok:     p.CacheReadPerMTok,
+		}
+	}
+	return out
+}
+
+func pricingRowsToMap(prices []db.ModelPricing) map[string]modelRates {
+	out := make(map[string]modelRates, len(prices))
+	for _, p := range prices {
+		if strings.HasPrefix(p.ModelPattern, "_") {
+			continue
+		}
+		out[p.ModelPattern] = modelRates{
+			input:         p.InputPerMTok,
+			output:        p.OutputPerMTok,
+			cacheCreation: p.CacheCreationPerMTok,
+			cacheRead:     p.CacheReadPerMTok,
+		}
+	}
+	return out
+}
+
+func fallbackPricingMap() map[string]modelRates {
+	return pricingRowsToMap(fallbackPricingRows())
+}
+
+func (s *Store) loadPricingMap(
+	ctx context.Context,
+) (map[string]modelRates, error) {
+	out := fallbackPricingMap()
+
+	rows, err := s.pg.QueryContext(
+		ctx,
+		`SELECT model_pattern, input_per_mtok,
+			output_per_mtok, cache_creation_per_mtok,
+			cache_read_per_mtok, updated_at
+		 FROM model_pricing`,
+	)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return out, nil
+		}
+		return nil, fmt.Errorf(
+			"querying pg pricing: %w", err,
+		)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var p db.ModelPricing
+		if err := rows.Scan(
+			&p.ModelPattern,
+			&p.InputPerMTok,
+			&p.OutputPerMTok,
+			&p.CacheCreationPerMTok,
+			&p.CacheReadPerMTok,
+			&p.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"scanning pg pricing: %w", err,
+			)
+		}
+		if strings.HasPrefix(p.ModelPattern, "_") {
+			continue
+		}
+		out[p.ModelPattern] = modelRates{
+			input:         p.InputPerMTok,
+			output:        p.OutputPerMTok,
+			cacheCreation: p.CacheCreationPerMTok,
+			cacheRead:     p.CacheReadPerMTok,
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"iterating pg pricing: %w", err,
+		)
+	}
+
+	return out, nil
+}
+
+func upsertModelPricing(
+	ctx context.Context, pg *sql.DB, prices []db.ModelPricing,
+) error {
+	if len(prices) == 0 {
+		return nil
+	}
+
+	tx, err := pg.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning pg pricing upsert: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO model_pricing
+			(model_pattern, input_per_mtok, output_per_mtok,
+			 cache_creation_per_mtok, cache_read_per_mtok,
+			 updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (model_pattern) DO UPDATE SET
+			input_per_mtok = EXCLUDED.input_per_mtok,
+			output_per_mtok = EXCLUDED.output_per_mtok,
+			cache_creation_per_mtok = EXCLUDED.cache_creation_per_mtok,
+			cache_read_per_mtok = EXCLUDED.cache_read_per_mtok,
+			updated_at = EXCLUDED.updated_at`)
+	if err != nil {
+		return fmt.Errorf("preparing pg pricing upsert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, p := range prices {
+		updatedAt := p.UpdatedAt
+		if updatedAt == "" {
+			updatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		}
+		if _, err := stmt.ExecContext(
+			ctx,
+			sanitizePG(p.ModelPattern),
+			p.InputPerMTok,
+			p.OutputPerMTok,
+			p.CacheCreationPerMTok,
+			p.CacheReadPerMTok,
+			sanitizePG(updatedAt),
+		); err != nil {
+			return fmt.Errorf(
+				"upserting pg pricing %q: %w",
+				p.ModelPattern, err,
+			)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing pg pricing upsert: %w", err)
+	}
+	return nil
+}
+
+func (s *Sync) syncModelPricing(ctx context.Context) error {
+	prices, err := s.local.ListModelPricing(ctx)
+	if err != nil {
+		return fmt.Errorf("listing local model pricing: %w", err)
+	}
+	if len(prices) == 0 {
+		prices = fallbackPricingRows()
+	}
+	if err := upsertModelPricing(ctx, s.pg, prices); err != nil {
+		return fmt.Errorf("syncing model pricing to pg: %w", err)
+	}
+	return nil
+}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -137,6 +137,9 @@ func (s *Sync) Push(
 			}
 		}
 	}
+	if err := s.syncModelPricing(ctx); err != nil {
+		return result, err
+	}
 
 	cutoff := time.Now().UTC().Format(LocalSyncTimestampLayout)
 

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -36,33 +36,20 @@ type PushResult struct {
 	Duration       time.Duration
 }
 
+// PushProgress is reported after each batch during Push.
+type PushProgress struct {
+	SessionsDone  int
+	SessionsTotal int
+	MessagesDone  int
+	Errors        int
+}
+
 // Push syncs local sessions and messages to PostgreSQL.
-// Only sessions modified since the last push are processed.
-// When full is true, the per-message content heuristic is
-// bypassed and every candidate session's messages are
-// re-pushed unconditionally.
-//
-// When project filters are set (via SyncOptions), only
-// matching sessions are pushed. Filtered pushes do not
-// advance the global watermark (last_push_at) because the
-// watermark covers all projects — advancing it would cause
-// unfiltered sessions to be skipped. Instead, filtered
-// pushes rely on fingerprints for incrementality: each run
-// re-queries all sessions since the last unfiltered push
-// and skips those whose fingerprint hasn't changed. The
-// query window grows between unfiltered pushes, but
-// fingerprint matching keeps the actual PG writes minimal.
-// Run an occasional unfiltered push (or use --all-projects)
-// to advance the watermark and bound the query window.
-//
-// Known limitation: sessions that are permanently deleted
-// from SQLite (via prune) are not propagated as deletions
-// to PG because the local rows no longer exist at push time.
-// Sessions soft-deleted with deleted_at are synced correctly.
-// Use a direct PG DELETE to remove permanently pruned
-// sessions from PG if needed.
+// The onProgress callback, if non-nil, is called after each
+// batch with current totals.
 func (s *Sync) Push(
 	ctx context.Context, full bool,
+	onProgress func(PushProgress),
 ) (PushResult, error) {
 	start := time.Now()
 	var result PushResult
@@ -271,24 +258,32 @@ func (s *Sync) Push(
 		if batchResult.ok {
 			result.SessionsPushed += batchResult.sessions
 			result.MessagesPushed += batchResult.messages
-			continue
+		} else {
+			// Batch failed — retry each session individually
+			// so one bad session doesn't block the rest.
+			for _, sess := range batch {
+				sr, retryErr := s.pushBatch(
+					ctx, []db.Session{sess},
+					full, &pushed,
+				)
+				if retryErr != nil {
+					return result, retryErr
+				}
+				if sr.ok {
+					result.SessionsPushed += sr.sessions
+					result.MessagesPushed += sr.messages
+				} else {
+					result.Errors++
+				}
+			}
 		}
-		// Batch failed — retry each session individually
-		// so one bad session doesn't block the rest.
-		for _, sess := range batch {
-			sr, retryErr := s.pushBatch(
-				ctx, []db.Session{sess},
-				full, &pushed,
-			)
-			if retryErr != nil {
-				return result, retryErr
-			}
-			if sr.ok {
-				result.SessionsPushed += sr.sessions
-				result.MessagesPushed += sr.messages
-			} else {
-				result.Errors++
-			}
+		if onProgress != nil {
+			onProgress(PushProgress{
+				SessionsDone:  end,
+				SessionsTotal: len(sessions),
+				MessagesDone:  result.MessagesPushed,
+				Errors:        result.Errors,
+			})
 		}
 	}
 

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -89,7 +89,7 @@ func TestPushSystemFingerprintCollisionRegression(t *testing.T) {
 	}
 
 	// First push.
-	_, err = sync.Push(ctx, false)
+	_, err = sync.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("Push (first): %v", err)
 	}
@@ -121,7 +121,7 @@ func TestPushSystemFingerprintCollisionRegression(t *testing.T) {
 	}
 
 	// Second push — must NOT skip due to fingerprint match.
-	_, err = sync.Push(ctx, false)
+	_, err = sync.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("Push (second): %v", err)
 	}

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -70,6 +70,15 @@ CREATE TABLE IF NOT EXISTS messages (
         REFERENCES sessions(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS model_pricing (
+    model_pattern TEXT PRIMARY KEY,
+    input_per_mtok DOUBLE PRECISION NOT NULL DEFAULT 0,
+    output_per_mtok DOUBLE PRECISION NOT NULL DEFAULT 0,
+    cache_creation_per_mtok DOUBLE PRECISION NOT NULL DEFAULT 0,
+    cache_read_per_mtok DOUBLE PRECISION NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT ''
+);
+
 CREATE TABLE IF NOT EXISTS tool_calls (
     id                    BIGSERIAL PRIMARY KEY,
     session_id            TEXT NOT NULL,

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -68,36 +68,6 @@ func (s *Store) GetSessionVersion(
 }
 
 // ------------------------------------------------------------
-// Usage stubs (not yet implemented for PG)
-//
-// These return db.ErrReadOnly so the usage HTTP handlers can map
-// them to 501 Not Implemented. Returning empty results silently
-// would look like "no usage data" on a fully populated PG
-// deployment, which is far worse than an explicit error.
-// ------------------------------------------------------------
-
-// GetDailyUsage is not implemented for PG.
-func (s *Store) GetDailyUsage(
-	_ context.Context, _ db.UsageFilter,
-) (db.DailyUsageResult, error) {
-	return db.DailyUsageResult{}, db.ErrReadOnly
-}
-
-// GetTopSessionsByCost is not implemented for PG.
-func (s *Store) GetTopSessionsByCost(
-	_ context.Context, _ db.UsageFilter, _ int,
-) ([]db.TopSessionEntry, error) {
-	return nil, db.ErrReadOnly
-}
-
-// GetUsageSessionCounts is not implemented for PG.
-func (s *Store) GetUsageSessionCounts(
-	_ context.Context, _ db.UsageFilter,
-) (db.UsageSessionCounts, error) {
-	return db.UsageSessionCounts{}, db.ErrReadOnly
-}
-
-// ------------------------------------------------------------
 // Write stubs (all return db.ErrReadOnly)
 // ------------------------------------------------------------
 

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -210,7 +210,7 @@ func TestPushSingleSession(t *testing.T) {
 		t.Fatalf("insert messages: %v", err)
 	}
 
-	result, err := ps.Push(ctx, false)
+	result, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestPushIdempotent(t *testing.T) {
 		t.Fatalf("upsert session: %v", err)
 	}
 
-	result1, err := ps.Push(ctx, false)
+	result1, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("first push: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestPushIdempotent(t *testing.T) {
 		)
 	}
 
-	result2, err := ps.Push(ctx, false)
+	result2, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("second push: %v", err)
 	}
@@ -375,7 +375,7 @@ func TestPushWithToolCalls(t *testing.T) {
 		t.Fatalf("insert messages: %v", err)
 	}
 
-	result, err := ps.Push(ctx, false)
+	result, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -471,7 +471,7 @@ func TestPushWithToolResultEvents(t *testing.T) {
 		t.Fatalf("insert messages: %v", err)
 	}
 
-	if _, err := ps.Push(ctx, false); err != nil {
+	if _, err := ps.Push(ctx, false, nil); err != nil {
 		t.Fatalf("push: %v", err)
 	}
 
@@ -636,7 +636,7 @@ func TestPushUpdatedAtFormat(t *testing.T) {
 		t.Fatalf("upsert session: %v", err)
 	}
 
-	if _, err := ps.Push(ctx, false); err != nil {
+	if _, err := ps.Push(ctx, false, nil); err != nil {
 		t.Fatalf("push: %v", err)
 	}
 
@@ -711,7 +711,7 @@ func TestPushBumpsUpdatedAtOnMessageRewrite(
 		t.Fatalf("replace messages: %v", err)
 	}
 
-	if _, err := ps.Push(ctx, false); err != nil {
+	if _, err := ps.Push(ctx, false, nil); err != nil {
 		t.Fatalf("initial push: %v", err)
 	}
 
@@ -725,7 +725,7 @@ func TestPushBumpsUpdatedAtOnMessageRewrite(
 
 	time.Sleep(50 * time.Millisecond)
 
-	result, err := ps.Push(ctx, true)
+	result, err := ps.Push(ctx, true, nil)
 	if err != nil {
 		t.Fatalf("full push: %v", err)
 	}
@@ -798,7 +798,7 @@ func TestPushFullBypassesHeuristic(t *testing.T) {
 		t.Fatalf("insert messages: %v", err)
 	}
 
-	if _, err := ps.Push(ctx, false); err != nil {
+	if _, err := ps.Push(ctx, false, nil); err != nil {
 		t.Fatalf("first push: %v", err)
 	}
 
@@ -808,7 +808,7 @@ func TestPushFullBypassesHeuristic(t *testing.T) {
 		t.Fatalf("resetting watermark: %v", err)
 	}
 
-	result, err := ps.Push(ctx, true)
+	result, err := ps.Push(ctx, true, nil)
 	if err != nil {
 		t.Fatalf("full push: %v", err)
 	}
@@ -870,7 +870,7 @@ func TestPushDetectsSchemaReset(t *testing.T) {
 		t.Fatalf("insert message: %v", err)
 	}
 
-	r1, err := ps.Push(ctx, false)
+	r1, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("initial push: %v", err)
 	}
@@ -888,7 +888,7 @@ func TestPushDetectsSchemaReset(t *testing.T) {
 	// An incremental push should detect the mismatch
 	// (local watermark set, PG has 0 sessions), recreate
 	// the schema, and automatically force a full push.
-	r2, err := ps.Push(ctx, false)
+	r2, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("post-reset push: %v", err)
 	}
@@ -936,7 +936,7 @@ func TestPushFullAfterSchemaDropRecreatesSchema(
 		t.Fatalf("upsert session: %v", err)
 	}
 
-	r1, err := ps.Push(ctx, false)
+	r1, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("initial push: %v", err)
 	}
@@ -952,7 +952,7 @@ func TestPushFullAfterSchemaDropRecreatesSchema(
 
 	// A full push should recreate the schema even though
 	// schemaDone is memoized from the first push.
-	r2, err := ps.Push(ctx, true)
+	r2, err := ps.Push(ctx, true, nil)
 	if err != nil {
 		t.Fatalf("full push after drop: %v", err)
 	}
@@ -1021,7 +1021,7 @@ func TestPushBatchesMultipleSessions(t *testing.T) {
 		}
 	}
 
-	result, err := ps.Push(ctx, false)
+	result, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -1132,7 +1132,7 @@ func TestPushBulkInsertManyMessages(t *testing.T) {
 		t.Fatalf("insert messages: %v", err)
 	}
 
-	result, err := ps.Push(ctx, false)
+	result, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -1301,7 +1301,7 @@ func TestPushFilteredByProject(t *testing.T) {
 	if err := filtered.EnsureSchema(ctx); err != nil {
 		t.Fatalf("ensure schema: %v", err)
 	}
-	r1, err := filtered.Push(ctx, false)
+	r1, err := filtered.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("filtered push: %v", err)
 	}
@@ -1347,7 +1347,7 @@ func TestPushFilteredByProject(t *testing.T) {
 	}
 	defer unfiltered.Close()
 
-	r2, err := unfiltered.Push(ctx, false)
+	r2, err := unfiltered.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("unfiltered push: %v", err)
 	}
@@ -1367,7 +1367,7 @@ func TestPushFilteredByProject(t *testing.T) {
 
 	// Step 3: second filtered push is a no-op (fingerprints
 	// match).
-	r3, err := filtered.Push(ctx, false)
+	r3, err := filtered.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("second filtered push: %v", err)
 	}
@@ -1426,7 +1426,7 @@ func TestPushExcludeProject(t *testing.T) {
 	if err := ps.EnsureSchema(ctx); err != nil {
 		t.Fatalf("ensure schema: %v", err)
 	}
-	r, err := ps.Push(ctx, false)
+	r, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
@@ -1485,7 +1485,7 @@ func TestPushFilteredFullIsIncremental(t *testing.T) {
 	}
 
 	// First push with --full.
-	r1, err := ps.Push(ctx, true)
+	r1, err := ps.Push(ctx, true, nil)
 	if err != nil {
 		t.Fatalf("first push: %v", err)
 	}
@@ -1517,7 +1517,7 @@ func TestPushFilteredFullIsIncremental(t *testing.T) {
 
 	// Second push (not --full) should be a no-op because
 	// fingerprints were persisted after the filtered --full.
-	r2, err := ps.Push(ctx, false)
+	r2, err := ps.Push(ctx, false, nil)
 	if err != nil {
 		t.Fatalf("second push: %v", err)
 	}

--- a/internal/postgres/token_usage_pgtest_test.go
+++ b/internal/postgres/token_usage_pgtest_test.go
@@ -150,7 +150,7 @@ func TestPushTokenUsageToPostgres(t *testing.T) {
 		t.Fatalf("InsertMessages: %v", err)
 	}
 
-	if _, err := ps.Push(ctx, false); err != nil {
+	if _, err := ps.Push(ctx, false, nil); err != nil {
 		t.Fatalf("Push: %v", err)
 	}
 

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -1,0 +1,784 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"github.com/wesm/agentsview/internal/db"
+)
+
+const pgUsageMessageEligibility = `
+	m.token_usage != ''
+	AND m.model != ''
+	AND m.model != '<synthetic>'
+	AND s.deleted_at IS NULL`
+
+func usageLocation(f db.UsageFilter) *time.Location {
+	if f.Timezone == "" {
+		return time.Local
+	}
+	loc, err := time.LoadLocation(f.Timezone)
+	if err != nil {
+		return time.Local
+	}
+	return loc
+}
+
+func paddedUTCBound(ts string, hours int) string {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ts
+	}
+	return t.Add(time.Duration(hours) * time.Hour).
+		Format(time.RFC3339)
+}
+
+func appendPGUsageFilterClauses(
+	query string, pb *paramBuilder, f db.UsageFilter,
+) (string, []any) {
+	appendCSV := func(
+		q, col, csv string, include bool,
+	) string {
+		if csv == "" {
+			return q
+		}
+		vals := strings.Split(csv, ",")
+		op := "IN"
+		if !include {
+			op = "NOT IN"
+		}
+		if len(vals) == 1 {
+			if include {
+				return q + " AND " + col + " = " + pb.add(vals[0])
+			}
+			return q + " AND " + col + " != " + pb.add(vals[0])
+		}
+		placeholders := make([]string, len(vals))
+		for i, v := range vals {
+			placeholders[i] = pb.add(v)
+		}
+		return q + " AND " + col + " " + op + " (" +
+			strings.Join(placeholders, ",") + ")"
+	}
+
+	query = appendCSV(query, "s.agent", f.Agent, true)
+	query = appendCSV(query, "s.project", f.Project, true)
+	query = appendCSV(query, "m.model", f.Model, true)
+	query = appendCSV(query, "s.project", f.ExcludeProject, false)
+	query = appendCSV(query, "s.agent", f.ExcludeAgent, false)
+	query = appendCSV(query, "m.model", f.ExcludeModel, false)
+
+	return query, pb.args
+}
+
+func usageDate(ts sql.NullTime, loc *time.Location) string {
+	if !ts.Valid {
+		return ""
+	}
+	return ts.Time.In(loc).Format("2006-01-02")
+}
+
+// GetDailyUsage returns token usage and cost aggregated by day.
+func (s *Store) GetDailyUsage(
+	ctx context.Context, f db.UsageFilter,
+) (db.DailyUsageResult, error) {
+	loc := usageLocation(f)
+
+	pricing, err := s.loadPricingMap(ctx)
+	if err != nil {
+		return db.DailyUsageResult{},
+			fmt.Errorf("loading pg pricing: %w", err)
+	}
+
+	var query string
+	if f.Breakdowns {
+		query = `
+SELECT
+	COALESCE(m.timestamp, s.started_at) as ts,
+	m.model,
+	m.token_usage,
+	m.claude_message_id,
+	m.claude_request_id,
+	s.project,
+	s.agent
+FROM messages m
+JOIN sessions s ON m.session_id = s.id
+WHERE ` + pgUsageMessageEligibility
+	} else {
+		query = `
+SELECT
+	COALESCE(m.timestamp, s.started_at) as ts,
+	m.model,
+	m.token_usage,
+	m.claude_message_id,
+	m.claude_request_id
+FROM messages m
+JOIN sessions s ON m.session_id = s.id
+WHERE ` + pgUsageMessageEligibility
+	}
+
+	pb := &paramBuilder{}
+	if f.From != "" {
+		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
+		query += " AND COALESCE(m.timestamp, s.started_at) >= " +
+			pb.add(padded) + "::timestamptz"
+	}
+	if f.To != "" {
+		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
+		query += " AND COALESCE(m.timestamp, s.started_at) <= " +
+			pb.add(padded) + "::timestamptz"
+	}
+	query, _ = appendPGUsageFilterClauses(query, pb, f)
+	query += ` ORDER BY COALESCE(m.timestamp, s.started_at) ASC,
+		m.session_id ASC, m.ordinal ASC`
+
+	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+	if err != nil {
+		return db.DailyUsageResult{},
+			fmt.Errorf("querying daily usage: %w", err)
+	}
+	defer rows.Close()
+
+	type accumKey struct {
+		date    string
+		project string
+		agent   string
+		model   string
+	}
+	type bucket struct {
+		inputTok  int
+		outputTok int
+		cacheCr   int
+		cacheRd   int
+		cost      float64
+	}
+	type dedupKey struct {
+		msgID string
+		reqID string
+	}
+
+	accum := make(map[accumKey]*bucket)
+	seen := make(map[dedupKey]struct{})
+	var totalSavings float64
+
+	var (
+		ts        sql.NullTime
+		model     string
+		tokenJSON string
+		msgID     string
+		reqID     string
+		project   string
+		agent     string
+	)
+	for rows.Next() {
+		var scanErr error
+		if f.Breakdowns {
+			scanErr = rows.Scan(
+				&ts, &model, &tokenJSON,
+				&msgID, &reqID, &project, &agent,
+			)
+		} else {
+			scanErr = rows.Scan(
+				&ts, &model, &tokenJSON,
+				&msgID, &reqID,
+			)
+		}
+		if scanErr != nil {
+			return db.DailyUsageResult{},
+				fmt.Errorf("scanning daily usage row: %w", scanErr)
+		}
+
+		date := usageDate(ts, loc)
+		if f.From != "" && date < f.From {
+			continue
+		}
+		if f.To != "" && date > f.To {
+			continue
+		}
+
+		if msgID != "" && reqID != "" {
+			key := dedupKey{msgID: msgID, reqID: reqID}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+
+		usage := gjson.Parse(tokenJSON)
+		inputTok := int(usage.Get("input_tokens").Int())
+		outputTok := int(usage.Get("output_tokens").Int())
+		cacheCrTok := int(
+			usage.Get("cache_creation_input_tokens").Int(),
+		)
+		cacheRdTok := int(
+			usage.Get("cache_read_input_tokens").Int(),
+		)
+
+		rates := pricing[model]
+		cost := (float64(inputTok)*rates.input +
+			float64(outputTok)*rates.output +
+			float64(cacheCrTok)*rates.cacheCreation +
+			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
+
+		readDelta := float64(cacheRdTok) *
+			(rates.input - rates.cacheRead) / 1_000_000
+		createDelta := float64(cacheCrTok) *
+			(rates.input - rates.cacheCreation) / 1_000_000
+		totalSavings += readDelta + createDelta
+
+		key := accumKey{
+			date:    date,
+			project: project,
+			agent:   agent,
+			model:   model,
+		}
+		b, ok := accum[key]
+		if !ok {
+			b = &bucket{}
+			accum[key] = b
+		}
+		b.inputTok += inputTok
+		b.outputTok += outputTok
+		b.cacheCr += cacheCrTok
+		b.cacheRd += cacheRdTok
+		b.cost += cost
+	}
+	if err := rows.Err(); err != nil {
+		return db.DailyUsageResult{},
+			fmt.Errorf("iterating daily usage rows: %w", err)
+	}
+
+	if !f.Breakdowns {
+		type dateModelKey struct {
+			date  string
+			model string
+		}
+		type modelAccum struct {
+			inputTok  int
+			outputTok int
+			cacheCr   int
+			cacheRd   int
+			cost      float64
+		}
+		dm := make(map[dateModelKey]*modelAccum)
+		for key, b := range accum {
+			dmk := dateModelKey{date: key.date, model: key.model}
+			ma, ok := dm[dmk]
+			if !ok {
+				ma = &modelAccum{}
+				dm[dmk] = ma
+			}
+			ma.inputTok += b.inputTok
+			ma.outputTok += b.outputTok
+			ma.cacheCr += b.cacheCr
+			ma.cacheRd += b.cacheRd
+			ma.cost += b.cost
+		}
+
+		type dayData struct {
+			models map[string]*modelAccum
+		}
+		days := make(map[string]*dayData)
+		for key, ma := range dm {
+			dd, ok := days[key.date]
+			if !ok {
+				dd = &dayData{models: make(map[string]*modelAccum)}
+				days[key.date] = dd
+			}
+			dd.models[key.model] = ma
+		}
+
+		dateKeys := make([]string, 0, len(days))
+		for d := range days {
+			dateKeys = append(dateKeys, d)
+		}
+		sort.Strings(dateKeys)
+
+		daily := make([]db.DailyUsageEntry, 0, len(dateKeys))
+		var totals db.UsageTotals
+		for _, date := range dateKeys {
+			dd := days[date]
+			var entry db.DailyUsageEntry
+			entry.Date = date
+
+			modelNames := make([]string, 0, len(dd.models))
+			for m := range dd.models {
+				modelNames = append(modelNames, m)
+			}
+			sort.Slice(modelNames, func(i, j int) bool {
+				ci := dd.models[modelNames[i]].cost
+				cj := dd.models[modelNames[j]].cost
+				if ci != cj {
+					return ci > cj
+				}
+				return modelNames[i] < modelNames[j]
+			})
+			entry.ModelsUsed = modelNames
+			mbd := make([]db.ModelBreakdown, 0, len(modelNames))
+			for _, m := range modelNames {
+				ma := dd.models[m]
+				entry.InputTokens += ma.inputTok
+				entry.OutputTokens += ma.outputTok
+				entry.CacheCreationTokens += ma.cacheCr
+				entry.CacheReadTokens += ma.cacheRd
+				entry.TotalCost += ma.cost
+				mbd = append(mbd, db.ModelBreakdown{
+					ModelName:           m,
+					InputTokens:         ma.inputTok,
+					OutputTokens:        ma.outputTok,
+					CacheCreationTokens: ma.cacheCr,
+					CacheReadTokens:     ma.cacheRd,
+					Cost:                ma.cost,
+				})
+			}
+			entry.ModelBreakdowns = mbd
+			daily = append(daily, entry)
+
+			totals.InputTokens += entry.InputTokens
+			totals.OutputTokens += entry.OutputTokens
+			totals.CacheCreationTokens += entry.CacheCreationTokens
+			totals.CacheReadTokens += entry.CacheReadTokens
+			totals.TotalCost += entry.TotalCost
+		}
+		if daily == nil {
+			daily = []db.DailyUsageEntry{}
+		}
+		totals.CacheSavings = totalSavings
+		return db.DailyUsageResult{
+			Daily:  daily,
+			Totals: totals,
+		}, nil
+	}
+
+	type dayMaps struct {
+		models   map[string]bucket
+		projects map[string]bucket
+		agents   map[string]bucket
+	}
+	days := make(map[string]*dayMaps, 64)
+	for key, b := range accum {
+		dm, ok := days[key.date]
+		if !ok {
+			dm = &dayMaps{
+				models:   make(map[string]bucket, 4),
+				projects: make(map[string]bucket, 8),
+				agents:   make(map[string]bucket, 4),
+			}
+			days[key.date] = dm
+		}
+
+		cur := dm.models[key.model]
+		cur.inputTok += b.inputTok
+		cur.outputTok += b.outputTok
+		cur.cacheCr += b.cacheCr
+		cur.cacheRd += b.cacheRd
+		cur.cost += b.cost
+		dm.models[key.model] = cur
+
+		cur = dm.projects[key.project]
+		cur.inputTok += b.inputTok
+		cur.outputTok += b.outputTok
+		cur.cacheCr += b.cacheCr
+		cur.cacheRd += b.cacheRd
+		cur.cost += b.cost
+		dm.projects[key.project] = cur
+
+		cur = dm.agents[key.agent]
+		cur.inputTok += b.inputTok
+		cur.outputTok += b.outputTok
+		cur.cacheCr += b.cacheCr
+		cur.cacheRd += b.cacheRd
+		cur.cost += b.cost
+		dm.agents[key.agent] = cur
+	}
+
+	dateKeys := make([]string, 0, len(days))
+	for d := range days {
+		dateKeys = append(dateKeys, d)
+	}
+	sort.Strings(dateKeys)
+
+	daily := make([]db.DailyUsageEntry, 0, len(dateKeys))
+	var totals db.UsageTotals
+	for _, date := range dateKeys {
+		dm := days[date]
+		var entry db.DailyUsageEntry
+		entry.Date = date
+
+		modelNames := make([]string, 0, len(dm.models))
+		for m := range dm.models {
+			modelNames = append(modelNames, m)
+		}
+		sort.Slice(modelNames, func(i, j int) bool {
+			ci := dm.models[modelNames[i]].cost
+			cj := dm.models[modelNames[j]].cost
+			if ci != cj {
+				return ci > cj
+			}
+			return modelNames[i] < modelNames[j]
+		})
+		entry.ModelsUsed = modelNames
+		mbd := make([]db.ModelBreakdown, 0, len(modelNames))
+		for _, m := range modelNames {
+			b := dm.models[m]
+			entry.InputTokens += b.inputTok
+			entry.OutputTokens += b.outputTok
+			entry.CacheCreationTokens += b.cacheCr
+			entry.CacheReadTokens += b.cacheRd
+			entry.TotalCost += b.cost
+			mbd = append(mbd, db.ModelBreakdown{
+				ModelName:           m,
+				InputTokens:         b.inputTok,
+				OutputTokens:        b.outputTok,
+				CacheCreationTokens: b.cacheCr,
+				CacheReadTokens:     b.cacheRd,
+				Cost:                b.cost,
+			})
+		}
+		entry.ModelBreakdowns = mbd
+
+		pbd := make([]db.ProjectBreakdown, 0, len(dm.projects))
+		for p, b := range dm.projects {
+			pbd = append(pbd, db.ProjectBreakdown{
+				Project:             p,
+				InputTokens:         b.inputTok,
+				OutputTokens:        b.outputTok,
+				CacheCreationTokens: b.cacheCr,
+				CacheReadTokens:     b.cacheRd,
+				Cost:                b.cost,
+			})
+		}
+		sort.Slice(pbd, func(i, j int) bool {
+			if pbd[i].Cost != pbd[j].Cost {
+				return pbd[i].Cost > pbd[j].Cost
+			}
+			return pbd[i].Project < pbd[j].Project
+		})
+		entry.ProjectBreakdowns = pbd
+
+		abd := make([]db.AgentBreakdown, 0, len(dm.agents))
+		for a, b := range dm.agents {
+			abd = append(abd, db.AgentBreakdown{
+				Agent:               a,
+				InputTokens:         b.inputTok,
+				OutputTokens:        b.outputTok,
+				CacheCreationTokens: b.cacheCr,
+				CacheReadTokens:     b.cacheRd,
+				Cost:                b.cost,
+			})
+		}
+		sort.Slice(abd, func(i, j int) bool {
+			if abd[i].Cost != abd[j].Cost {
+				return abd[i].Cost > abd[j].Cost
+			}
+			return abd[i].Agent < abd[j].Agent
+		})
+		entry.AgentBreakdowns = abd
+
+		daily = append(daily, entry)
+
+		totals.InputTokens += entry.InputTokens
+		totals.OutputTokens += entry.OutputTokens
+		totals.CacheCreationTokens += entry.CacheCreationTokens
+		totals.CacheReadTokens += entry.CacheReadTokens
+		totals.TotalCost += entry.TotalCost
+	}
+
+	if daily == nil {
+		daily = []db.DailyUsageEntry{}
+	}
+
+	totals.CacheSavings = totalSavings
+	return db.DailyUsageResult{
+		Daily:  daily,
+		Totals: totals,
+	}, nil
+}
+
+// GetTopSessionsByCost returns sessions ranked by total cost.
+func (s *Store) GetTopSessionsByCost(
+	ctx context.Context, f db.UsageFilter, limit int,
+) ([]db.TopSessionEntry, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	pricing, err := s.loadPricingMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading pg pricing: %w", err)
+	}
+
+	query := `
+SELECT
+	s.id,
+	COALESCE(s.display_name, s.id),
+	s.agent,
+	s.project,
+	s.started_at,
+	m.model,
+	m.token_usage,
+	m.claude_message_id,
+	m.claude_request_id,
+	COALESCE(m.timestamp, s.started_at) as ts
+FROM messages m
+JOIN sessions s ON m.session_id = s.id
+WHERE ` + pgUsageMessageEligibility
+
+	pb := &paramBuilder{}
+	if f.From != "" {
+		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
+		query += " AND COALESCE(m.timestamp, s.started_at) >= " +
+			pb.add(padded) + "::timestamptz"
+	}
+	if f.To != "" {
+		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
+		query += " AND COALESCE(m.timestamp, s.started_at) <= " +
+			pb.add(padded) + "::timestamptz"
+	}
+	query, _ = appendPGUsageFilterClauses(query, pb, f)
+	query += ` ORDER BY COALESCE(m.timestamp, s.started_at) ASC,
+		m.session_id ASC, m.ordinal ASC`
+
+	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying top sessions: %w", err)
+	}
+	defer rows.Close()
+
+	loc := usageLocation(f)
+
+	type sessAccum struct {
+		displayName string
+		agent       string
+		project     string
+		startedAt   string
+		totalTokens int
+		cost        float64
+	}
+	type dedupKey struct {
+		msgID string
+		reqID string
+	}
+
+	accum := make(map[string]*sessAccum)
+	var order []string
+	seen := make(map[dedupKey]struct{})
+
+	var (
+		sid         string
+		displayName string
+		agent       string
+		project     string
+		startedAt   sql.NullTime
+		model       string
+		tokenJSON   string
+		msgID       string
+		reqID       string
+		ts          sql.NullTime
+	)
+	for rows.Next() {
+		if err := rows.Scan(
+			&sid, &displayName, &agent, &project,
+			&startedAt, &model, &tokenJSON,
+			&msgID, &reqID, &ts,
+		); err != nil {
+			return nil, fmt.Errorf("scanning top sessions row: %w", err)
+		}
+
+		date := usageDate(ts, loc)
+		if f.From != "" && date < f.From {
+			continue
+		}
+		if f.To != "" && date > f.To {
+			continue
+		}
+
+		if msgID != "" && reqID != "" {
+			key := dedupKey{msgID: msgID, reqID: reqID}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+
+		usage := gjson.Parse(tokenJSON)
+		inputTok := int(usage.Get("input_tokens").Int())
+		outputTok := int(usage.Get("output_tokens").Int())
+		cacheCrTok := int(
+			usage.Get("cache_creation_input_tokens").Int(),
+		)
+		cacheRdTok := int(
+			usage.Get("cache_read_input_tokens").Int(),
+		)
+
+		rates := pricing[model]
+		cost := (float64(inputTok)*rates.input +
+			float64(outputTok)*rates.output +
+			float64(cacheCrTok)*rates.cacheCreation +
+			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
+
+		sa, ok := accum[sid]
+		if !ok {
+			started := ""
+			if startedAt.Valid {
+				started = FormatISO8601(startedAt.Time)
+			}
+			sa = &sessAccum{
+				displayName: displayName,
+				agent:       agent,
+				project:     project,
+				startedAt:   started,
+			}
+			accum[sid] = sa
+			order = append(order, sid)
+		}
+		sa.totalTokens += inputTok + outputTok + cacheCrTok + cacheRdTok
+		sa.cost += cost
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating top sessions rows: %w", err)
+	}
+
+	result := make([]db.TopSessionEntry, 0, len(order))
+	for _, id := range order {
+		sa := accum[id]
+		result = append(result, db.TopSessionEntry{
+			SessionID:   id,
+			DisplayName: sa.displayName,
+			Agent:       sa.agent,
+			Project:     sa.project,
+			StartedAt:   sa.startedAt,
+			TotalTokens: sa.totalTokens,
+			Cost:        sa.cost,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Cost != result[j].Cost {
+			return result[i].Cost > result[j].Cost
+		}
+		return result[i].SessionID < result[j].SessionID
+	})
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
+// GetUsageSessionCounts returns distinct session counts grouped by project and agent.
+func (s *Store) GetUsageSessionCounts(
+	ctx context.Context, f db.UsageFilter,
+) (db.UsageSessionCounts, error) {
+	query := `
+SELECT
+	s.id,
+	s.project,
+	s.agent,
+	m.claude_message_id,
+	m.claude_request_id,
+	COALESCE(m.timestamp, s.started_at) as ts
+FROM messages m
+JOIN sessions s ON m.session_id = s.id
+WHERE ` + pgUsageMessageEligibility
+
+	pb := &paramBuilder{}
+	if f.From != "" {
+		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
+		query += " AND COALESCE(m.timestamp, s.started_at) >= " +
+			pb.add(padded) + "::timestamptz"
+	}
+	if f.To != "" {
+		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
+		query += " AND COALESCE(m.timestamp, s.started_at) <= " +
+			pb.add(padded) + "::timestamptz"
+	}
+	query, _ = appendPGUsageFilterClauses(query, pb, f)
+	query += ` ORDER BY COALESCE(m.timestamp, s.started_at) ASC,
+		m.session_id ASC, m.ordinal ASC`
+
+	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+	if err != nil {
+		return db.UsageSessionCounts{},
+			fmt.Errorf("querying session counts: %w", err)
+	}
+	defer rows.Close()
+
+	loc := usageLocation(f)
+
+	type sessInfo struct {
+		project string
+		agent   string
+	}
+	type dedupKey struct {
+		msgID string
+		reqID string
+	}
+
+	seen := make(map[string]sessInfo)
+	dedup := make(map[dedupKey]struct{})
+
+	var (
+		sid     string
+		project string
+		agent   string
+		msgID   string
+		reqID   string
+		ts      sql.NullTime
+	)
+	for rows.Next() {
+		if err := rows.Scan(
+			&sid, &project, &agent,
+			&msgID, &reqID, &ts,
+		); err != nil {
+			return db.UsageSessionCounts{},
+				fmt.Errorf("scanning session counts: %w", err)
+		}
+
+		date := usageDate(ts, loc)
+		if f.From != "" && date < f.From {
+			continue
+		}
+		if f.To != "" && date > f.To {
+			continue
+		}
+
+		if msgID != "" && reqID != "" {
+			key := dedupKey{msgID: msgID, reqID: reqID}
+			if _, dup := dedup[key]; dup {
+				continue
+			}
+			dedup[key] = struct{}{}
+		}
+
+		if _, ok := seen[sid]; !ok {
+			seen[sid] = sessInfo{
+				project: project,
+				agent:   agent,
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return db.UsageSessionCounts{},
+			fmt.Errorf("iterating session counts: %w", err)
+	}
+
+	out := db.UsageSessionCounts{
+		Total:     len(seen),
+		ByProject: make(map[string]int),
+		ByAgent:   make(map[string]int),
+	}
+	for _, info := range seen {
+		out.ByProject[info.project]++
+		out.ByAgent[info.agent]++
+	}
+
+	return out, nil
+}

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -1,0 +1,378 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+func prepareUsageSchema(
+	t *testing.T, schema string,
+) (string, *Store) {
+	t.Helper()
+
+	pgURL := testPGURL(t)
+	pg, err := Open(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.Close() })
+
+	ctx := context.Background()
+	if _, err := pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`); err != nil {
+		t.Fatalf("drop schema: %v", err)
+	}
+	if err := EnsureSchema(ctx, pg, schema); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	store, err := NewStore(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return pgURL, store
+}
+
+func TestStoreGetDailyUsageUsesFallbackPricing(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_fallback_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES (
+			'usage-fallback-001', 'test-machine', 'proj', 'claude',
+			'2026-03-12T10:00:00Z'::timestamptz, 1, 1
+		)`)
+	if err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model, token_usage
+		) VALUES (
+			'usage-fallback-001', 0, 'assistant', 'hi',
+			'2026-03-12T10:00:00Z'::timestamptz, 2,
+			'claude-sonnet-4-20250514',
+			'{"input_tokens":1000000}'
+		)`)
+	if err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+
+	result, err := store.GetDailyUsage(ctx, db.UsageFilter{
+		From:     "2026-03-12",
+		To:       "2026-03-12",
+		Timezone: "UTC",
+	})
+	if err != nil {
+		t.Fatalf("GetDailyUsage: %v", err)
+	}
+	if got := result.Totals.TotalCost; got != 3.0 {
+		t.Fatalf("TotalCost = %.2f, want 3.0", got)
+	}
+	if len(result.Daily) != 1 {
+		t.Fatalf("daily len = %d, want 1", len(result.Daily))
+	}
+}
+
+func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_breakdown_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES
+			('test-model-a', 1, 2, 3, 0.5, 'seed'),
+			('test-model-b', 2, 4, 0, 0, 'seed')`)
+	if err != nil {
+		t.Fatalf("insert pricing: %v", err)
+	}
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES
+			('usage-breakdown-001', 'test-machine', 'proj-a', 'claude',
+			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
+			('usage-breakdown-002', 'test-machine', 'proj-b', 'codex',
+			 '2026-03-12T11:00:00Z'::timestamptz, 1, 1)`)
+	if err != nil {
+		t.Fatalf("insert sessions: %v", err)
+	}
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage
+		) VALUES
+			('usage-breakdown-001', 0, 'assistant', 'one',
+			 '2026-03-12T10:00:00Z'::timestamptz, 3,
+			 'test-model-a',
+			 '{"input_tokens":1000000,"output_tokens":500000,"cache_creation_input_tokens":250000,"cache_read_input_tokens":250000}'),
+			('usage-breakdown-002', 0, 'assistant', 'two',
+			 '2026-03-12T11:00:00Z'::timestamptz, 3,
+			 'test-model-b',
+			 '{"input_tokens":500000,"output_tokens":250000}')`)
+	if err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+
+	result, err := store.GetDailyUsage(ctx, db.UsageFilter{
+		From:       "2026-03-12",
+		To:         "2026-03-12",
+		Timezone:   "UTC",
+		Breakdowns: true,
+	})
+	if err != nil {
+		t.Fatalf("GetDailyUsage: %v", err)
+	}
+	if len(result.Daily) != 1 {
+		t.Fatalf("daily len = %d, want 1", len(result.Daily))
+	}
+	day := result.Daily[0]
+	if got, want := day.InputTokens, 1500000; got != want {
+		t.Fatalf("InputTokens = %d, want %d", got, want)
+	}
+	if got, want := day.OutputTokens, 750000; got != want {
+		t.Fatalf("OutputTokens = %d, want %d", got, want)
+	}
+	if got, want := len(day.ProjectBreakdowns), 2; got != want {
+		t.Fatalf("ProjectBreakdowns len = %d, want %d", got, want)
+	}
+	if got, want := len(day.AgentBreakdowns), 2; got != want {
+		t.Fatalf("AgentBreakdowns len = %d, want %d", got, want)
+	}
+	if got, want := len(day.ModelBreakdowns), 2; got != want {
+		t.Fatalf("ModelBreakdowns len = %d, want %d", got, want)
+	}
+	if day.TotalCost <= 0 {
+		t.Fatalf("TotalCost = %.4f, want > 0", day.TotalCost)
+	}
+}
+
+func TestStoreGetTopSessionsByCostDedupesClaudeKeys(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_top_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('test-model-top', 1, 0, 0, 0, 'seed')`)
+	if err != nil {
+		t.Fatalf("insert pricing: %v", err)
+	}
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES
+			('usage-top-001', 'test-machine', 'proj-a', 'claude',
+			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
+			('usage-top-002', 'test-machine', 'proj-b', 'claude',
+			 '2026-03-12T10:01:00Z'::timestamptz, 1, 1)`)
+	if err != nil {
+		t.Fatalf("insert sessions: %v", err)
+	}
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage, claude_message_id, claude_request_id
+		) VALUES
+			('usage-top-001', 0, 'assistant', 'one',
+			 '2026-03-12T10:00:00Z'::timestamptz, 3,
+			 'test-model-top', '{"input_tokens":1000000}', 'msg-1', 'req-1'),
+			('usage-top-002', 0, 'assistant', 'two',
+			 '2026-03-12T10:01:00Z'::timestamptz, 3,
+			 'test-model-top', '{"input_tokens":1000000}', 'msg-1', 'req-1')`)
+	if err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+
+	top, err := store.GetTopSessionsByCost(ctx, db.UsageFilter{
+		From:     "2026-03-12",
+		To:       "2026-03-12",
+		Timezone: "UTC",
+	}, 20)
+	if err != nil {
+		t.Fatalf("GetTopSessionsByCost: %v", err)
+	}
+	if len(top) != 1 {
+		t.Fatalf("top len = %d, want 1", len(top))
+	}
+	if top[0].SessionID != "usage-top-001" {
+		t.Fatalf("top[0].SessionID = %q, want usage-top-001", top[0].SessionID)
+	}
+}
+
+func TestStoreGetUsageSessionCountsDedupesClaudeKeys(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_counts_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES
+			('usage-counts-001', 'test-machine', 'proj-a', 'claude',
+			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
+			('usage-counts-002', 'test-machine', 'proj-b', 'claude',
+			 '2026-03-12T10:01:00Z'::timestamptz, 1, 1)`)
+	if err != nil {
+		t.Fatalf("insert sessions: %v", err)
+	}
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage, claude_message_id, claude_request_id
+		) VALUES
+			('usage-counts-001', 0, 'assistant', 'one',
+			 '2026-03-12T10:00:00Z'::timestamptz, 3,
+			 'test-model-counts', '{"input_tokens":1}', 'msg-1', 'req-1'),
+			('usage-counts-002', 0, 'assistant', 'two',
+			 '2026-03-12T10:01:00Z'::timestamptz, 3,
+			 'test-model-counts', '{"input_tokens":1}', 'msg-1', 'req-1')`)
+	if err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+
+	counts, err := store.GetUsageSessionCounts(ctx, db.UsageFilter{
+		From:     "2026-03-12",
+		To:       "2026-03-12",
+		Timezone: "UTC",
+	})
+	if err != nil {
+		t.Fatalf("GetUsageSessionCounts: %v", err)
+	}
+	if counts.Total != 1 {
+		t.Fatalf("Total = %d, want 1", counts.Total)
+	}
+	if counts.ByProject["proj-a"] != 1 {
+		t.Fatalf("ByProject[proj-a] = %d, want 1", counts.ByProject["proj-a"])
+	}
+	if _, ok := counts.ByProject["proj-b"]; ok {
+		t.Fatalf("proj-b should have been deduped out: %#v", counts.ByProject)
+	}
+}
+
+func TestPushSyncsModelPricingToPostgres(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanPGSchema(t, pgURL)
+	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
+
+	local := testDB(t)
+	if err := local.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern:         "test-model-sync",
+		InputPerMTok:         1.5,
+		OutputPerMTok:        2.5,
+		CacheCreationPerMTok: 3.5,
+		CacheReadPerMTok:     0.5,
+	}}); err != nil {
+		t.Fatalf("UpsertModelPricing: %v", err)
+	}
+
+	ps, err := New(pgURL, "agentsview", local, "test-machine", true, SyncOptions{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer ps.Close()
+
+	if _, err := ps.Push(context.Background(), false); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	store, err := NewStore(pgURL, "agentsview", true)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	rows, err := store.DB().QueryContext(context.Background(), `
+		SELECT model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok
+		FROM model_pricing
+		WHERE model_pattern = 'test-model-sync'`)
+	if err != nil {
+		t.Fatalf("query pricing: %v", err)
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		t.Fatal("expected synced pricing row")
+	}
+	var (
+		model                                   string
+		input, output, cacheCreation, cacheRead float64
+	)
+	if err := rows.Scan(
+		&model, &input, &output, &cacheCreation, &cacheRead,
+	); err != nil {
+		t.Fatalf("scan pricing: %v", err)
+	}
+	if model != "test-model-sync" {
+		t.Fatalf("model = %q, want test-model-sync", model)
+	}
+	if input != 1.5 || output != 2.5 || cacheCreation != 3.5 || cacheRead != 0.5 {
+		t.Fatalf(
+			"pricing row = (%v,%v,%v,%v), want (1.5,2.5,3.5,0.5)",
+			input, output, cacheCreation, cacheRead,
+		)
+	}
+}
+
+func TestPushFallsBackToBuiltinPricingWhenLocalTableEmpty(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanPGSchema(t, pgURL)
+	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
+
+	local := testDB(t)
+	ps, err := New(pgURL, "agentsview", local, "test-machine", true, SyncOptions{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer ps.Close()
+
+	if _, err := ps.Push(context.Background(), false); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	store, err := NewStore(pgURL, "agentsview", true)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	rows, err := store.DB().QueryContext(context.Background(), `
+		SELECT model_pattern
+		FROM model_pricing
+		ORDER BY model_pattern`)
+	if err != nil {
+		t.Fatalf("query pricing: %v", err)
+	}
+	defer rows.Close()
+
+	var models []string
+	for rows.Next() {
+		var model string
+		if err := rows.Scan(&model); err != nil {
+			t.Fatalf("scan model: %v", err)
+		}
+		models = append(models, model)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows err: %v", err)
+	}
+	joined := strings.Join(models, ",")
+	if !strings.Contains(joined, "claude-sonnet-4-20250514") {
+		t.Fatalf("fallback pricing not synced: %s", joined)
+	}
+}

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -286,7 +286,7 @@ func TestPushSyncsModelPricingToPostgres(t *testing.T) {
 	}
 	defer ps.Close()
 
-	if _, err := ps.Push(context.Background(), false); err != nil {
+	if _, err := ps.Push(context.Background(), false, nil); err != nil {
 		t.Fatalf("Push: %v", err)
 	}
 
@@ -341,7 +341,7 @@ func TestPushFallsBackToBuiltinPricingWhenLocalTableEmpty(t *testing.T) {
 	}
 	defer ps.Close()
 
-	if _, err := ps.Push(context.Background(), false); err != nil {
+	if _, err := ps.Push(context.Background(), false, nil); err != nil {
 		t.Fatalf("Push: %v", err)
 	}
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -11,9 +11,9 @@ import (
 type contextKey int
 
 const (
-	// ctxKeyRemoteAuth indicates the request is from an authenticated
-	// remote client. When set to true, host-check and CORS middleware
-	// skip their restrictions.
+	// ctxKeyRemoteAuth indicates the request passed token auth.
+	// When set to true, host-check and CORS middleware skip
+	// their restrictions.
 	ctxKeyRemoteAuth contextKey = iota
 )
 
@@ -39,9 +39,9 @@ func isLocalhostRequest(r *http.Request) bool {
 	return ip.IsLoopback()
 }
 
-// authMiddleware enforces Bearer token authentication for remote
-// API requests. Localhost connections always bypass auth for backward
-// compatibility. Non-API routes (static assets) are never gated.
+// authMiddleware enforces Bearer token authentication when
+// require_auth is enabled. Non-API routes (static assets) are
+// never gated.
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Only gate /api/ routes — static assets are always served.
@@ -53,17 +53,16 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		// Read config once for all checks below.
 		s.mu.RLock()
 		token := s.cfg.AuthToken
-		remoteEnabled := s.cfg.RemoteAccess
+		authRequired := s.cfg.RequireAuth
 		s.mu.RUnlock()
 
 		// CORS preflight requests (OPTIONS) never include credentials.
 		// Let them through so the browser can negotiate CORS before
-		// sending the authenticated request. When remote access is
-		// enabled with a token, mark OPTIONS as remote-auth so the
-		// CORS middleware allows the preflight for cross-origin
-		// remote clients.
+		// sending the authenticated request. When auth is required,
+		// mark OPTIONS as authenticated so the CORS middleware
+		// allows the preflight for cross-origin clients.
 		if r.Method == http.MethodOptions {
-			if remoteEnabled && token != "" {
+			if authRequired && token != "" {
 				ctx := context.WithValue(r.Context(), ctxKeyRemoteAuth, true)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
@@ -72,33 +71,11 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// Localhost bypass: when remote access is disabled, local
-		// connections skip auth for backward compatibility. When
-		// remote access is enabled with a token, localhost must also
-		// authenticate — this prevents bypass via reverse proxy or
-		// SSH port-forward where remote clients appear as 127.0.0.1.
-		if isLocalhostRequest(r) {
-			if !remoteEnabled || token == "" {
-				next.ServeHTTP(w, r)
-				return
-			}
-			// Fall through to token check below.
-		}
-
-		// When remote access is not enabled, reject non-loopback
-		// requests outright. This prevents unauthenticated LAN
-		// access when the server is bound to 0.0.0.0. No CORS
-		// headers — cross-origin requests are not expected when
-		// remote access is off.
-		if !remoteEnabled {
-			http.Error(w, "Forbidden", http.StatusForbidden)
-			return
-		}
-		// Remote access enabled but no token configured yet — reject.
-		// No CORS headers — this is a server misconfiguration, not
-		// an auth challenge the client can resolve with a token.
-		if token == "" {
-			http.Error(w, "Forbidden", http.StatusForbidden)
+		// When auth is not required, skip token checks entirely.
+		// Users on private networks (Tailscale, VPN, LAN) don't
+		// need token auth; they opt in with require_auth=true.
+		if !authRequired || token == "" {
+			next.ServeHTTP(w, r)
 			return
 		}
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -72,10 +72,15 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		}
 
 		// When auth is not required, skip token checks entirely.
-		// Users on private networks (Tailscale, VPN, LAN) don't
-		// need token auth; they opt in with require_auth=true.
-		if !authRequired || token == "" {
+		if !authRequired {
 			next.ServeHTTP(w, r)
+			return
+		}
+		// Auth required but no token configured — fail closed.
+		if token == "" {
+			http.Error(w,
+				"server misconfiguration: auth required but no token set",
+				http.StatusInternalServerError)
 			return
 		}
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -276,7 +276,7 @@ func TestCSPMiddlewareSetsHeaderOnNonAPIRoutes(t *testing.T) {
 			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})
-			handler := cspMiddleware(tt.host, tt.port, tt.publicOrigins, tt.bindAllIPs, inner)
+			handler := cspMiddleware(tt.host, tt.port, tt.publicOrigins, tt.bindAllIPs, "", inner)
 
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			w := httptest.NewRecorder()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -382,7 +382,7 @@ func (s *Server) Handler() http.Handler {
 	if bindAll {
 		bindAllIPs = localInterfaceIPs()
 	}
-	h := cspMiddleware(s.cfg.Host, s.cfg.Port, s.cfg.PublicOrigins, bindAllIPs,
+	h := cspMiddleware(s.cfg.Host, s.cfg.Port, s.cfg.PublicOrigins, bindAllIPs, s.basePath,
 		s.authMiddleware(
 			hostCheckMiddleware(
 				allowedHosts, bindAll, s.cfg.Port, bindAllIPs,
@@ -422,8 +422,8 @@ func (s *Server) Handler() http.Handler {
 // responses. The policy pins the exact host:port origin so that
 // even if Tauri's compile-time CSP uses a wildcard port, the
 // intersection narrows to the actual runtime port.
-func cspMiddleware(host string, port int, publicOrigins []string, bindAllIPs map[string]bool, next http.Handler) http.Handler {
-	policy := buildCSPPolicy(host, port, publicOrigins, bindAllIPs)
+func cspMiddleware(host string, port int, publicOrigins []string, bindAllIPs map[string]bool, basePath string, next http.Handler) http.Handler {
+	policy := buildCSPPolicy(host, port, publicOrigins, bindAllIPs, basePath)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(r.URL.Path, "/api/") {
 			w.Header().Set("Content-Security-Policy", policy)
@@ -443,7 +443,7 @@ func cspMiddleware(host string, port int, publicOrigins []string, bindAllIPs map
 // resolve 'self' to the Go server origin after navigating from
 // tauri://localhost. Public origins and LAN IPs are restricted
 // to connect-src only to limit the script execution surface.
-func buildCSPPolicy(host string, port int, publicOrigins []string, bindAllIPs map[string]bool) string {
+func buildCSPPolicy(host string, port int, publicOrigins []string, bindAllIPs map[string]bool, basePath string) string {
 	// serverOrigin is the pinned http origin for the configured
 	// host:port, used in all directives so resources load
 	// correctly regardless of how the webview resolves 'self'.
@@ -506,6 +506,11 @@ func buildCSPPolicy(host string, port int, publicOrigins []string, bindAllIPs ma
 	connectParts = append(connectParts, connectWS...)
 	connectSrc := strings.Join(connectParts, " ")
 
+	baseURI := "'none'"
+	if basePath != "" {
+		baseURI = "'self'"
+	}
+
 	return fmt.Sprintf(
 		"default-src %[1]s; "+
 			"script-src %[1]s; "+
@@ -514,9 +519,9 @@ func buildCSPPolicy(host string, port int, publicOrigins []string, bindAllIPs ma
 			"style-src %[1]s 'unsafe-inline' https://fonts.googleapis.com; "+
 			"font-src %[1]s data: https://fonts.gstatic.com; "+
 			"object-src 'none'; "+
-			"base-uri 'none'; "+
+			"base-uri %[3]s; "+
 			"frame-ancestors 'none'",
-		resourceSrc, connectSrc,
+		resourceSrc, connectSrc, baseURI,
 	)
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1914,6 +1914,28 @@ func TestNoAuthWhenRemoteDisabled(t *testing.T) {
 	}
 }
 
+func TestAuthRequiredButNoToken(t *testing.T) {
+	te := setup(t, func(c *config.Config) {
+		c.Host = "0.0.0.0"
+		c.RequireAuth = true
+		// AuthToken intentionally left empty.
+	})
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/api/v1/stats", nil,
+	)
+	req.Host = "127.0.0.1:0"
+	w := httptest.NewRecorder()
+	te.srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf(
+			"expected 500 when auth required but no token, got %d",
+			w.Code,
+		)
+	}
+}
+
 func TestGetGithubConfig(t *testing.T) {
 	te := setup(t)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1576,8 +1576,8 @@ func TestHostHeaderBindAllPort80AllowsPortlessLANIP(t *testing.T) {
 			te := setup(t, func(c *config.Config) {
 				c.Host = bindHost
 				c.Port = 80
-				// LAN access now requires remote_access + auth token.
-				c.RemoteAccess = true
+				// LAN access requires require_auth + auth token.
+				c.RequireAuth = true
 				c.AuthToken = "test-token"
 			})
 
@@ -1693,8 +1693,8 @@ func TestHostHeaderBindAllAllowsLANIP(t *testing.T) {
 		t.Run(bindHost, func(t *testing.T) {
 			te := setup(t, func(c *config.Config) {
 				c.Host = bindHost
-				// LAN access now requires remote_access + auth token.
-				c.RemoteAccess = true
+				// LAN access requires require_auth + auth token.
+				c.RequireAuth = true
 				c.AuthToken = "test-token"
 			})
 
@@ -1837,7 +1837,7 @@ func TestCORSAllowMethods(t *testing.T) {
 func TestAuthErrorIncludesCORSHeaders(t *testing.T) {
 	te := setup(t, func(c *config.Config) {
 		c.Host = "0.0.0.0"
-		c.RemoteAccess = true
+		c.RequireAuth = true
 		c.AuthToken = "secret-token"
 	})
 
@@ -1864,7 +1864,7 @@ func TestAuthErrorIncludesCORSHeaders(t *testing.T) {
 func TestAuthErrorNoCORSWithoutOrigin(t *testing.T) {
 	te := setup(t, func(c *config.Config) {
 		c.Host = "0.0.0.0"
-		c.RemoteAccess = true
+		c.RequireAuth = true
 		c.AuthToken = "secret-token"
 	})
 
@@ -1887,27 +1887,29 @@ func TestAuthErrorNoCORSWithoutOrigin(t *testing.T) {
 	}
 }
 
-func TestForbiddenNoCORSWhenRemoteDisabled(t *testing.T) {
+func TestNoAuthWhenRemoteDisabled(t *testing.T) {
 	te := setup(t, func(c *config.Config) {
 		c.Host = "0.0.0.0"
-		// remote_access is false — non-loopback requests are
-		// rejected with 403 and no CORS headers.
+		// require_auth is false — auth is not enforced, so
+		// non-loopback requests pass through without a token.
 	})
 
 	req := httptest.NewRequest(
 		http.MethodGet, "/api/v1/stats", nil,
 	)
-	req.Header.Set("Origin", "http://192.168.1.50:8080")
+	// Use localhost Host header to pass host-check; the point
+	// of this test is that auth middleware doesn't block when
+	// require_auth is off.
+	req.Host = "127.0.0.1:0"
 	req.RemoteAddr = "192.168.1.50:9999"
 	w := httptest.NewRecorder()
 	te.srv.Handler().ServeHTTP(w, req)
-	assertStatus(t, w, http.StatusForbidden)
 
-	cors := w.Header().Get("Access-Control-Allow-Origin")
-	if cors != "" {
+	if w.Code == http.StatusForbidden ||
+		w.Code == http.StatusUnauthorized {
 		t.Fatalf(
-			"expected no CORS on 403 when remote disabled, got %q",
-			cors,
+			"expected no auth gate when remote disabled, got %d",
+			w.Code,
 		)
 	}
 }

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -16,7 +16,7 @@ type settingsResponse struct {
 	Host             string              `json:"host"`
 	Port             int                 `json:"port"`
 	AuthToken        string              `json:"auth_token,omitempty"`
-	RemoteAccess     bool                `json:"remote_access"`
+	RequireAuth      bool                `json:"require_auth"`
 }
 
 // terminalResponse mirrors config.TerminalConfig for JSON output.
@@ -59,7 +59,7 @@ func (s *Server) handleGetSettings(
 		GithubConfigured: s.cfg.GithubToken != "",
 		Host:             s.cfg.Host,
 		Port:             s.cfg.Port,
-		RemoteAccess:     s.cfg.RemoteAccess,
+		RequireAuth:      s.cfg.RequireAuth,
 	}
 
 	// Only expose auth_token to localhost requests, never to remote clients.
@@ -74,9 +74,9 @@ func (s *Server) handleGetSettings(
 // settingsUpdateRequest is the JSON body for PUT /api/v1/settings.
 // All fields are optional; only non-nil fields are applied.
 type settingsUpdateRequest struct {
-	Terminal     *terminalResponse `json:"terminal,omitempty"`
-	AuthToken    *string           `json:"auth_token,omitempty"`
-	RemoteAccess *bool             `json:"remote_access,omitempty"`
+	Terminal    *terminalResponse `json:"terminal,omitempty"`
+	AuthToken   *string           `json:"auth_token,omitempty"`
+	RequireAuth *bool             `json:"require_auth,omitempty"`
 }
 
 func (s *Server) handleUpdateSettings(
@@ -110,8 +110,8 @@ func (s *Server) handleUpdateSettings(
 		patch["auth_token"] = *req.AuthToken
 	}
 
-	if req.RemoteAccess != nil {
-		patch["remote_access"] = *req.RemoteAccess
+	if req.RequireAuth != nil {
+		patch["require_auth"] = *req.RequireAuth
 	}
 
 	if len(patch) == 0 {
@@ -122,8 +122,8 @@ func (s *Server) handleUpdateSettings(
 
 	s.mu.Lock()
 	err := s.cfg.SaveSettings(patch)
-	// Auto-generate auth token when remote_access is enabled.
-	if err == nil && s.cfg.RemoteAccess {
+	// Auto-generate auth token when require_auth is enabled.
+	if err == nil && s.cfg.RequireAuth {
 		err = s.cfg.EnsureAuthToken()
 	}
 	s.mu.Unlock()

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -36,8 +36,8 @@ func (f fakeFileInfo) Mode() os.FileMode { return 0 }
 func (f fakeFileInfo) ModTime() time.Time {
 	return time.Unix(0, f.mtime)
 }
-func (f fakeFileInfo) IsDir() bool      { return false }
-func (f fakeFileInfo) Sys() any         { return nil }
+func (f fakeFileInfo) IsDir() bool { return false }
+func (f fakeFileInfo) Sys() any    { return nil }
 
 func TestFilterEmptyMessages(t *testing.T) {
 	tests := []struct {
@@ -716,12 +716,12 @@ func TestApplyRemoteRewrites(t *testing.T) {
 					},
 				},
 			},
-			wantSessID:  "host~abc",
-			wantParent:  strPtr("host~parent-1"),
+			wantSessID:   "host~abc",
+			wantParent:   strPtr("host~parent-1"),
 			wantFilePath: strPtr("/tmp/file"),
-			wantMsgSess: "host~abc",
-			wantSubs:    []string{"host~sub-1", ""},
-			wantEvSubs:  []string{"host~ev-1", ""},
+			wantMsgSess:  "host~abc",
+			wantSubs:     []string{"host~sub-1", ""},
+			wantEvSubs:   []string{"host~ev-1", ""},
 		},
 		{
 			name:   "path rewriter applied",


### PR DESCRIPTION
Closes #326.

## Summary

- Add PostgreSQL-backed `/usage` queries for read-only mode
  (`GetDailyUsage`, `GetTopSessionsByCost`, `GetUsageSessionCounts`)
- Add additive PostgreSQL `model_pricing` schema support and sync
  pricing rows during `agentsview pg push`
- Fall back to built-in pricing rows on PG-backed viewers so
  already-deployed instances keep returning usage data before every
  host has pushed fresh pricing metadata
- Rename `remote_access` config to `require_auth` and make token
  auth opt-in instead of auto-enabled for non-loopback binds

## PG Usage

Closes the parity gap where session-level token fields were already
visible on PG-backed multi-host views, but the dedicated `/usage`
page returned `501 not available in remote mode`.

The implementation keeps the same high-level semantics as the SQLite
usage pipeline: timezone-aware date bucketing, Claude dedup by
`(claude_message_id, claude_request_id)`, include/exclude filters for
project/agent/model, per-day breakdowns, top-session ranking by
computed cost, and aligned session-count totals.

On the storage side, PostgreSQL gets an additive `model_pricing`
table. `pg push` syncs local pricing rows into PG before usage
queries run. PG viewers also overlay built-in fallback pricing so
upgraded read-only deployments remain usable before every exporter
has refreshed pricing data.

## Auth Rename

`remote_access` was a confusing name for token auth enablement, and
it auto-enabled whenever binding to a non-loopback address -- forcing
users on private networks (Tailscale, VPN, LAN) to deal with token
auth they don't need.

Changes:
- Renamed `remote_access` to `require_auth` across Go, TypeScript,
  and Svelte
- Auth is now opt-in: set `require_auth = true` in config or pass
  `--require-auth` on the CLI
- Legacy `remote_access` TOML key still recognized for backward
  compatibility (deleted from persisted config when `require_auth`
  is saved)
- Auto-bind to 0.0.0.0 skipped when managed Caddy proxy is active
  to preserve the loopback-backend invariant

## Upgrade / Rollout

- PostgreSQL: additive schema change only; no drop/recreate required
- Exporters: upgrade host binaries and run `agentsview pg push`
- PG-backed viewers can start serving `/usage` immediately after
  upgrading the reader binary
- Existing `remote_access = true` configs continue to work