### PR TITLE
fix(insights): correctly parse Claude Code CLI JSON array output

### DIFF
--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -245,16 +245,17 @@ func generateClaude(
 		)
 	}
 
-	var resp struct {
-		Result string `json:"result"`
-		Model  string `json:"model"`
-	}
-	if json.Unmarshal(stdoutBytes, &resp) == nil &&
-		strings.TrimSpace(resp.Result) != "" {
+	// Claude Code CLI outputs a JSON array of events when
+	// invoked with -p --output-format json. Find the element
+	// with type="result" and extract its result field.
+	// Also accept the legacy single-object format as a
+	// fallback for older Claude CLI versions.
+	content, model := parseCLIResult(stdoutBytes)
+	if strings.TrimSpace(content) != "" {
 		return Result{
-			Content: resp.Result,
+			Content: content,
 			Agent:   "claude",
-			Model:   resp.Model,
+			Model:   model,
 		}, nil
 	}
 
@@ -269,6 +270,45 @@ func generateClaude(
 		"claude returned empty result\nraw: %s",
 		string(stdoutBytes),
 	)
+}
+
+// parseCLIResult extracts the result text and model from
+// claude CLI output. Claude Code (v2+) outputs a JSON array
+// of events; we find type="result" and read its result field.
+// Falls back to the legacy single-object format for older
+// versions: {"result":"...","model":"..."}.
+func parseCLIResult(data []byte) (result, model string) {
+	// Try JSON array format (Claude Code v2+).
+	var events []json.RawMessage
+	if json.Unmarshal(data, &events) == nil {
+		for _, raw := range events {
+			var ev struct {
+				Type       string                     `json:"type"`
+				Result     string                     `json:"result"`
+				ModelUsage map[string]json.RawMessage `json:"modelUsage"`
+			}
+			if json.Unmarshal(raw, &ev) != nil {
+				continue
+			}
+			if ev.Type == "result" &&
+				strings.TrimSpace(ev.Result) != "" {
+				for name := range ev.ModelUsage {
+					model = name
+					break
+				}
+				return ev.Result, model
+			}
+		}
+	}
+	// Fall back to legacy single-object format.
+	var resp struct {
+		Result string `json:"result"`
+		Model  string `json:"model"`
+	}
+	if json.Unmarshal(data, &resp) == nil {
+		return resp.Result, resp.Model
+	}
+	return "", ""
 }
 
 // generateCodex invokes `codex exec` in read-only sandbox

--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -292,9 +293,13 @@ func parseCLIResult(data []byte) (result, model string) {
 			}
 			if ev.Type == "result" &&
 				strings.TrimSpace(ev.Result) != "" {
-				for name := range ev.ModelUsage {
-					model = name
-					break
+				if len(ev.ModelUsage) > 0 {
+					keys := make([]string, 0, len(ev.ModelUsage))
+					for k := range ev.ModelUsage {
+						keys = append(keys, k)
+					}
+					sort.Strings(keys)
+					model = keys[0]
 				}
 				return ev.Result, model
 			}

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -272,7 +272,7 @@ func TestGenerateClaude_CLIFlags(t *testing.T) {
 		t.Skip("shell script test not supported on windows")
 	}
 
-	stdout := `{"result":"OK","model":"m1"}`
+	stdout := `[{"type":"result","result":"OK","modelUsage":{"m1":{}}}]`
 	bin, argsFile := createMockBinary(
 		t, stdout, 0, true, "claude",
 	)
@@ -467,13 +467,13 @@ func TestGenerateClaude_SalvageOnNonZeroExit(t *testing.T) {
 	}{
 		{
 			name:       "non-zero exit with valid result",
-			stdout:     `{"result":"# Analysis\nDone.","model":"m1"}`,
+			stdout:     `[{"type":"result","result":"# Analysis\nDone.","modelUsage":{"m1":{}}}]`,
 			exitCode:   1,
 			wantResult: "# Analysis\nDone.",
 		},
 		{
 			name:     "non-zero exit with empty result",
-			stdout:   `{"result":"","model":"m1"}`,
+			stdout:   `[{"type":"result","result":"","modelUsage":{"m1":{}}}]`,
 			exitCode: 1,
 			wantErr:  true,
 		},
@@ -491,13 +491,13 @@ func TestGenerateClaude_SalvageOnNonZeroExit(t *testing.T) {
 		},
 		{
 			name:       "zero exit with valid result",
-			stdout:     `{"result":"OK","model":"m2"}`,
+			stdout:     `[{"type":"result","result":"OK","modelUsage":{"m2":{}}}]`,
 			exitCode:   0,
 			wantResult: "OK",
 		},
 		{
 			name:     "zero exit with empty result",
-			stdout:   `{"result":"","model":"m2"}`,
+			stdout:   `[{"type":"result","result":"","modelUsage":{"m2":{}}}]`,
 			exitCode: 0,
 			wantErr:  true,
 		},
@@ -605,7 +605,7 @@ func TestGenerateClaude_CancelledContext(t *testing.T) {
 	// Pre-cancelled context: cmd.Run fails (runErr != nil)
 	// and ctx.Err() != nil → cancellation error.
 	bin := fakeClaudeBin(
-		t, `{"result":"OK","model":"m1"}`, 0,
+		t, `[{"type":"result","result":"OK","modelUsage":{"m1":{}}}]`, 0,
 	)
 	ctx, cancel := context.WithCancel(
 		context.Background(),
@@ -626,7 +626,7 @@ func TestGenerateClaude_SuccessNotDiscarded(t *testing.T) {
 	// the context is not fresh (regression test for gating
 	// ctx.Err() on runErr != nil).
 	bin := fakeClaudeBin(
-		t, `{"result":"OK","model":"m1"}`, 0,
+		t, `[{"type":"result","result":"OK","modelUsage":{"m1":{}}}]`, 0,
 	)
 	result, err := generateClaude(
 		context.Background(), bin, "test", nil,
@@ -641,7 +641,7 @@ func TestGenerateClaude_SuccessNotDiscarded(t *testing.T) {
 
 func TestGenerateClaude_TruncatesLargeStdoutLogEvent(t *testing.T) {
 	largeResult := strings.Repeat("x", claudeStdoutLogMaxBytes*2)
-	stdout := fmt.Sprintf(`{"result":%q,"model":"m1"}`, largeResult)
+	stdout := fmt.Sprintf(`[{"type":"result","result":%q,"modelUsage":{"m1":{}}}]`, largeResult)
 	bin := fakeClaudeBin(t, stdout, 0)
 
 	var logs []LogEvent

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -639,6 +639,57 @@ func TestGenerateClaude_SuccessNotDiscarded(t *testing.T) {
 	}
 }
 
+func TestParseCLIResult(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantResult  string
+		wantModel   string
+	}{
+		{
+			name:       "array format with result event",
+			input:      `[{"type":"result","result":"# Summary","modelUsage":{"claude-3":{}}}]`,
+			wantResult: "# Summary",
+			wantModel:  "claude-3",
+		},
+		{
+			name:       "legacy single-object format",
+			input:      `{"result":"legacy result","model":"old-model"}`,
+			wantResult: "legacy result",
+			wantModel:  "old-model",
+		},
+		{
+			name:      "array with no result event",
+			input:     `[{"type":"system_prompt","content":"hello"},{"type":"turn","result":""}]`,
+			wantResult: "",
+			wantModel:  "",
+		},
+		{
+			name:      "empty input",
+			input:     ``,
+			wantResult: "",
+			wantModel:  "",
+		},
+		{
+			name:      "garbage input",
+			input:     `not json at all`,
+			wantResult: "",
+			wantModel:  "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, model := parseCLIResult([]byte(tc.input))
+			if result != tc.wantResult {
+				t.Errorf("result: got %q, want %q", result, tc.wantResult)
+			}
+			if model != tc.wantModel {
+				t.Errorf("model: got %q, want %q", model, tc.wantModel)
+			}
+		})
+	}
+}
+
 func TestGenerateClaude_TruncatesLargeStdoutLogEvent(t *testing.T) {
 	largeResult := strings.Repeat("x", claudeStdoutLogMaxBytes*2)
 	stdout := fmt.Sprintf(`[{"type":"result","result":%q,"modelUsage":{"m1":{}}}]`, largeResult)


### PR DESCRIPTION
## Problem (identified in #328)

The insights feature invokes the Claude Code CLI with `-p --output-format json`
to generate session summaries. Claude Code v2+ changed the output format from a
single JSON object to a **JSON array of events**, where the actual result is
carried in the element with `type: "result"`:

```json
[
  { "type": "system_prompt", ... },
  { "type": "turn", ... },
  { "type": "result", "result": "...", "modelUsage": { "claude-opus-4-5": {} } }
]
```

The previous parser expected the legacy single-object format:

```json
{ "result": "...", "model": "claude-opus-4-5" }
```

As a result, insight generation silently returned an empty result for any
installation running Claude Code v2+, falling through to the error path with a
confusing "no usable output" message.

## Solution

Extract the parsing logic into a dedicated `parseCLIResult` function that:

1. **Tries the JSON array format first** — iterates events, finds the element
   with `type: "result"`, reads its `result` field, and derives the model name
   from the first (sorted) key of `modelUsage`.
2. **Falls back to the legacy single-object format** — preserves compatibility
   with older Claude CLI versions that still emit `{"result":"...","model":"..."}`.

The model-name extraction from `modelUsage` sorts the keys before selecting so
the result is deterministic when multiple models are reported.

## Changes

- `internal/insight/generate.go` — replaced the inline JSON unmarshal with a
  call to `parseCLIResult`; added `parseCLIResult` with array-first / legacy
  fallback logic.
- `internal/insight/generate_test.go` — updated all existing test fixtures from
  the legacy format to the array format; added a new `TestParseCLIResult` table
  test covering both formats, edge cases (no result event, empty input, garbage
  input).

## Testing

All existing tests pass with the updated fixtures. The new `TestParseCLIResult`
test covers:

- Array format with a `result` event
- Legacy single-object format (backward compat)
- Array with no `result` event
- Empty input
- Non-JSON garbage input