### PR TITLE
fix: resolve ephemeral serve port

### DIFF
--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/wesm/agentsview/internal/config"
 )
 
 func TestMustLoadConfig(t *testing.T) {
@@ -78,6 +80,66 @@ func TestMustLoadConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrepareServeRuntimeConfigPortZeroUsesAssignedPort(t *testing.T) {
+	cfg := config.Config{
+		Host: "127.0.0.1",
+		Port: 0,
+	}
+
+	var err error
+	out := captureStdout(t, func() {
+		cfg, err = prepareServeRuntimeConfig(
+			cfg,
+			serveRuntimeOptions{
+				Mode:          "serve",
+				RequestedPort: 0,
+			},
+		)
+	})
+	if err != nil {
+		t.Fatalf("prepareServeRuntimeConfig: %v", err)
+	}
+	if cfg.Port == 0 {
+		t.Fatal("Port remained literal 0")
+	}
+	if strings.Contains(out, "Port 0 in use") {
+		t.Fatalf("unexpected literal port 0 fallback message: %q", out)
+	}
+	if !strings.Contains(out, "Using available port") {
+		t.Fatalf("missing ephemeral port message: %q", out)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = orig
+	})
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout pipe writer: %v", err)
+	}
+	os.Stdout = orig
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close stdout pipe reader: %v", err)
+	}
+	return string(data)
 }
 
 func TestSetupLogFile(t *testing.T) {

--- a/cmd/agentsview/serve_runtime.go
+++ b/cmd/agentsview/serve_runtime.go
@@ -35,7 +35,11 @@ func prepareServeRuntimeConfig(
 
 	port := server.FindAvailablePort(cfg.Host, cfg.Port)
 	if port != cfg.Port {
-		fmt.Printf("Port %d in use, using %d\n", cfg.Port, port)
+		if cfg.Port == 0 {
+			fmt.Printf("Using available port %d\n", port)
+		} else {
+			fmt.Printf("Port %d in use, using %d\n", cfg.Port, port)
+		}
 	}
 	cfg.Port = port
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -789,6 +789,18 @@ func (s *Server) Shutdown(ctx context.Context) error {
 // FindAvailablePort finds an available port starting from the
 // given port, binding to the specified host.
 func FindAvailablePort(host string, start int) int {
+	if start == 0 {
+		addr := net.JoinHostPort(host, "0")
+		ln, err := net.Listen("tcp", addr)
+		if err == nil {
+			defer ln.Close()
+			if tcpAddr, ok := ln.Addr().(*net.TCPAddr); ok {
+				return tcpAddr.Port
+			}
+		}
+		return start
+	}
+
 	for port := start; port < start+100; port++ {
 		addr := net.JoinHostPort(host, strconv.Itoa(port))
 		ln, err := net.Listen("tcp", addr)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2953,3 +2953,22 @@ func TestFindAvailablePortSkipsOccupied(t *testing.T) {
 	}
 	ln2.Close()
 }
+
+func TestFindAvailablePortZeroReturnsAssignedPort(t *testing.T) {
+	got := server.FindAvailablePort("127.0.0.1", 0)
+	if got == 0 {
+		t.Fatal("FindAvailablePort returned literal port 0")
+	}
+
+	// The returned ephemeral port should be bindable on the same host.
+	ln, err := net.Listen(
+		"tcp",
+		fmt.Sprintf("127.0.0.1:%d", got),
+	)
+	if err != nil {
+		t.Fatalf(
+			"returned port %d not bindable: %v", got, err,
+		)
+	}
+	ln.Close()
+}


### PR DESCRIPTION
## Summary
- resolve `--port 0` to the concrete OS-assigned TCP port before serve runtime readiness checks and state-file writes
- keep fixed-port collision fallback behavior unchanged
- add regression tests for the port helper and serve runtime startup message

## Root Cause
`FindAvailablePort` treated `:0` as successfully bindable but returned the requested value `0` instead of reading the assigned listener port. The serve runtime then continued to construct readiness checks, URLs, and state around the literal port `0`.

## Validation
- `make frontend`
- `go test -tags fts5 ./internal/server ./cmd/agentsview -count=1`
- `AGENT_VIEWER_DATA_DIR=$(mktemp -d)/data go run -tags fts5 ./cmd/agentsview --port 0 --no-sync --no-browser`