### PR TITLE
fix(frontend): only self-heal events store on transient failures

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -478,8 +478,22 @@ export function watchSession(
  */
 export const WATCH_EVENTS_MAX_CONSECUTIVE_ERRORS = 5;
 
+export interface WatchEventsOptions {
+  /** Called once when the circuit breaker trips WITHOUT the
+   * EventSource ever having reached the OPEN state. That pattern
+   * indicates the endpoint is permanently unreachable for this
+   * client (PG serve mode returning 503, incompatible server
+   * build, wrong URL, etc.), so callers should stop retrying.
+   * Transient failures — where `open` fired at least once before
+   * the breaker tripped — do not call this, letting callers
+   * recover on their own.
+   */
+  onPermanentFailure?: () => void;
+}
+
 export function watchEvents(
   onEvent: (e: DataChangedEvent) => void,
+  opts: WatchEventsOptions = {},
 ): EventSource {
   const url = `${getBase()}/events`;
   const token = getAuthToken();
@@ -489,20 +503,27 @@ export function watchEvents(
   const es = new EventSource(fullUrl);
 
   // Circuit breaker: on N consecutive onerror firings without any
-  // successful connection or event delivery, assume the endpoint
-  // is permanently unavailable (e.g. PG serve mode 503) and stop
-  // reconnecting. The counter resets on both `open` (a successful
-  // (re)connect) and a delivered `data_changed` event, so a quiet
-  // but healthy stream isn't tripped by transient network blips.
+  // successful connection or event delivery, close the stream.
+  // The counter resets on both `open` (a successful (re)connect)
+  // and a delivered `data_changed` event, so a quiet but healthy
+  // stream isn't tripped by transient network blips.
+  //
+  // `hasOpened` distinguishes "never worked" (permanent failure,
+  // e.g. PG serve 503) from "worked once, then failed" (transient
+  // outage). Permanent failures invoke onPermanentFailure so the
+  // caller can stop retrying.
   let consecutiveErrors = 0;
+  let hasOpened = false;
 
   es.addEventListener("open", () => {
+    hasOpened = true;
     consecutiveErrors = 0;
   });
 
   es.addEventListener("data_changed", (msg) => {
     // Successful delivery also resets the circuit breaker.
     consecutiveErrors = 0;
+    hasOpened = true;
     // Parse and shape-check the payload. Anything that isn't an
     // object with a known scope collapses to a safe refresh signal
     // so subscribers never observe scope === undefined.
@@ -532,6 +553,9 @@ export function watchEvents(
     consecutiveErrors += 1;
     if (consecutiveErrors >= WATCH_EVENTS_MAX_CONSECUTIVE_ERRORS) {
       es.close();
+      if (!hasOpened && opts.onPermanentFailure) {
+        opts.onPermanentFailure();
+      }
     }
   };
 

--- a/frontend/src/lib/stores/events.svelte.ts
+++ b/frontend/src/lib/stores/events.svelte.ts
@@ -17,15 +17,20 @@ class EventsStore {
   private healTimer: ReturnType<typeof setInterval> | null = null;
   // Sticky flag. When watchEvents reports a permanent failure
   // (circuit breaker tripped without the EventSource ever reaching
-  // OPEN — i.e., the endpoint is unreachable for this client, as in
-  // PG serve mode), stop rebuilding the connection. A page reload
-  // is required to recover if the backend configuration changes.
+  // OPEN — typical of PG serve mode's 503 but also possible for
+  // false positives: slow startup, tunnel handshake, transient
+  // network issue at mount time), stop rebuilding the connection.
+  // The flag clears when the subscriber set empties OR when the
+  // tab becomes visible again (giving a user-initiated retry
+  // window so false positives recover without a page reload).
   private permanentlyFailed = false;
+  private visibilityHandlerInstalled = false;
 
   /** Subscribe to every event. Returns unsubscribe. */
   subscribe(fn: Listener): () => void {
     const key = Symbol();
     this.listeners.set(key, fn);
+    this.installVisibilityHandler();
     this.ensureOpen();
     this.ensureHealTimer();
     return () => {
@@ -141,6 +146,33 @@ class EventsStore {
         this.ensureOpen();
       }
     }, EVENTS_STORE_HEAL_INTERVAL_MS);
+  }
+
+  // installVisibilityHandler wires a one-time document listener
+  // that gives permanently-failed SSE one more retry when the user
+  // refocuses the tab. This absorbs false-positive "permanent"
+  // classifications (slow startup, tunnel handshake, transient
+  // network hiccup at mount time) without running a periodic
+  // retry storm in the background. Installed lazily on first
+  // subscribe so module import has no global side effect.
+  private installVisibilityHandler() {
+    if (this.visibilityHandlerInstalled) return;
+    if (
+      typeof document === "undefined" ||
+      typeof document.addEventListener !== "function"
+    ) {
+      return;
+    }
+    this.visibilityHandlerInstalled = true;
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) return;
+      if (!this.permanentlyFailed) return;
+      if (this.listeners.size === 0) return;
+      this.permanentlyFailed = false;
+      this.es = null;
+      this.ensureOpen();
+      this.ensureHealTimer();
+    });
   }
 }
 

--- a/frontend/src/lib/stores/events.svelte.ts
+++ b/frontend/src/lib/stores/events.svelte.ts
@@ -15,6 +15,12 @@ class EventsStore {
   // each unsubscribe only removes its own entry.
   private listeners = new Map<symbol, Listener>();
   private healTimer: ReturnType<typeof setInterval> | null = null;
+  // Sticky flag. When watchEvents reports a permanent failure
+  // (circuit breaker tripped without the EventSource ever reaching
+  // OPEN — i.e., the endpoint is unreachable for this client, as in
+  // PG serve mode), stop rebuilding the connection. A page reload
+  // is required to recover if the backend configuration changes.
+  private permanentlyFailed = false;
 
   /** Subscribe to every event. Returns unsubscribe. */
   subscribe(fn: Listener): () => void {
@@ -61,6 +67,10 @@ class EventsStore {
   }
 
   private ensureOpen() {
+    // Don't retry once watchEvents has told us the endpoint is
+    // permanently unavailable. The safety-net polls on each view
+    // still keep data fresh in that mode.
+    if (this.permanentlyFailed) return;
     // watchEvents trips a circuit breaker and calls es.close() on
     // repeated errors; the store's cached handle then points at a
     // CLOSED EventSource. Treat that as "not open" and build a
@@ -75,9 +85,20 @@ class EventsStore {
     if (this.es !== null && this.es.readyState !== CLOSED) {
       return;
     }
-    this.es = watchEvents((e) => {
-      for (const fn of this.listeners.values()) fn(e);
-    });
+    this.es = watchEvents(
+      (e) => {
+        for (const fn of this.listeners.values()) fn(e);
+      },
+      {
+        onPermanentFailure: () => {
+          this.permanentlyFailed = true;
+          if (this.healTimer !== null) {
+            clearInterval(this.healTimer);
+            this.healTimer = null;
+          }
+        },
+      },
+    );
   }
 
   private close() {
@@ -88,17 +109,26 @@ class EventsStore {
       clearInterval(this.healTimer);
       this.healTimer = null;
     }
+    // Reset permanent-failure state when the subscriber set empties.
+    // A fresh round of subscribers may succeed if the backend state
+    // has changed (e.g., the user navigated pages, a sidebar opened
+    // fresh, or the server was restarted between subscriptions).
+    this.permanentlyFailed = false;
   }
 
   // ensureHealTimer starts a periodic check that rebuilds the
   // shared EventSource when it has been closed by the circuit
   // breaker but listeners are still registered. Without it, a
   // transient outage that trips the breaker would leave long-lived
-  // subscribers stuck until the page reloads.
+  // subscribers stuck until the page reloads. Permanent failures
+  // (endpoint never reached OPEN) disable the timer via
+  // permanentlyFailed so this never becomes a retry storm against
+  // a known-dead endpoint like PG serve's 503.
   private ensureHealTimer() {
     if (this.healTimer !== null) return;
+    if (this.permanentlyFailed) return;
     this.healTimer = setInterval(() => {
-      if (this.listeners.size === 0) {
+      if (this.listeners.size === 0 || this.permanentlyFailed) {
         if (this.healTimer !== null) {
           clearInterval(this.healTimer);
           this.healTimer = null;

--- a/frontend/src/lib/stores/events.test.ts
+++ b/frontend/src/lib/stores/events.test.ts
@@ -33,6 +33,12 @@ class FakeEventSource {
     (this.listeners[name] || []).forEach((cb) => cb(payload));
   }
 
+  fireOpen() {
+    (this.listeners["open"] || []).forEach((cb) =>
+      cb(new Event("open") as MessageEvent),
+    );
+  }
+
   static reset() {
     FakeEventSource.instances = [];
   }
@@ -101,7 +107,7 @@ describe("events store", () => {
     expect(FakeEventSource.instances[0]!.closed).toBe(true);
   });
 
-  it("self-heals a closed EventSource while listeners are still subscribed", async () => {
+  it("self-heals a closed EventSource after a transient failure", async () => {
     vi.useFakeTimers();
     const { events, EVENTS_STORE_HEAL_INTERVAL_MS } = await import(
       "./events.svelte.js"
@@ -110,9 +116,10 @@ describe("events store", () => {
     const unsub = events.subscribe((e) => received.push(e.scope));
     const first = FakeEventSource.instances[0]!;
 
-    // Trip the circuit breaker on the first connection; the long-
-    // lived subscriber never resubscribes, so without the heal
-    // timer it would be stuck on a closed stream.
+    // Simulate a transient failure: the stream opens successfully
+    // at least once, then later errors trip the circuit breaker.
+    // This is the "worked once, then failed" case that should heal.
+    first.fireOpen();
     for (let i = 0; i < 5; i++) first.fireError();
     expect(first.closed).toBe(true);
 
@@ -130,16 +137,40 @@ describe("events store", () => {
     vi.useRealTimers();
   });
 
-  it("reopens the EventSource after the circuit breaker closes it", async () => {
+  it("does not heal after a permanent failure (never opened)", async () => {
+    vi.useFakeTimers();
+    const { events, EVENTS_STORE_HEAL_INTERVAL_MS } = await import(
+      "./events.svelte.js"
+    );
+    const unsub = events.subscribe(() => {});
+    const first = FakeEventSource.instances[0]!;
+
+    // Permanent failure pattern: errors fire without any open ever
+    // succeeding (e.g. PG serve 503 on /api/v1/events). The circuit
+    // breaker trips AND marks the store permanentlyFailed, so no
+    // heal timer rebuilds.
+    for (let i = 0; i < 5; i++) first.fireError();
+    expect(first.closed).toBe(true);
+
+    // Advance far past the heal interval. The store must NOT
+    // rebuild — doing so would reintroduce retry churn on an
+    // endpoint that has already been classified as unreachable.
+    await vi.advanceTimersByTimeAsync(EVENTS_STORE_HEAL_INTERVAL_MS * 3);
+    expect(FakeEventSource.instances.length).toBe(1);
+
+    unsub();
+    vi.useRealTimers();
+  });
+
+  it("reopens the EventSource after a transient close on new subscribe", async () => {
     const { events } = await import("./events.svelte.js");
     const received: string[] = [];
     const unsub = events.subscribe((e) => received.push(e.scope));
     const first = FakeEventSource.instances[0]!;
 
-    // Trip the circuit breaker on the first connection. watchEvents
-    // closes the ES after N consecutive onerror firings without a
-    // successful delivery; the FakeEventSource's fireError + close
-    // sequence simulates that permanent failure.
+    // Transient-close pattern: open fires once so the failure is
+    // classified as recoverable, then the breaker trips.
+    first.fireOpen();
     for (let i = 0; i < 5; i++) first.fireError();
     expect(first.closed).toBe(true);
     expect(first.readyState).toBe(2);


### PR DESCRIPTION
## Summary

The events store's heal timer added in #351 rebuilds the shared `EventSource` every 60s whenever it's in the CLOSED state. In PG serve mode (or any environment where `/api/v1/events` permanently returns 503), that turns into 5 failed requests every minute forever, defeating the circuit breaker's point of suppressing retry churn on known-dead endpoints.

This distinguishes permanent failure (circuit breaker trips without the `EventSource` ever reaching OPEN) from transient (worked once, later failed):

- `watchEvents` now accepts `opts.onPermanentFailure` and tracks a `hasOpened` flag. When the breaker trips with `hasOpened === false`, it calls the callback.
- The events store sets a sticky `permanentlyFailed` flag on that signal, clears the heal timer, and refuses to rebuild. The safety-net polls on each view still keep data fresh.
- Transient failures continue to heal every 60s.
- Flag clears when the subscriber set empties, so a fresh round of subscribers can retry after page/state changes.

Two tests added in `events.test.ts`: `does not heal after a permanent failure (never opened)` and `self-heals a closed EventSource after a transient failure` (the latter now calls `fireOpen()` first to classify as recoverable).