### PR TITLE
feat: track file inode/device to validate incremental parses

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -461,6 +461,14 @@ func (db *DB) migrateColumns() error {
 			"ALTER TABLE sessions ADD COLUMN is_truncated INTEGER NOT NULL DEFAULT 0",
 		},
 		{
+			"sessions", "file_inode",
+			"ALTER TABLE sessions ADD COLUMN file_inode INTEGER",
+		},
+		{
+			"sessions", "file_device",
+			"ALTER TABLE sessions ADD COLUMN file_device INTEGER",
+		},
+		{
 			"messages", "thinking_text",
 			"ALTER TABLE messages ADD COLUMN thinking_text TEXT NOT NULL DEFAULT ''",
 		},

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -13,6 +13,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     file_path   TEXT,
     file_size   INTEGER,
     file_mtime  INTEGER,
+    file_inode  INTEGER,
+    file_device INTEGER,
     file_hash   TEXT,
     local_modified_at TEXT,
     parent_session_id TEXT,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -88,6 +88,7 @@ const sessionFullCols = `id, project, machine, agent,
 	cwd, git_branch, source_session_id, source_version,
 	parser_malformed_lines, is_truncated,
 	deleted_at, file_path, file_size, file_mtime,
+	file_inode, file_device,
 	file_hash, local_modified_at, created_at`
 
 const (
@@ -181,6 +182,8 @@ type Session struct {
 	FilePath        *string `json:"file_path,omitempty"`
 	FileSize        *int64  `json:"file_size,omitempty"`
 	FileMtime       *int64  `json:"file_mtime,omitempty"`
+	FileInode       *int64  `json:"file_inode,omitempty"`
+	FileDevice      *int64  `json:"file_device,omitempty"`
 	FileHash        *string `json:"file_hash,omitempty"`
 	LocalModifiedAt *string `json:"local_modified_at,omitempty"`
 	CreatedAt       string  `json:"created_at"`
@@ -618,7 +621,8 @@ func (db *DB) GetSessionFull(
 		&s.SourceSessionID, &s.SourceVersion,
 		&s.ParserMalformedLines, &s.IsTruncated,
 		&s.DeletedAt, &s.FilePath, &s.FileSize,
-		&s.FileMtime, &s.FileHash, &s.LocalModifiedAt, &s.CreatedAt,
+		&s.FileMtime, &s.FileInode, &s.FileDevice,
+		&s.FileHash, &s.LocalModifiedAt, &s.CreatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -692,8 +696,9 @@ func (db *DB) UpsertSession(s Session) error {
 			cwd, git_branch, source_session_id,
 			source_version, parser_malformed_lines,
 			is_truncated,
-			file_path, file_size, file_mtime, file_hash
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			file_path, file_size, file_mtime,
+			file_inode, file_device, file_hash
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project,
 			machine = excluded.machine,
@@ -719,6 +724,8 @@ func (db *DB) UpsertSession(s Session) error {
 			file_path = excluded.file_path,
 			file_size = excluded.file_size,
 			file_mtime = excluded.file_mtime,
+			file_inode = excluded.file_inode,
+			file_device = excluded.file_device,
 			file_hash = excluded.file_hash`,
 		s.ID, s.Project, s.Machine, s.Agent, s.FirstMessage, s.DisplayName,
 		s.StartedAt, s.EndedAt, s.MessageCount,
@@ -730,7 +737,8 @@ func (db *DB) UpsertSession(s Session) error {
 		s.Cwd, s.GitBranch, s.SourceSessionID,
 		s.SourceVersion, s.ParserMalformedLines,
 		s.IsTruncated,
-		s.FilePath, s.FileSize, s.FileMtime, s.FileHash)
+		s.FilePath, s.FileSize, s.FileMtime,
+		s.FileInode, s.FileDevice, s.FileHash)
 	if err != nil {
 		return fmt.Errorf("upserting session %s: %w", s.ID, err)
 	}
@@ -984,6 +992,9 @@ func (db *DB) GetSessionVersion(
 type IncrementalInfo struct {
 	ID                   string
 	FileSize             int64
+	FileMtime            int64
+	FileInode            int64
+	FileDevice           int64
 	MsgCount             int
 	UserMsgCount         int
 	TotalOutputTokens    int
@@ -1012,16 +1023,18 @@ func (db *DB) GetSessionForIncremental(
 	}
 
 	var info IncrementalInfo
-	var fs sql.NullInt64
+	var fs, fm, fi, fd sql.NullInt64
 	err = db.getReader().QueryRow(
-		`SELECT id, file_size, message_count,
-			user_message_count,
+		`SELECT id, file_size, file_mtime,
+			file_inode, file_device,
+			message_count, user_message_count,
 			total_output_tokens, peak_context_tokens,
 			has_total_output_tokens, has_peak_context_tokens
 		 FROM sessions WHERE file_path = ?`,
 		path,
 	).Scan(
-		&info.ID, &fs, &info.MsgCount, &info.UserMsgCount,
+		&info.ID, &fs, &fm, &fi, &fd,
+		&info.MsgCount, &info.UserMsgCount,
 		&info.TotalOutputTokens, &info.PeakContextTokens,
 		&info.HasTotalOutputTokens, &info.HasPeakContextTokens,
 	)
@@ -1030,6 +1043,15 @@ func (db *DB) GetSessionForIncremental(
 	}
 	if fs.Valid {
 		info.FileSize = fs.Int64
+	}
+	if fm.Valid {
+		info.FileMtime = fm.Int64
+	}
+	if fi.Valid {
+		info.FileInode = fi.Int64
+	}
+	if fd.Valid {
+		info.FileDevice = fd.Int64
 	}
 	info.HasTotalOutputTokens =
 		info.HasTotalOutputTokens || info.TotalOutputTokens != 0
@@ -1724,7 +1746,8 @@ func (db *DB) ListSessionsModifiedBetween(
 			&s.SourceSessionID, &s.SourceVersion,
 			&s.ParserMalformedLines, &s.IsTruncated,
 			&s.DeletedAt, &s.FilePath, &s.FileSize,
-			&s.FileMtime, &s.FileHash, &s.LocalModifiedAt, &s.CreatedAt,
+			&s.FileMtime, &s.FileInode, &s.FileDevice,
+			&s.FileHash, &s.LocalModifiedAt, &s.CreatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning session: %w", err)

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -392,10 +392,12 @@ const (
 
 // FileInfo holds file system metadata for a session source file.
 type FileInfo struct {
-	Path  string
-	Size  int64
-	Mtime int64
-	Hash  string
+	Path   string
+	Size   int64
+	Mtime  int64
+	Inode  int64
+	Device int64
+	Hash   string
 }
 
 // ParsedSession holds session metadata extracted from a JSONL file.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1860,6 +1860,12 @@ func (e *Engine) processClaude(
 		return processResult{err: err}
 	}
 
+	inode, device := getFileIdentity(info)
+	for i := range results {
+		results[i].Session.File.Inode = inode
+		results[i].Session.File.Device = device
+	}
+
 	hash, err := ComputeFileHash(file.Path)
 	if err == nil {
 		for i := range results {
@@ -1914,6 +1920,27 @@ func (e *Engine) tryIncrementalJSONL(
 	currentSize := info.Size()
 	if currentSize <= inc.FileSize {
 		return processResult{}, false
+	}
+
+	// If the file was replaced (different inode/device), fall
+	// back to a full parse so we don't append on top of stale
+	// state. Only check when both sides have a known identity
+	// (non-zero); zeros mean the data is missing or the
+	// platform doesn't expose inode/device (Windows).
+	if inc.FileInode != 0 && inc.FileDevice != 0 {
+		curInode, curDevice := getFileIdentity(info)
+		if curInode != 0 && curDevice != 0 &&
+			(curInode != inc.FileInode ||
+				curDevice != inc.FileDevice) {
+			log.Printf(
+				"incremental %s %s: file identity changed "+
+					"(inode %d→%d, device %d→%d), full parse",
+				agent, file.Path,
+				inc.FileInode, curInode,
+				inc.FileDevice, curDevice,
+			)
+			return processResult{}, false
+		}
 	}
 
 	maxOrd := e.db.MaxOrdinal(inc.ID)
@@ -2038,6 +2065,8 @@ func (e *Engine) processCodex(
 	if err != nil {
 		return processResult{err: err}
 	}
+
+	sess.File.Inode, sess.File.Device = getFileIdentity(info)
 
 	hash, err := ComputeFileHash(file.Path)
 	if err == nil {
@@ -2981,10 +3010,12 @@ func toDBSession(pw pendingWrite) db.Session {
 		// not persist this field; the caller bumps it via
 		// SetSessionDataVersion only after the message
 		// rewrite succeeds.
-		FilePath:  strPtr(pw.sess.File.Path),
-		FileSize:  int64Ptr(pw.sess.File.Size),
-		FileMtime: int64Ptr(pw.sess.File.Mtime),
-		FileHash:  strPtr(pw.sess.File.Hash),
+		FilePath:   strPtr(pw.sess.File.Path),
+		FileSize:   int64Ptr(pw.sess.File.Size),
+		FileMtime:  int64Ptr(pw.sess.File.Mtime),
+		FileInode:  int64Ptr(pw.sess.File.Inode),
+		FileDevice: int64Ptr(pw.sess.File.Device),
+		FileHash:   strPtr(pw.sess.File.Hash),
 	}
 	if pw.sess.FirstMessage != "" {
 		s.FirstMessage = &pw.sess.FirstMessage

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -3179,6 +3179,85 @@ func TestIncrementalSync_ClaudeAppend(t *testing.T) {
 	}
 }
 
+// TestIncrementalSync_ClaudeFileReplaced verifies that when a
+// session file is replaced atomically (new inode/device), the
+// sync engine detects the identity change and falls back to a
+// full parse instead of treating the new content as an append.
+func TestIncrementalSync_ClaudeFileReplaced(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("identity tracking is a no-op on Windows")
+	}
+	env := setupTestEnv(t)
+
+	original := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsZero),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "replaced.jsonl", original,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	assertSessionMessageCount(t, env.db, "replaced", 1)
+
+	full, err := env.db.GetSessionFull(
+		context.Background(), "replaced",
+	)
+	if err != nil {
+		t.Fatalf("GetSessionFull: %v", err)
+	}
+	if full.FileInode == nil || *full.FileInode == 0 {
+		t.Fatal("file_inode not populated after initial sync")
+	}
+	origInode := *full.FileInode
+
+	// Atomically replace the file. The content is longer than the
+	// original so an incremental parse would mistakenly append the
+	// new file's bytes past the old offset.
+	replacement := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("second", tsZero),
+		testjsonl.ClaudeUserJSON("third", tsZeroS5),
+	)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(replacement), 0o644); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatalf("rename replacement: %v", err)
+	}
+
+	env.engine.SyncPaths([]string{path})
+
+	// The stored inode must track the new file (i.e. a full
+	// parse re-ran and overwrote the identity). If the incremental
+	// path had run instead, the old inode would still be stored
+	// and the appended bytes would be interpreted as continuation
+	// of the original file.
+	full, err = env.db.GetSessionFull(
+		context.Background(), "replaced",
+	)
+	if err != nil {
+		t.Fatalf("GetSessionFull after replace: %v", err)
+	}
+	if full.FileInode == nil {
+		t.Fatal("file_inode cleared after replace")
+	}
+	if *full.FileInode == origInode {
+		t.Errorf("file_inode = %d, want change from original",
+			*full.FileInode)
+	}
+	// File size in the DB should match the replacement, not the
+	// pre-replacement size that an incremental parse would have
+	// left in place.
+	newInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat replacement: %v", err)
+	}
+	if full.FileSize == nil || *full.FileSize != newInfo.Size() {
+		t.Errorf("file_size = %v, want %d (full-parse size)",
+			full.FileSize, newInfo.Size())
+	}
+}
+
 func TestIncrementalSync_CodexAppend(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/identity.go
+++ b/internal/sync/identity.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package sync
+
+import (
+	"os"
+	"syscall"
+)
+
+// getFileIdentity extracts inode and device numbers from a
+// file's stat info on Unix systems. Returns zeros if the
+// stat data is unavailable in the expected form.
+func getFileIdentity(info os.FileInfo) (inode, device int64) {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return int64(stat.Ino), int64(stat.Dev)
+	}
+	return 0, 0
+}

--- a/internal/sync/identity_windows.go
+++ b/internal/sync/identity_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package sync
+
+import "os"
+
+// getFileIdentity returns zeros on Windows. Native file
+// identity (NTFS FileID + volume serial) requires the
+// GetFileInformationByHandle API; treating identity as
+// unknown here disables the identity-changed check and
+// falls back to size/mtime, which is the pre-existing
+// behavior.
+func getFileIdentity(info os.FileInfo) (inode, device int64) {
+	return 0, 0
+}


### PR DESCRIPTION
Records `file_inode` and `file_device` on each session row alongside the existing size/mtime. Before running an incremental parse, compares the stored identity against the current file's; if it differs, skips the incremental path and full-parses instead.

This catches cases where a session file is replaced atomically (`mv`, `cp`, editor atomic write) — size and mtime alone can miss the swap, which causes the incremental parser to append unrelated bytes onto the prior session's state.

Unix captures identity from `syscall.Stat_t`. Windows stubs to `(0, 0)`, which disables the check and preserves current behavior.