### PR TITLE
feat(config): add configuration option for custom model pricing

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -297,9 +297,18 @@ func truncateLogFile(path string, limit int64) {
 	_ = os.Truncate(path, 0)
 }
 
-func mustOpenDB(cfg config.Config) *db.DB {
+func openDB(cfg config.Config) (*db.DB, error) {
 	applyClassifierConfig(cfg)
 	database, err := db.Open(cfg.DBPath)
+	if err != nil {
+		return nil, err
+	}
+	applyCustomPricing(database, cfg)
+	return database, nil
+}
+
+func mustOpenDB(cfg config.Config) *db.DB {
+	database, err := openDB(cfg)
 	if err != nil {
 		fatal("opening database: %v", err)
 	}

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -244,6 +244,10 @@ func runPGServe(appCfg config.Config, basePath string) {
 	}
 	defer store.Close()
 
+	if len(appCfg.CustomModelPricing) > 0 {
+		store.SetCustomPricing(appCfg.CustomModelPricing)
+	}
+
 	ctx, stop := signal.NotifyContext(
 		context.Background(),
 		os.Interrupt, syscall.SIGTERM,

--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -138,7 +138,7 @@ func openStatsService(
 		return nil, nil, fmt.Errorf("loading config: %w", err)
 	}
 	applyClassifierConfig(cfg)
-	d, err := db.Open(cfg.DBPath)
+	d, err := openDB(cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening db: %w", err)
 	}

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -144,6 +144,13 @@ func runUsageStatusline(cfg UsageStatuslineConfig) {
 	}
 }
 
+func applyCustomPricing(database *db.DB, cfg config.Config) {
+	if len(cfg.CustomModelPricing) == 0 {
+		return
+	}
+	database.SetCustomPricing(cfg.CustomModelPricing)
+}
+
 func openUsageDB() (*db.DB, config.Config) {
 	cfg, err := config.LoadMinimal()
 	if err != nil {
@@ -151,8 +158,7 @@ func openUsageDB() (*db.DB, config.Config) {
 		os.Exit(1)
 	}
 
-	applyClassifierConfig(cfg)
-	database, err := db.Open(cfg.DBPath)
+	database, err := openDB(cfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr,
 			"error opening database: %v\n", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,13 @@ type AutomatedConfig struct {
 	Prefixes []string `toml:"prefixes" json:"prefixes,omitempty"`
 }
 
+type CustomModelRate struct {
+	Input         float64 `json:"input" toml:"input"`
+	Output        float64 `json:"output" toml:"output"`
+	CacheCreation float64 `json:"cache_creation,omitempty" toml:"cache_creation"`
+	CacheRead     float64 `json:"cache_read,omitempty" toml:"cache_read"`
+}
+
 // Config holds all application configuration.
 type Config struct {
 	Host                 string          `json:"host" toml:"host"`
@@ -112,6 +119,8 @@ type Config struct {
 	// into a single trailing broadcast, bounding dashboard refetch
 	// work during bursts of sync activity. Zero disables coalescing.
 	EventsCoalesceInterval time.Duration `json:"events_coalesce_interval,omitempty" toml:"events_coalesce_interval"`
+
+	CustomModelPricing map[string]CustomModelRate `json:"custom_model_pricing,omitempty" toml:"custom_model_pricing"`
 
 	// HostExplicit is true when the user passed --host on the CLI.
 	// Used to prevent auto-bind to 0.0.0.0 when the user
@@ -342,21 +351,22 @@ func (c *Config) loadFile() error {
 	}
 
 	var file struct {
-		GithubToken                    string          `toml:"github_token"`
-		CursorSecret                   string          `toml:"cursor_secret"`
-		PublicURL                      string          `toml:"public_url"`
-		PublicOrigins                  []string        `toml:"public_origins"`
-		Proxy                          ProxyConfig     `toml:"proxy"`
-		WatchExcludePatterns           []string        `toml:"watch_exclude_patterns"`
-		ResultContentBlockedCategories []string        `toml:"result_content_blocked_categories"`
-		Terminal                       TerminalConfig  `toml:"terminal"`
-		AuthToken                      string          `toml:"auth_token"`
-		RequireAuth                    bool            `toml:"require_auth"`
-		RemoteAccess                   bool            `toml:"remote_access"`
-		DisableUpdateCheck             bool            `toml:"disable_update_check"`
-		PG                             PGConfig        `toml:"pg"`
-		Automated                      AutomatedConfig `toml:"automated"`
-		EventsCoalesceInterval         time.Duration   `toml:"events_coalesce_interval"`
+		GithubToken                    string                     `toml:"github_token"`
+		CursorSecret                   string                     `toml:"cursor_secret"`
+		PublicURL                      string                     `toml:"public_url"`
+		PublicOrigins                  []string                   `toml:"public_origins"`
+		Proxy                          ProxyConfig                `toml:"proxy"`
+		WatchExcludePatterns           []string                   `toml:"watch_exclude_patterns"`
+		ResultContentBlockedCategories []string                   `toml:"result_content_blocked_categories"`
+		Terminal                       TerminalConfig             `toml:"terminal"`
+		AuthToken                      string                     `toml:"auth_token"`
+		RequireAuth                    bool                       `toml:"require_auth"`
+		RemoteAccess                   bool                       `toml:"remote_access"`
+		DisableUpdateCheck             bool                       `toml:"disable_update_check"`
+		PG                             PGConfig                   `toml:"pg"`
+		Automated                      AutomatedConfig            `toml:"automated"`
+		EventsCoalesceInterval         time.Duration              `toml:"events_coalesce_interval"`
+		CustomModelPricing             map[string]CustomModelRate `toml:"custom_model_pricing"`
 	}
 	meta, err := toml.DecodeFile(path, &file)
 	if err != nil {
@@ -422,6 +432,9 @@ func (c *Config) loadFile() error {
 	}
 	if file.Automated.Prefixes != nil {
 		c.Automated.Prefixes = file.Automated.Prefixes
+	}
+	if len(file.CustomModelPricing) > 0 {
+		c.CustomModelPricing = file.CustomModelPricing
 	}
 
 	// Parse config-file dir arrays for agents that have a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1114,3 +1114,74 @@ func TestAutomatedPrefixesAbsentIsNil(t *testing.T) {
 		t.Errorf("expected nil, got %v", cfg.Automated.Prefixes)
 	}
 }
+
+func TestLoadFile_CustomModelPricing(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		want map[string]CustomModelRate
+	}{
+		{
+			name: "basic rates",
+			data: map[string]any{
+				"custom_model_pricing": map[string]CustomModelRate{
+					"acme-ultra-2.1": {Input: 2.0, Output: 8.0},
+				},
+			},
+			want: map[string]CustomModelRate{
+				"acme-ultra-2.1": {Input: 2.0, Output: 8.0},
+			},
+		},
+		{
+			name: "multiple models with cache rates",
+			data: map[string]any{
+				"custom_model_pricing": map[string]CustomModelRate{
+					"acme-ultra-2.1": {Input: 2.0, Output: 8.0, CacheCreation: 2.5, CacheRead: 0.2},
+					"acme-fast-2.1":  {Input: 0.8, Output: 4.0},
+				},
+			},
+			want: map[string]CustomModelRate{
+				"acme-ultra-2.1": {Input: 2.0, Output: 8.0, CacheCreation: 2.5, CacheRead: 0.2},
+				"acme-fast-2.1":  {Input: 0.8, Output: 4.0},
+			},
+		},
+		{
+			name: "empty map omitted",
+			data: map[string]any{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := setupTestEnv(t)
+			writeConfig(t, dir, tt.data)
+
+			cfg, err := LoadMinimal()
+			if err != nil {
+				t.Fatalf("LoadMinimal: %v", err)
+			}
+
+			if len(tt.want) == 0 {
+				if len(cfg.CustomModelPricing) != 0 {
+					t.Fatalf("expected nil/empty, got %v", cfg.CustomModelPricing)
+				}
+				return
+			}
+
+			if len(cfg.CustomModelPricing) != len(tt.want) {
+				t.Fatalf("got %d entries, want %d", len(cfg.CustomModelPricing), len(tt.want))
+			}
+			for model, wantRate := range tt.want {
+				got, ok := cfg.CustomModelPricing[model]
+				if !ok {
+					t.Errorf("missing model %q", model)
+					continue
+				}
+				if got != wantRate {
+					t.Errorf("model %q = %+v, want %+v", model, got, wantRate)
+				}
+			}
+		})
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -16,6 +16,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/wesm/agentsview/internal/config"
 	"github.com/wesm/agentsview/internal/parser"
 )
 
@@ -95,6 +96,8 @@ type DB struct {
 
 	cursorMu     sync.RWMutex
 	cursorSecret []byte
+
+	customPricing map[string]config.CustomModelRate
 }
 
 // getReader returns the current read-only connection pool.
@@ -110,6 +113,10 @@ func (db *DB) Path() string {
 
 // ReadOnly returns false for the local SQLite store.
 func (db *DB) ReadOnly() bool { return false }
+
+func (db *DB) SetCustomPricing(p map[string]config.CustomModelRate) {
+	db.customPricing = p
+}
 
 // SetCursorSecret updates the secret key used for cursor signing.
 func (db *DB) SetCursorSecret(secret []byte) {

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -221,7 +221,20 @@ func (db *DB) loadPricingMap(
 		}
 		out[pattern] = rates
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	for model, cp := range db.customPricing {
+		out[model] = modelRates{
+			input:         cp.Input,
+			output:        cp.Output,
+			cacheCreation: cp.CacheCreation,
+			cacheRead:     cp.CacheRead,
+		}
+	}
+
+	return out, nil
 }
 
 // paddedUTCBound pads a UTC timestamp by hours to cover timezone

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/wesm/agentsview/internal/config"
 )
 
 func TestGetDailyUsageEmpty(t *testing.T) {
@@ -1914,5 +1916,92 @@ func BenchmarkGetDailyUsage(b *testing.B) {
 		if err != nil {
 			b.Fatalf("GetDailyUsage: %v", err)
 		}
+	}
+}
+
+func TestGetDailyUsage_PricingPrecedence(t *testing.T) {
+	tests := []struct {
+		name     string
+		dbRates  []ModelPricing
+		custom   map[string]config.CustomModelRate
+		model    string
+		input    int // input tokens
+		output   int // output tokens
+		wantCost float64
+	}{
+		{
+			name:     "db pricing only",
+			dbRates:  []ModelPricing{{ModelPattern: "acme-ultra-2.1", InputPerMTok: 1.0, OutputPerMTok: 4.0}},
+			model:    "acme-ultra-2.1",
+			input:    1_000_000,
+			output:   100_000,
+			wantCost: 1.4, // 1M*$1/M + 100k*$4/M
+		},
+		{
+			name:    "custom overrides db for same model",
+			dbRates: []ModelPricing{{ModelPattern: "acme-ultra-2.1", InputPerMTok: 1.0, OutputPerMTok: 4.0}},
+			custom:  map[string]config.CustomModelRate{"acme-ultra-2.1": {Input: 2.0, Output: 8.0}},
+			model:   "acme-ultra-2.1",
+			input:   1_000_000,
+			output:  100_000,
+			wantCost: 2.8, // 1M*$2/M + 100k*$8/M
+		},
+		{
+			name:    "custom for unknown model, no db entry",
+			custom:  map[string]config.CustomModelRate{"my-custom-model": {Input: 1.5, Output: 6.0}},
+			model:   "my-custom-model",
+			input:   500_000,
+			output:  50_000,
+			wantCost: 1.05, // 500k*$1.5/M + 50k*$6/M
+		},
+		{
+			name:     "no pricing at all yields zero cost",
+			model:    "unknown-model",
+			input:    1_000_000,
+			output:   100_000,
+			wantCost: 0.0,
+		},
+		{
+			name:    "custom only affects targeted model",
+			dbRates: []ModelPricing{{ModelPattern: "db-model", InputPerMTok: 3.0, OutputPerMTok: 10.0}},
+			custom:  map[string]config.CustomModelRate{"other-model": {Input: 99.0, Output: 99.0}},
+			model:   "db-model",
+			input:   1_000_000,
+			output:  100_000,
+			wantCost: 4.0, // 1M*$3/M + 100k*$10/M -- db rates, not custom
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := testDB(t)
+			if len(tt.dbRates) > 0 {
+				requireNoError(t, d.UpsertModelPricing(tt.dbRates), "UpsertModelPricing")
+			}
+			if tt.custom != nil {
+				d.SetCustomPricing(tt.custom)
+			}
+
+			insertSession(t, d, "s1", "proj", func(s *Session) {
+				s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+			})
+			insertMessages(t, d, Message{
+				SessionID:  "s1",
+				Ordinal:    0,
+				Role:       "assistant",
+				Timestamp:  "2024-06-15T10:30:00Z",
+				Model:      tt.model,
+				TokenUsage: json.RawMessage(`{"input_tokens":` + strconv.Itoa(tt.input) + `,"output_tokens":` + strconv.Itoa(tt.output) + `}`),
+			})
+
+			result, err := d.GetDailyUsage(context.Background(), UsageFilter{
+				From: "2024-06-01", To: "2024-06-30",
+			})
+			requireNoError(t, err, "GetDailyUsage")
+
+			if math.Abs(result.Totals.TotalCost-tt.wantCost) > 0.01 {
+				t.Errorf("TotalCost = %.4f, want %.4f", result.Totals.TotalCost, tt.wantCost)
+			}
+		})
 	}
 }

--- a/internal/postgres/pricing.go
+++ b/internal/postgres/pricing.go
@@ -57,7 +57,20 @@ func (s *Store) loadPricingMap(
 	ctx context.Context,
 ) (map[string]modelRates, error) {
 	out := fallbackPricingMap()
+	if err := s.mergeDBPricing(ctx, out); err != nil {
+		return nil, err
+	}
+	s.applyCustomPricing(out)
+	return out, nil
+}
 
+// mergeDBPricing layers rows from the PG model_pricing table onto
+// out. A missing table is treated as "no DB overrides" so that
+// custom_model_pricing still applies on fresh PG installs where
+// `agentsview pg push` has not run yet.
+func (s *Store) mergeDBPricing(
+	ctx context.Context, out map[string]modelRates,
+) error {
 	rows, err := s.pg.QueryContext(
 		ctx,
 		`SELECT model_pattern, input_per_mtok,
@@ -67,11 +80,9 @@ func (s *Store) loadPricingMap(
 	)
 	if err != nil {
 		if isUndefinedTable(err) {
-			return out, nil
+			return nil
 		}
-		return nil, fmt.Errorf(
-			"querying pg pricing: %w", err,
-		)
+		return fmt.Errorf("querying pg pricing: %w", err)
 	}
 	defer rows.Close()
 
@@ -85,9 +96,7 @@ func (s *Store) loadPricingMap(
 			&p.CacheReadPerMTok,
 			&p.UpdatedAt,
 		); err != nil {
-			return nil, fmt.Errorf(
-				"scanning pg pricing: %w", err,
-			)
+			return fmt.Errorf("scanning pg pricing: %w", err)
 		}
 		if strings.HasPrefix(p.ModelPattern, "_") {
 			continue
@@ -100,12 +109,24 @@ func (s *Store) loadPricingMap(
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf(
-			"iterating pg pricing: %w", err,
-		)
+		return fmt.Errorf("iterating pg pricing: %w", err)
 	}
+	return nil
+}
 
-	return out, nil
+// applyCustomPricing overlays user-configured rates onto out, letting
+// custom entries win over both DB and fallback pricing for the same
+// model. Kept separate from loadPricingMap so unit tests can exercise
+// the override step without a live PostgreSQL connection.
+func (s *Store) applyCustomPricing(out map[string]modelRates) {
+	for model, cp := range s.customPricing {
+		out[model] = modelRates{
+			input:         cp.Input,
+			output:        cp.Output,
+			cacheCreation: cp.CacheCreation,
+			cacheRead:     cp.CacheRead,
+		}
+	}
 }
 
 func upsertModelPricing(

--- a/internal/postgres/pricing_pgtest_test.go
+++ b/internal/postgres/pricing_pgtest_test.go
@@ -1,0 +1,58 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/config"
+)
+
+// TestLoadPricingMapAppliesCustomWhenTableMissing covers the fresh-PG
+// case where `agentsview pg push` has not seeded model_pricing yet.
+// loadPricingMap must still honor config.CustomModelPricing on that
+// fallback path.
+func TestLoadPricingMapAppliesCustomWhenTableMissing(t *testing.T) {
+	_, store := prepareUsageSchema(
+		t, "agentsview_pricing_missing_table_test",
+	)
+
+	ctx := context.Background()
+	if _, err := store.DB().ExecContext(
+		ctx, `DROP TABLE model_pricing`,
+	); err != nil {
+		t.Fatalf("drop model_pricing: %v", err)
+	}
+
+	store.SetCustomPricing(map[string]config.CustomModelRate{
+		"acme-ultra-2.1": {Input: 9.0, Output: 18.0},
+	})
+
+	out, err := store.loadPricingMap(ctx)
+	if err != nil {
+		t.Fatalf("loadPricingMap: %v", err)
+	}
+
+	got, ok := out["acme-ultra-2.1"]
+	if !ok {
+		t.Fatalf("custom model missing from pricing map")
+	}
+	if math.Abs(got.input-9.0) > 0.001 {
+		t.Errorf("input = %.4f, want 9.0", got.input)
+	}
+	if math.Abs(got.output-18.0) > 0.001 {
+		t.Errorf("output = %.4f, want 18.0", got.output)
+	}
+
+	// Fallback pricing must still populate the map so real models
+	// continue to resolve when custom_model_pricing only covers a
+	// subset.
+	if len(out) < 2 {
+		t.Errorf(
+			"pricing map only has %d entries, expected fallback + custom",
+			len(out),
+		)
+	}
+}

--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -1,0 +1,62 @@
+package postgres
+
+import (
+	"math"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/config"
+	"github.com/wesm/agentsview/internal/db"
+)
+
+func TestCustomPricingOverridesPricingMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		dbPrices  []db.ModelPricing
+		custom    map[string]config.CustomModelRate
+		model     string
+		wantInput float64
+	}{
+		{
+			name:      "db pricing only",
+			dbPrices:  []db.ModelPricing{{ModelPattern: "acme-ultra-2.1", InputPerMTok: 1.0}},
+			model:     "acme-ultra-2.1",
+			wantInput: 1.0,
+		},
+		{
+			name:      "custom overrides db",
+			dbPrices:  []db.ModelPricing{{ModelPattern: "acme-ultra-2.1", InputPerMTok: 1.0}},
+			custom:    map[string]config.CustomModelRate{"acme-ultra-2.1": {Input: 9.0}},
+			model:     "acme-ultra-2.1",
+			wantInput: 9.0,
+		},
+		{
+			name:      "custom adds new model",
+			custom:    map[string]config.CustomModelRate{"new-model": {Input: 4.0}},
+			model:     "new-model",
+			wantInput: 4.0,
+		},
+		{
+			name:      "custom does not affect other models",
+			dbPrices:  []db.ModelPricing{{ModelPattern: "db-model", InputPerMTok: 2.0}},
+			custom:    map[string]config.CustomModelRate{"other": {Input: 99.0}},
+			model:     "db-model",
+			wantInput: 2.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Store{}
+			s.SetCustomPricing(tt.custom)
+			out := pricingRowsToMap(tt.dbPrices)
+			s.applyCustomPricing(out)
+			got, ok := out[tt.model]
+			if !ok {
+				t.Fatalf("model %q not in map", tt.model)
+			}
+			if math.Abs(got.input-tt.wantInput) > 0.001 {
+				t.Errorf("input = %.4f, want %.4f", got.input, tt.wantInput)
+			}
+		})
+	}
+}

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/wesm/agentsview/internal/config"
 	"github.com/wesm/agentsview/internal/db"
 )
 
@@ -21,6 +22,8 @@ type Store struct {
 	pg           *sql.DB
 	cursorMu     sync.RWMutex
 	cursorSecret []byte
+
+	customPricing map[string]config.CustomModelRate
 }
 
 // pgSessionCols is the column list for standard PG session

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/wesm/agentsview/internal/config"
 	"github.com/wesm/agentsview/internal/db"
 )
 
@@ -32,6 +33,10 @@ func (s *Store) DB() *sql.DB { return s.pg }
 // Close closes the underlying database connection.
 func (s *Store) Close() error {
 	return s.pg.Close()
+}
+
+func (s *Store) SetCustomPricing(p map[string]config.CustomModelRate) {
+	s.customPricing = p
 }
 
 // SetCursorSecret sets the HMAC key used for cursor signing.


### PR DESCRIPTION
Some agents expose model names that are not in the LiteLLM pricing catalog or the built-in fallback table (e.g. agent-specific aliases with dots in the name). These models show up as $0.00 in usage reports.

This adds a `[custom_model_pricing.<model>]` section to `config.toml` so users can set per-token rates for any model. Custom rates override LiteLLM and fallback entries for the same model name.

Tested locally: `make install`, added custom pricing in my config, ran `agentsview usage daily` — costs display correctly. Changing prices in config and re-running the command reflects the updated rates immediately.

Documentation: https://github.com/wesm/agentsview-docs/pull/28