### PR TITLE
Update Go to 1.26, fix arm64 desktop test flake and nilaway pre-commit hook

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   tests: true
+  go: "1.26"
   build-tags:
     - fts5
 linters:

--- a/Makefile
+++ b/Makefile
@@ -292,18 +292,21 @@ lint-golangci-ci: ensure-embed-dir
 	golangci-lint run ./...
 
 # Build a custom golangci-lint binary with the NilAway module plugin.
-# Unset GIT_* and clear GOFLAGS' VCS stamping so the inner `git clone`
-# and `go build` don't inherit the parent repo's git state. When
-# `make nilaway` runs from a pre-commit hook, git exports GIT_DIR and
-# GIT_INDEX_FILE pointing at the parent repo, which confuses both the
-# clone and the subsequent VCS-stamped build (exit 128).
+# Strip every repo-local Git env var (GIT_DIR, GIT_INDEX_FILE,
+# GIT_CONFIG_PARAMETERS, etc.) and disable VCS stamping so the inner
+# `git clone` and `go build` don't inherit the parent repo's state.
+# When `make nilaway` runs from a pre-commit hook, git exports those
+# vars pointing at the parent repo, which makes the clone and the
+# VCS-stamped build fail with exit 128. The list comes from
+# `git rev-parse --local-env-vars` so it tracks whatever Git considers
+# repo-local at runtime.
 nilaway-golangci-build:
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "golangci-lint not found. Install with: make lint-tools" >&2; \
 		exit 1; \
 	fi
-	env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE -u GIT_PREFIX \
-		GOFLAGS=-buildvcs=false \
+	@unset_args=$$(git rev-parse --local-env-vars 2>/dev/null | sed 's/^/-u /' | tr '\n' ' '); \
+	env $$unset_args GOFLAGS=-buildvcs=false \
 		golangci-lint custom --version "$(GOLANGCI_LINT_VERSION)" --name custom-gcl
 
 # Run NilAway through the custom golangci-lint module plugin.

--- a/Makefile
+++ b/Makefile
@@ -292,12 +292,19 @@ lint-golangci-ci: ensure-embed-dir
 	golangci-lint run ./...
 
 # Build a custom golangci-lint binary with the NilAway module plugin.
+# Unset GIT_* and clear GOFLAGS' VCS stamping so the inner `git clone`
+# and `go build` don't inherit the parent repo's git state. When
+# `make nilaway` runs from a pre-commit hook, git exports GIT_DIR and
+# GIT_INDEX_FILE pointing at the parent repo, which confuses both the
+# clone and the subsequent VCS-stamped build (exit 128).
 nilaway-golangci-build:
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "golangci-lint not found. Install with: make lint-tools" >&2; \
 		exit 1; \
 	fi
-	golangci-lint custom --version "$(GOLANGCI_LINT_VERSION)" --name custom-gcl
+	env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE -u GIT_PREFIX \
+		GOFLAGS=-buildvcs=false \
+		golangci-lint custom --version "$(GOLANGCI_LINT_VERSION)" --name custom-gcl
 
 # Run NilAway through the custom golangci-lint module plugin.
 nilaway: ensure-embed-dir nilaway-golangci-build

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ ______________________________________________________________________
 
 ## Development
 
-Requires Go 1.25+ (CGO), Node.js 22+.
+Requires Go 1.26+ (CGO), Node.js 22+.
 
 ```bash
 make dev            # Go server (dev mode)

--- a/cmd/agentsview/health_test.go
+++ b/cmd/agentsview/health_test.go
@@ -18,7 +18,7 @@ func TestGradeCell(t *testing.T) {
 		want string
 	}{
 		{"nil grade renders dash", nil, "-"},
-		{"empty grade renders dash", strPtr(""), "-"},
+		{"empty grade renders dash", new(""), "-"},
 		{"grade preserved", &a, "A"},
 	}
 	for _, tc := range tests {
@@ -181,7 +181,7 @@ func TestPrintHealthList(t *testing.T) {
 			Outcome:            "success",
 			HealthGrade:        &a,
 			ContextPressureMax: &pressure,
-			EndedAt:            strPtr("2026-04-15T20:48:24Z"),
+			EndedAt:            new("2026-04-15T20:48:24Z"),
 		},
 		{
 			ID:                 "def67890",
@@ -219,8 +219,8 @@ func TestPrintHealthDetail(t *testing.T) {
 		ID:                     "abc12345",
 		Project:                "agentsview",
 		Agent:                  "claude",
-		StartedAt:              strPtr("2026-04-15T20:48:24Z"),
-		EndedAt:                strPtr("2026-04-15T21:30:00Z"),
+		StartedAt:              new("2026-04-15T20:48:24Z"),
+		EndedAt:                new("2026-04-15T21:30:00Z"),
 		MessageCount:           42,
 		UserMessageCount:       12,
 		HealthGrade:            &a,
@@ -416,8 +416,6 @@ func TestResolveSessionIDCollisionBeyondTopFew(t *testing.T) {
 		t.Errorf("error %q lacks 'ambiguous'", err.Error())
 	}
 }
-
-func strPtr(s string) *string { return &s }
 
 func parseLocalDate(t *testing.T, ts string) string {
 	t.Helper()

--- a/cmd/agentsview/prune_test.go
+++ b/cmd/agentsview/prune_test.go
@@ -177,8 +177,8 @@ func TestConfirm(t *testing.T) {
 
 func TestWriteSummary(t *testing.T) {
 	sessions := []db.Session{
-		{ID: "s1", Project: "projA", FileSize: dbtest.Ptr(int64(1024))},
-		{ID: "s2", Project: "projA", FileSize: dbtest.Ptr(int64(2048))},
+		{ID: "s1", Project: "projA", FileSize: new(int64(1024))},
+		{ID: "s2", Project: "projA", FileSize: new(int64(2048))},
 		{ID: "s3", Project: "projB"},
 	}
 
@@ -260,7 +260,7 @@ func TestPrunerMaxMessagesCountsUserOnly(t *testing.T) {
 
 	pruner, buf := newTestPruner(t, d, "")
 	cfg := PruneConfig{
-		Filter: db.PruneFilter{MaxMessages: dbtest.Ptr(1)},
+		Filter: db.PruneFilter{MaxMessages: new(1)},
 		DryRun: true,
 	}
 
@@ -322,7 +322,7 @@ func TestPruner_PruneScenarios(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := dbtest.OpenTestDB(t)
 			dbtest.SeedSession(t, d, "s1", "test", func(s *db.Session) {
-				s.EndedAt = dbtest.Ptr("2024-01-01T00:00:00Z")
+				s.EndedAt = new("2024-01-01T00:00:00Z")
 				s.MessageCount = 0
 			})
 
@@ -364,7 +364,7 @@ func TestDeleteFilesRemovesFiles(t *testing.T) {
 	}
 
 	sessions := []db.Session{
-		{ID: "s1", FilePath: dbtest.Ptr(f)},
+		{ID: "s1", FilePath: new(f)},
 	}
 
 	removed, reclaimed := deleteFiles(sessions)
@@ -388,7 +388,7 @@ func TestDeleteFilesRemovesFiles(t *testing.T) {
 
 func TestDeleteFilesMissingFile(t *testing.T) {
 	sessions := []db.Session{
-		{ID: "s1", FilePath: dbtest.Ptr("/nonexistent/path/file.jsonl")},
+		{ID: "s1", FilePath: new("/nonexistent/path/file.jsonl")},
 	}
 
 	removed, reclaimed := deleteFiles(sessions)

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -103,8 +103,6 @@ func main() {
 	fmt.Printf("Fixture DB written to %s\n", *out)
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func createSessionFixture(
 	database *db.DB, spec sessionSpec,
 	index int, base time.Time,
@@ -122,17 +120,17 @@ func createSessionFixture(
 		Project:          spec.project,
 		Machine:          "test-machine",
 		Agent:            "claude",
-		StartedAt:        ptr(startedAt.Format(time.RFC3339Nano)),
-		EndedAt:          ptr(endedAt.Format(time.RFC3339Nano)),
+		StartedAt:        new(startedAt.Format(time.RFC3339Nano)),
+		EndedAt:          new(endedAt.Format(time.RFC3339Nano)),
 		MessageCount:     spec.msgCount,
 		UserMessageCount: spec.userMsgCount,
 		RelationshipType: spec.relationshipType,
 	}
 	if spec.parentSessionID != "" {
-		sess.ParentSessionID = ptr(spec.parentSessionID)
+		sess.ParentSessionID = new(spec.parentSessionID)
 	}
 	if spec.msgCount > 0 {
-		sess.FirstMessage = ptr(
+		sess.FirstMessage = new(
 			fmt.Sprintf("First message for %s", spec.project),
 		)
 	}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1373,10 +1373,29 @@ mod tests {
         // Result-returning variant so a CI flake prints the real
         // reason (spawn error, non-zero exit + stderr, timeout,
         // etc.) instead of an opaque "returned None".
-        let result = try_run_login_shell_env(
-            script_path.to_str().expect("script path utf-8"),
-            Duration::from_secs(10),
-        );
+        //
+        // Linux can return ETXTBSY (OS error 26) on execve when a
+        // parallel test thread's fork briefly holds a writable fd
+        // for the script we just wrote. Retry a few times on that
+        // race so cargo test -j N doesn't flake.
+        let mut attempts_left = 5;
+        let result = loop {
+            let result = try_run_login_shell_env(
+                script_path.to_str().expect("script path utf-8"),
+                Duration::from_secs(10),
+            );
+            match &result {
+                Err(LoginShellEnvError::Spawn(e)) if e.raw_os_error() == Some(26) => {
+                    attempts_left -= 1;
+                    if attempts_left == 0 {
+                        break result;
+                    }
+                    thread::sleep(Duration::from_millis(50));
+                    continue;
+                }
+                _ => break result,
+            }
+        };
         let removed = fs::remove_file(&script_path);
 
         let output = result.unwrap_or_else(|err| {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wesm/agentsview
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/internal/db/activity_test.go
+++ b/internal/db/activity_test.go
@@ -12,7 +12,7 @@ func TestGetSessionActivity(t *testing.T) {
 	err := d.UpsertSession(Session{
 		ID:        sid,
 		Agent:     "claude",
-		StartedAt: Ptr("2026-03-26T10:00:00Z"),
+		StartedAt: new("2026-03-26T10:00:00Z"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -59,8 +59,8 @@ func seedAnalyticsData(t *testing.T, d *DB) seedStats {
 		}
 
 		insertSession(t, d, sess.id, sess.project, func(s *Session) {
-			s.StartedAt = Ptr(sess.start)
-			s.EndedAt = Ptr(sess.end)
+			s.StartedAt = new(sess.start)
+			s.EndedAt = new(sess.end)
 			s.MessageCount = sess.msgs
 			s.Agent = sess.agent
 		})
@@ -536,12 +536,12 @@ func TestMostActiveTieBreak(t *testing.T) {
 
 	// Two projects with equal message counts
 	insertSession(t, d, "t1", "zebra", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+		s.StartedAt = new("2024-06-01T09:00:00Z")
 		s.MessageCount = 20
 		s.Agent = "claude"
 	})
 	insertSession(t, d, "t2", "alpha", func(s *Session) {
-		s.StartedAt = Ptr(tsMidYear)
+		s.StartedAt = new(tsMidYear)
 		s.MessageCount = 20
 		s.Agent = "claude"
 	})
@@ -598,7 +598,7 @@ func TestAnalyticsTimezone(t *testing.T) {
 
 	// Session at 2024-06-01T23:00:00Z = 2024-06-02 in UTC+5
 	insertSession(t, d, "tz1", "tz-project", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T23:00:00Z")
+		s.StartedAt = new("2024-06-01T23:00:00Z")
 		s.MessageCount = 10
 		s.Agent = "claude"
 	})
@@ -708,7 +708,7 @@ func TestConcentrationTopThree(t *testing.T) {
 	t.Run("OneProject", func(t *testing.T) {
 		d := testDB(t)
 		insertSession(t, d, "c1", "solo", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+			s.StartedAt = new("2024-06-01T09:00:00Z")
 			s.MessageCount = 50
 			s.Agent = "claude"
 		})
@@ -729,12 +729,12 @@ func TestConcentrationTopThree(t *testing.T) {
 	t.Run("TwoProjects", func(t *testing.T) {
 		d := testDB(t)
 		insertSession(t, d, "c1", "alpha", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+			s.StartedAt = new("2024-06-01T09:00:00Z")
 			s.MessageCount = 35
 			s.Agent = "claude"
 		})
 		insertSession(t, d, "c2", "beta", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T10:00:00Z")
+			s.StartedAt = new("2024-06-01T10:00:00Z")
 			s.MessageCount = 45
 			s.Agent = "claude"
 		})
@@ -813,7 +813,7 @@ func TestGetAnalyticsHourOfWeek(t *testing.T) {
 	// Seed sessions with known UTC times:
 	// 2024-06-01 is Saturday, 09:00 UTC
 	insertSession(t, d, "hw1", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+		s.StartedAt = new("2024-06-01T09:00:00Z")
 		s.MessageCount = 2
 		s.Agent = "claude"
 	})
@@ -832,7 +832,7 @@ func TestGetAnalyticsHourOfWeek(t *testing.T) {
 
 	// 23:00 UTC on a Saturday
 	insertSession(t, d, "hw2", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T23:00:00Z")
+		s.StartedAt = new("2024-06-01T23:00:00Z")
 		s.MessageCount = 1
 		s.Agent = "claude"
 	})
@@ -916,8 +916,8 @@ func TestGetAnalyticsSessionShape(t *testing.T) {
 
 	// Session with 10 messages, 1h duration
 	insertSession(t, d, "ss1", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T09:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T10:00:00Z")
+		s.StartedAt = new("2024-06-01T09:00:00Z")
+		s.EndedAt = new("2024-06-01T10:00:00Z")
 		s.MessageCount = 10
 		s.Agent = "claude"
 	})
@@ -939,7 +939,7 @@ func TestGetAnalyticsSessionShape(t *testing.T) {
 
 	// Session with 25 messages, no ended_at
 	insertSession(t, d, "ss2", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-02T10:00:00Z")
+		s.StartedAt = new("2024-06-02T10:00:00Z")
 		s.MessageCount = 25
 		s.Agent = "claude"
 	})
@@ -1064,7 +1064,7 @@ func insertConversation(t *testing.T, d *DB, id, proj, agent, start string, dela
 	clock := newTestClock(start)
 
 	insertSession(t, d, id, proj, func(s *Session) {
-		s.StartedAt = Ptr(start)
+		s.StartedAt = new(start)
 		s.MessageCount = len(delays)
 		s.Agent = agent
 		if len(delays) > 0 {
@@ -1072,7 +1072,7 @@ func insertConversation(t *testing.T, d *DB, id, proj, agent, start string, dela
 			for _, delay := range delays {
 				endClock.Next(delay)
 			}
-			s.EndedAt = Ptr(endClock.Now())
+			s.EndedAt = new(endClock.Now())
 		}
 	})
 
@@ -1179,7 +1179,7 @@ func TestGetAnalyticsVelocity_EdgeCases(t *testing.T) {
 	t.Run("EmptyTimestampsSkipped", func(t *testing.T) {
 		d := testDB(t)
 		insertSession(t, d, "v3", "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+			s.StartedAt = new("2024-06-01T09:00:00Z")
 			s.MessageCount = 2
 			s.Agent = "claude"
 		})
@@ -1197,7 +1197,7 @@ func TestGetAnalyticsVelocity_EdgeCases(t *testing.T) {
 	t.Run("AssistantBeforeUser", func(t *testing.T) {
 		d := testDB(t)
 		insertSession(t, d, "v4", "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+			s.StartedAt = new("2024-06-01T09:00:00Z")
 			s.MessageCount = 3
 			s.Agent = "claude"
 		})
@@ -1216,7 +1216,7 @@ func TestGetAnalyticsVelocity_EdgeCases(t *testing.T) {
 	t.Run("OrdinalVsTimestampSkew", func(t *testing.T) {
 		d := testDB(t)
 		insertSession(t, d, "v5", "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+			s.StartedAt = new("2024-06-01T09:00:00Z")
 			s.MessageCount = 3
 			s.Agent = "claude"
 		})
@@ -1235,7 +1235,7 @@ func TestGetAnalyticsVelocity_EdgeCases(t *testing.T) {
 	t.Run("NegativeDeltaClampsToZero", func(t *testing.T) {
 		d := testDB(t)
 		insertSession(t, d, "v6", "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+			s.StartedAt = new("2024-06-01T09:00:00Z")
 			s.MessageCount = 2
 			s.Agent = "claude"
 		})
@@ -1257,7 +1257,7 @@ func TestGetAnalyticsVelocity_ToolUsage(t *testing.T) {
 	t.Run("ToolCallsPerActiveMin", func(t *testing.T) {
 		d := testDB(t)
 		insertSession(t, d, "vt1", "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+			s.StartedAt = new("2024-06-01T09:00:00Z")
 			s.MessageCount = 4
 			s.Agent = "claude"
 		})
@@ -1285,7 +1285,7 @@ func TestGetAnalyticsVelocity_ToolUsage(t *testing.T) {
 	t.Run("ToolCallsByAgentBreakdown", func(t *testing.T) {
 		d := testDB(t)
 		insertSession(t, d, "vta1", "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+			s.StartedAt = new("2024-06-01T09:00:00Z")
 			s.MessageCount = 2
 			s.Agent = "claude"
 		})
@@ -1298,7 +1298,7 @@ func TestGetAnalyticsVelocity_ToolUsage(t *testing.T) {
 			},
 		)
 		insertSession(t, d, "vta2", "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T10:00:00Z")
+			s.StartedAt = new("2024-06-01T10:00:00Z")
 			s.MessageCount = 2
 			s.Agent = "codex"
 		})
@@ -1350,7 +1350,7 @@ func TestVelocityChunkedQuery(t *testing.T) {
 	for i := range n {
 		id := fmt.Sprintf("chunk-%d", i)
 		insertSession(t, d, id, "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+			s.StartedAt = new("2024-06-01T09:00:00Z")
 			s.MessageCount = 2
 			s.Agent = "claude"
 		})
@@ -1438,7 +1438,7 @@ func TestGetAnalyticsTools(t *testing.T) {
 
 	// Seed sessions with tool_calls.
 	insertSession(t, d, "t1", "alpha", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+		s.StartedAt = new("2024-06-01T09:00:00Z")
 		s.MessageCount = 3
 		s.Agent = "claude"
 	})
@@ -1461,7 +1461,7 @@ func TestGetAnalyticsTools(t *testing.T) {
 	insertMessages(t, d, m1, m2, m3)
 
 	insertSession(t, d, "t2", "beta", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-02T10:00:00Z")
+		s.StartedAt = new("2024-06-02T10:00:00Z")
 		s.MessageCount = 1
 		s.Agent = "codex"
 	})
@@ -1614,7 +1614,7 @@ func TestActivityToolAndThinkingCounts(t *testing.T) {
 	ctx := context.Background()
 
 	insertSession(t, d, "at1", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+		s.StartedAt = new("2024-06-01T09:00:00Z")
 		s.MessageCount = 3
 		s.Agent = "claude"
 	})
@@ -1799,8 +1799,8 @@ func TestTimeFilter(t *testing.T) {
 	// 2024-06-01 = Saturday (ISO dow 5)
 	// 2024-06-03 = Monday   (ISO dow 0)
 	insertSession(t, d, "tf1", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T09:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T10:00:00Z")
+		s.StartedAt = new("2024-06-01T09:00:00Z")
+		s.EndedAt = new("2024-06-01T10:00:00Z")
 		s.MessageCount = 2
 		s.Agent = "claude"
 	})
@@ -1818,8 +1818,8 @@ func TestTimeFilter(t *testing.T) {
 	)
 
 	insertSession(t, d, "tf2", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T14:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T15:00:00Z")
+		s.StartedAt = new("2024-06-01T14:00:00Z")
+		s.EndedAt = new("2024-06-01T15:00:00Z")
 		s.MessageCount = 1
 		s.Agent = "claude"
 	})
@@ -1830,8 +1830,8 @@ func TestTimeFilter(t *testing.T) {
 	})
 
 	insertSession(t, d, "tf3", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-03T09:00:00Z")
-		s.EndedAt = Ptr("2024-06-03T10:00:00Z")
+		s.StartedAt = new("2024-06-03T09:00:00Z")
+		s.EndedAt = new("2024-06-03T10:00:00Z")
 		s.MessageCount = 1
 		s.Agent = "claude"
 	})
@@ -1902,22 +1902,22 @@ func TestAnalyticsFilterAgentAndMinUserMessages(
 	ctx := context.Background()
 
 	insertSession(t, d, "c1", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T09:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T10:00:00Z")
+		s.StartedAt = new("2024-06-01T09:00:00Z")
+		s.EndedAt = new("2024-06-01T10:00:00Z")
 		s.MessageCount = 10
 		s.UserMessageCount = 5
 		s.Agent = "claude"
 	})
 	insertSession(t, d, "c2", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T11:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T12:00:00Z")
+		s.StartedAt = new("2024-06-01T11:00:00Z")
+		s.EndedAt = new("2024-06-01T12:00:00Z")
 		s.MessageCount = 4
 		s.UserMessageCount = 1
 		s.Agent = "claude"
 	})
 	insertSession(t, d, "x1", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T14:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T15:00:00Z")
+		s.StartedAt = new("2024-06-01T14:00:00Z")
+		s.EndedAt = new("2024-06-01T15:00:00Z")
 		s.MessageCount = 20
 		s.UserMessageCount = 8
 		s.Agent = "codex"
@@ -1980,8 +1980,8 @@ func TestAutonomyExcludesSystemMessages(t *testing.T) {
 
 	insertSession(t, d, "s1", "proj", func(s *Session) {
 		s.Agent = "zencoder"
-		s.StartedAt = Ptr(tsMidYear)
-		s.EndedAt = Ptr(tsMidYear)
+		s.StartedAt = new(tsMidYear)
+		s.EndedAt = new(tsMidYear)
 		s.MessageCount = 4
 	})
 
@@ -2025,8 +2025,8 @@ func TestActivityExcludesSystemUserMessages(t *testing.T) {
 
 	insertSession(t, d, "s1", "proj", func(s *Session) {
 		s.Agent = "zencoder"
-		s.StartedAt = Ptr(tsMidYear)
-		s.EndedAt = Ptr(tsMidYear)
+		s.StartedAt = new(tsMidYear)
+		s.EndedAt = new(tsMidYear)
 		s.MessageCount = 3
 	})
 
@@ -2091,14 +2091,14 @@ func TestGetAnalyticsSignals(t *testing.T) {
 	// UpsertSession only writes core fields; signal columns
 	// are written by UpdateSessionSignals.
 	insertSession(t, d, "sig1", "alpha", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T09:00:00Z")
+		s.StartedAt = new("2024-06-01T09:00:00Z")
 		s.MessageCount = 10
 		s.Agent = "claude"
 	})
 	cp1 := 0.6
 	updateSignals(t, d, "sig1", SessionSignalUpdate{
-		HealthScore:            Ptr(85),
-		HealthGrade:            Ptr("B"),
+		HealthScore:            new(85),
+		HealthGrade:            new("B"),
 		Outcome:                "completed",
 		OutcomeConfidence:      "high",
 		ToolFailureSignalCount: 2,
@@ -2107,14 +2107,14 @@ func TestGetAnalyticsSignals(t *testing.T) {
 		ContextPressureMax:     &cp1,
 	})
 	insertSession(t, d, "sig2", "alpha", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T14:00:00Z")
+		s.StartedAt = new("2024-06-01T14:00:00Z")
 		s.MessageCount = 5
 		s.Agent = "codex"
 	})
 	cp2 := 0.9
 	updateSignals(t, d, "sig2", SessionSignalUpdate{
-		HealthScore:            Ptr(45),
-		HealthGrade:            Ptr("D"),
+		HealthScore:            new(45),
+		HealthGrade:            new("D"),
 		Outcome:                "errored",
 		OutcomeConfidence:      "medium",
 		ToolFailureSignalCount: 5,
@@ -2123,7 +2123,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 		ContextPressureMax:     &cp2,
 	})
 	insertSession(t, d, "sig3", "beta", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-02T10:00:00Z")
+		s.StartedAt = new("2024-06-02T10:00:00Z")
 		s.MessageCount = 8
 		s.Agent = "claude"
 	})

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -36,8 +36,8 @@ func sessionSet(t *testing.T, d *DB) {
 		end := fmt.Sprintf("2024-06-0%dT11:00:00Z", i+1)
 		insertSession(t, d, fmt.Sprintf("s%d", i+1),
 			"proj", func(s *Session) {
-				s.StartedAt = Ptr(day)
-				s.EndedAt = Ptr(end)
+				s.StartedAt = new(day)
+				s.EndedAt = new(end)
 				s.MessageCount = mc
 			})
 	}
@@ -127,7 +127,9 @@ func testDB(t *testing.T) *DB {
 }
 
 // Ptr returns a pointer to v.
-func Ptr[T any](v T) *T { return &v }
+//
+//go:fix inline
+func Ptr[T any](v T) *T { return new(v) }
 
 // insertSession creates and upserts a session with sensible
 // defaults. Override any field via the opts functions.
@@ -308,7 +310,7 @@ func TestOpenDataVersionBump_PreservesData(t *testing.T) {
 		Machine:      "local",
 		Agent:        "codex",
 		MessageCount: 1,
-		FileMtime:    Ptr(int64(12345)),
+		FileMtime:    new(int64(12345)),
 	})
 	requireNoError(t, err, "insert session")
 	insertMessages(t, d,
@@ -784,9 +786,9 @@ func TestSessionCRUD(t *testing.T) {
 		Project:      "my_project",
 		Machine:      defaultMachine,
 		Agent:        defaultAgent,
-		FirstMessage: Ptr("Hello world"),
-		StartedAt:    Ptr(tsZero),
-		EndedAt:      Ptr(tsHour1),
+		FirstMessage: new("Hello world"),
+		StartedAt:    new(tsZero),
+		EndedAt:      new(tsHour1),
 		MessageCount: 5,
 	}
 
@@ -822,7 +824,7 @@ func TestSessionParentSessionID(t *testing.T) {
 
 	t.Run("UpsertWithParent", func(t *testing.T) {
 		insertSession(t, d, "child-1", "proj", func(s *Session) {
-			s.ParentSessionID = Ptr("parent-uuid")
+			s.ParentSessionID = new("parent-uuid")
 		})
 
 		got := requireSessionExists(t, d, "child-1")
@@ -889,45 +891,45 @@ func TestGetChildSessions(t *testing.T) {
 
 	// Insert a parent session.
 	insertSession(t, d, "parent-1", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T10:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T11:00:00Z")
+		s.StartedAt = new("2024-06-01T10:00:00Z")
+		s.EndedAt = new("2024-06-01T11:00:00Z")
 		s.MessageCount = 5
 	})
 
 	// Insert child sessions with different relationship types.
 	insertSession(t, d, "child-sub", "proj", func(s *Session) {
-		s.ParentSessionID = Ptr("parent-1")
+		s.ParentSessionID = new("parent-1")
 		s.RelationshipType = "subagent"
-		s.StartedAt = Ptr("2024-06-01T10:05:00Z")
-		s.EndedAt = Ptr("2024-06-01T10:10:00Z")
+		s.StartedAt = new("2024-06-01T10:05:00Z")
+		s.EndedAt = new("2024-06-01T10:10:00Z")
 		s.MessageCount = 3
 	})
 	insertSession(t, d, "child-fork", "proj", func(s *Session) {
-		s.ParentSessionID = Ptr("parent-1")
+		s.ParentSessionID = new("parent-1")
 		s.RelationshipType = "fork"
-		s.StartedAt = Ptr("2024-06-01T10:20:00Z")
-		s.EndedAt = Ptr("2024-06-01T10:30:00Z")
+		s.StartedAt = new("2024-06-01T10:20:00Z")
+		s.EndedAt = new("2024-06-01T10:30:00Z")
 		s.MessageCount = 2
 	})
 	insertSession(t, d, "child-cont", "proj", func(s *Session) {
-		s.ParentSessionID = Ptr("parent-1")
+		s.ParentSessionID = new("parent-1")
 		s.RelationshipType = "continuation"
-		s.StartedAt = Ptr("2024-06-01T10:10:00Z")
-		s.EndedAt = Ptr("2024-06-01T10:15:00Z")
+		s.StartedAt = new("2024-06-01T10:10:00Z")
+		s.EndedAt = new("2024-06-01T10:15:00Z")
 		s.MessageCount = 4
 	})
 	insertSession(t, d, "child-deleted", "proj", func(s *Session) {
-		s.ParentSessionID = Ptr("parent-1")
+		s.ParentSessionID = new("parent-1")
 		s.RelationshipType = "subagent"
-		s.StartedAt = Ptr("2024-06-01T10:07:00Z")
-		s.EndedAt = Ptr("2024-06-01T10:08:00Z")
+		s.StartedAt = new("2024-06-01T10:07:00Z")
+		s.EndedAt = new("2024-06-01T10:08:00Z")
 		s.MessageCount = 1
 	})
 	requireNoError(t, d.SoftDeleteSession("child-deleted"), "SoftDeleteSession")
 
 	// Insert an unrelated session (no parent).
 	insertSession(t, d, "unrelated", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T10:00:00Z")
+		s.StartedAt = new("2024-06-01T10:00:00Z")
 		s.MessageCount = 1
 	})
 
@@ -985,7 +987,7 @@ func TestListSessions(t *testing.T) {
 		insertSession(t, d,
 			fmt.Sprintf("session-%c", 'a'+i), "proj",
 			func(s *Session) {
-				s.EndedAt = Ptr(ea)
+				s.EndedAt = new(ea)
 				s.MessageCount = i + 1
 			},
 		)
@@ -1025,7 +1027,7 @@ func TestListSessionsPaginationNoDuplicates(t *testing.T) {
 	for i, ea := range times {
 		insertSession(t, d,
 			fmt.Sprintf("page-%c", 'a'+i), "proj",
-			func(s *Session) { s.EndedAt = Ptr(ea) },
+			func(s *Session) { s.EndedAt = new(ea) },
 		)
 	}
 
@@ -1066,16 +1068,16 @@ func TestListSessionsPaginationEmptyTimestamps(t *testing.T) {
 	// Empty-string ended_at/started_at should sort by
 	// created_at, same as NULL.
 	insertSession(t, d, "s-normal", "proj", func(s *Session) {
-		s.EndedAt = Ptr("2024-06-01T12:00:00Z")
-		s.StartedAt = Ptr("2024-06-01T10:00:00Z")
+		s.EndedAt = new("2024-06-01T12:00:00Z")
+		s.StartedAt = new("2024-06-01T10:00:00Z")
 	})
 	insertSession(t, d, "s-empty-ended", "proj", func(s *Session) {
-		s.EndedAt = Ptr("")
-		s.StartedAt = Ptr("2024-05-01T10:00:00Z")
+		s.EndedAt = new("")
+		s.StartedAt = new("2024-05-01T10:00:00Z")
 	})
 	insertSession(t, d, "s-both-empty", "proj", func(s *Session) {
-		s.EndedAt = Ptr("")
-		s.StartedAt = Ptr("")
+		s.EndedAt = new("")
+		s.StartedAt = new("")
 	})
 	insertSession(t, d, "s-null-ts", "proj")
 
@@ -1113,7 +1115,7 @@ func TestListSessionsProjectFilter(t *testing.T) {
 		ea := fmt.Sprintf("2024-01-01T00:00:0%dZ", i)
 		insertSession(t, d,
 			fmt.Sprintf("%s-%d", proj, i), proj,
-			func(s *Session) { s.EndedAt = Ptr(ea) },
+			func(s *Session) { s.EndedAt = new(ea) },
 		)
 	}
 
@@ -1127,15 +1129,15 @@ func TestListSessionsMachineMultiSelect(t *testing.T) {
 
 	insertSession(t, d, "s-local", "proj", func(s *Session) {
 		s.Machine = "local"
-		s.EndedAt = Ptr("2024-01-01T00:00:00Z")
+		s.EndedAt = new("2024-01-01T00:00:00Z")
 	})
 	insertSession(t, d, "s-remote", "proj", func(s *Session) {
 		s.Machine = "remote"
-		s.EndedAt = Ptr("2024-01-01T00:00:01Z")
+		s.EndedAt = new("2024-01-01T00:00:01Z")
 	})
 	insertSession(t, d, "s-other", "proj", func(s *Session) {
 		s.Machine = "other"
-		s.EndedAt = Ptr("2024-01-01T00:00:02Z")
+		s.EndedAt = new("2024-01-01T00:00:02Z")
 	})
 
 	page, err := d.ListSessions(
@@ -1771,7 +1773,7 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 	// Session with empty-string started_at — NULLIF should
 	// treat it the same as NULL.
 	insertSession(t, d, "s-empty-start", "proj", func(s *Session) {
-		s.StartedAt = Ptr("")
+		s.StartedAt = new("")
 	})
 	insertMessages(t, d, userMsg("s-empty-start", 0, "hey"))
 
@@ -1837,8 +1839,8 @@ func setupPruneData(t *testing.T, d *DB) {
 	t.Helper()
 	// s1: 2 user messages
 	insertSession(t, d, "s1", "spicytakes", func(s *Session) {
-		s.FirstMessage = Ptr("You are a code reviewer")
-		s.EndedAt = Ptr("2024-01-15T00:00:00Z")
+		s.FirstMessage = new("You are a code reviewer")
+		s.EndedAt = new("2024-01-15T00:00:00Z")
 		s.MessageCount = 2
 	})
 	b1 := &msgBuilder{id: "s1"}
@@ -1847,8 +1849,8 @@ func setupPruneData(t *testing.T, d *DB) {
 	insertMessages(t, d, b1.msgs...)
 	// s2: 2 user messages
 	insertSession(t, d, "s2", "spicytakes", func(s *Session) {
-		s.FirstMessage = Ptr("Analyze this blog post")
-		s.EndedAt = Ptr("2024-03-01T00:00:00Z")
+		s.FirstMessage = new("Analyze this blog post")
+		s.EndedAt = new("2024-03-01T00:00:00Z")
 		s.MessageCount = 2
 	})
 	b2 := &msgBuilder{id: "s2"}
@@ -1857,8 +1859,8 @@ func setupPruneData(t *testing.T, d *DB) {
 	insertMessages(t, d, b2.msgs...)
 	// s3: 2 user messages
 	insertSession(t, d, "s3", "roborev", func(s *Session) {
-		s.FirstMessage = Ptr("You are a code reviewer")
-		s.EndedAt = Ptr("2024-03-01T00:00:00Z")
+		s.FirstMessage = new("You are a code reviewer")
+		s.EndedAt = new("2024-03-01T00:00:00Z")
 		s.MessageCount = 2
 	})
 	b3 := &msgBuilder{id: "s3"}
@@ -1867,8 +1869,8 @@ func setupPruneData(t *testing.T, d *DB) {
 	insertMessages(t, d, b3.msgs...)
 	// s4: 5 user messages + 5 assistant messages = 10 total
 	insertSession(t, d, "s4", "spicytakes", func(s *Session) {
-		s.FirstMessage = Ptr("Help me refactor")
-		s.EndedAt = Ptr("2024-06-01T00:00:00Z")
+		s.FirstMessage = new("Help me refactor")
+		s.EndedAt = new("2024-06-01T00:00:00Z")
 		s.MessageCount = 10
 	})
 	b4 := &msgBuilder{id: "s4"}
@@ -1901,7 +1903,7 @@ func TestFindPruneCandidates(t *testing.T) {
 		},
 		{
 			name:   "MaxMessages",
-			filter: PruneFilter{MaxMessages: Ptr(2)},
+			filter: PruneFilter{MaxMessages: new(2)},
 			want:   []string{"s1", "s2", "s3"},
 		},
 		{
@@ -1921,7 +1923,7 @@ func TestFindPruneCandidates(t *testing.T) {
 		{
 			name: "CombinedProjectAndMaxMessages",
 			filter: PruneFilter{
-				Project: "spicytakes", MaxMessages: Ptr(2),
+				Project: "spicytakes", MaxMessages: new(2),
 			},
 			want: []string{"s1", "s2"},
 		},
@@ -1929,7 +1931,7 @@ func TestFindPruneCandidates(t *testing.T) {
 			name: "AllFiltersNoMatch",
 			filter: PruneFilter{
 				Project:      "spicytakes",
-				MaxMessages:  Ptr(2),
+				MaxMessages:  new(2),
 				Before:       "2024-02-01",
 				FirstMessage: "Analyze",
 			},
@@ -1975,8 +1977,8 @@ func TestFindPruneCandidates(t *testing.T) {
 	t.Run("ReturnsFileMetadata", func(t *testing.T) {
 		fp := "/path/to/file.jsonl"
 		insertSession(t, d, "s5", "test", func(s *Session) {
-			s.FilePath = Ptr(fp)
-			s.FileSize = Ptr(int64(4096))
+			s.FilePath = new(fp)
+			s.FileSize = new(int64(4096))
 		})
 		got, err := d.FindPruneCandidates(PruneFilter{
 			Project: "test",
@@ -2008,18 +2010,18 @@ func TestFindPruneCandidatesExcludesParents(t *testing.T) {
 
 	// Create a parent -> child chain.
 	insertSession(t, d, "parent1", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T10:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T11:00:00Z")
+		s.StartedAt = new("2024-06-01T10:00:00Z")
+		s.EndedAt = new("2024-06-01T11:00:00Z")
 	})
 	insertSession(t, d, "child1", "proj", func(s *Session) {
-		s.ParentSessionID = Ptr("parent1")
-		s.StartedAt = Ptr("2024-06-01T12:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T13:00:00Z")
+		s.ParentSessionID = new("parent1")
+		s.StartedAt = new("2024-06-01T12:00:00Z")
+		s.EndedAt = new("2024-06-01T13:00:00Z")
 	})
 	// A standalone session with no children.
 	insertSession(t, d, "standalone", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-01T14:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T15:00:00Z")
+		s.StartedAt = new("2024-06-01T14:00:00Z")
+		s.EndedAt = new("2024-06-01T15:00:00Z")
 	})
 
 	got, err := d.FindPruneCandidates(PruneFilter{
@@ -2046,14 +2048,14 @@ func TestFindPruneCandidatesLikeEscaping(t *testing.T) {
 	d := testDB(t)
 
 	insertSession(t, d, "e1", "my%project", func(s *Session) {
-		s.FirstMessage = Ptr("100% complete")
+		s.FirstMessage = new("100% complete")
 	})
 	insertSession(t, d, "e2", "my_project", func(s *Session) {
-		s.FirstMessage = Ptr("100% complete")
+		s.FirstMessage = new("100% complete")
 	})
 	insertSession(t, d, "e3", "myXproject")
 	insertSession(t, d, "e4", `my\project`, func(s *Session) {
-		s.FirstMessage = Ptr(`path\to\file`)
+		s.FirstMessage = new(`path\to\file`)
 	})
 
 	tests := []struct {
@@ -2144,7 +2146,7 @@ func TestFindPruneCandidatesMaxMessagesSentinel(t *testing.T) {
 	}{
 		{
 			name:   "ZeroMatchesOnlyZero",
-			filter: PruneFilter{MaxMessages: Ptr(0)},
+			filter: PruneFilter{MaxMessages: new(0)},
 			want:   1,
 		},
 		{
@@ -2167,7 +2169,7 @@ func TestFindPruneCandidatesMaxMessagesSentinel(t *testing.T) {
 	}
 
 	// Additional check: MaxMessages=0 returns m1 specifically.
-	got, err := d.FindPruneCandidates(PruneFilter{MaxMessages: Ptr(0)})
+	got, err := d.FindPruneCandidates(PruneFilter{MaxMessages: new(0)})
 	requireNoError(t, err, "FindPruneCandidates MaxMessages=0")
 	if len(got) != 1 {
 		t.Fatalf("MaxMessages 0: got %d results, want 1", len(got))
@@ -2193,7 +2195,7 @@ func TestFindPruneCandidatesIgnoresSystemMessages(t *testing.T) {
 
 	// MaxMessages=1 should include zen1 (1 real user msg).
 	got, err := d.FindPruneCandidates(
-		PruneFilter{MaxMessages: Ptr(1)},
+		PruneFilter{MaxMessages: new(1)},
 	)
 	requireNoError(t, err, "FindPruneCandidates")
 	if len(got) != 1 {
@@ -2206,7 +2208,7 @@ func TestFindPruneCandidatesIgnoresSystemMessages(t *testing.T) {
 	// MaxMessages=0 should NOT include zen1 (it has 1 real
 	// user message).
 	got, err = d.FindPruneCandidates(
-		PruneFilter{MaxMessages: Ptr(0)},
+		PruneFilter{MaxMessages: new(0)},
 	)
 	requireNoError(t, err, "FindPruneCandidates")
 	if len(got) != 0 {
@@ -2307,9 +2309,9 @@ func TestSessionFileInfo(t *testing.T) {
 	d := testDB(t)
 
 	insertSession(t, d, "s1", "p", func(s *Session) {
-		s.FileSize = Ptr(int64(1024))
-		s.FileMtime = Ptr(int64(1700000000))
-		s.FileHash = Ptr("abc123def456")
+		s.FileSize = new(int64(1024))
+		s.FileMtime = new(int64(1700000000))
+		s.FileHash = new("abc123def456")
 	})
 
 	gotSize, gotMtime, ok := d.GetSessionFileInfo("s1")
@@ -2335,14 +2337,14 @@ func TestGetSessionFull(t *testing.T) {
 
 	t.Run("AllMetadata", func(t *testing.T) {
 		insertSession(t, d, "full-1", "proj", func(s *Session) {
-			s.FirstMessage = Ptr("hello")
-			s.StartedAt = Ptr(tsZero)
-			s.EndedAt = Ptr(tsHour1)
+			s.FirstMessage = new("hello")
+			s.StartedAt = new(tsZero)
+			s.EndedAt = new(tsHour1)
 			s.MessageCount = 5
-			s.FilePath = Ptr("/tmp/session.jsonl")
-			s.FileSize = Ptr(int64(2048))
-			s.FileMtime = Ptr(int64(1700000000))
-			s.FileHash = Ptr("abc123")
+			s.FilePath = new("/tmp/session.jsonl")
+			s.FileSize = new(int64(2048))
+			s.FileMtime = new(int64(1700000000))
+			s.FileHash = new("abc123")
 		})
 
 		got, err := d.GetSessionFull(ctx, "full-1")
@@ -2355,13 +2357,13 @@ func TestGetSessionFull(t *testing.T) {
 			ID:                "full-1",
 			Project:           "proj",
 			MessageCount:      5,
-			FilePath:          Ptr("/tmp/session.jsonl"),
-			FileSize:          Ptr(int64(2048)),
-			FileMtime:         Ptr(int64(1700000000)),
-			FileHash:          Ptr("abc123"),
-			FirstMessage:      Ptr("hello"),
-			StartedAt:         Ptr(tsZero),
-			EndedAt:           Ptr(tsHour1),
+			FilePath:          new("/tmp/session.jsonl"),
+			FileSize:          new(int64(2048)),
+			FileMtime:         new(int64(1700000000)),
+			FileHash:          new("abc123"),
+			FirstMessage:      new("hello"),
+			StartedAt:         new(tsZero),
+			EndedAt:           new(tsHour1),
 			Machine:           defaultMachine,
 			Agent:             defaultAgent,
 			Outcome:           "unknown",
@@ -5287,18 +5289,18 @@ func TestGetSessionForIncremental(t *testing.T) {
 		Project:              "my-project",
 		Machine:              "test",
 		Agent:                "codex",
-		FirstMessage:         Ptr("hello world"),
-		StartedAt:            Ptr("2024-01-15T10:00:00Z"),
-		EndedAt:              Ptr("2024-01-15T10:30:00Z"),
+		FirstMessage:         new("hello world"),
+		StartedAt:            new("2024-01-15T10:00:00Z"),
+		EndedAt:              new("2024-01-15T10:30:00Z"),
 		MessageCount:         5,
 		UserMessageCount:     2,
 		TotalOutputTokens:    500,
 		PeakContextTokens:    1500,
 		HasTotalOutputTokens: true,
 		HasPeakContextTokens: true,
-		FilePath:             Ptr("/tmp/sessions/test.jsonl"),
-		FileSize:             Ptr(int64(4096)),
-		FileMtime:            Ptr(int64(999)),
+		FilePath:             new("/tmp/sessions/test.jsonl"),
+		FileSize:             new(int64(4096)),
+		FileMtime:            new(int64(999)),
 	}
 	requireNoError(t, d.UpsertSession(s), "upsert")
 
@@ -5353,8 +5355,8 @@ func TestGetSessionForIncremental(t *testing.T) {
 			requireNoError(t, d.UpsertSession(Session{
 				ID:       id,
 				Agent:    "claude",
-				FilePath: Ptr(path),
-				FileSize: Ptr(int64(8192)),
+				FilePath: new(path),
+				FileSize: new(int64(8192)),
 			}), "upsert "+id)
 		}
 		_, ok := d.GetSessionForIncremental(path)
@@ -5422,16 +5424,16 @@ func TestUpdateSessionIncremental(t *testing.T) {
 		Project:              "my-project",
 		Machine:              "test",
 		Agent:                "codex",
-		FirstMessage:         Ptr("hello"),
-		StartedAt:            Ptr("2024-01-15T10:00:00Z"),
+		FirstMessage:         new("hello"),
+		StartedAt:            new("2024-01-15T10:00:00Z"),
 		MessageCount:         3,
 		UserMessageCount:     1,
-		ParentSessionID:      Ptr("parent-1"),
+		ParentSessionID:      new("parent-1"),
 		RelationshipType:     "continuation",
-		FilePath:             Ptr("/tmp/sessions/update.jsonl"),
-		FileSize:             Ptr(int64(1024)),
-		FileMtime:            Ptr(int64(100)),
-		FileHash:             Ptr("abc123"),
+		FilePath:             new("/tmp/sessions/update.jsonl"),
+		FileSize:             new(int64(1024)),
+		FileMtime:            new(int64(100)),
+		FileHash:             new("abc123"),
 		TotalOutputTokens:    300,
 		PeakContextTokens:    1200,
 		HasTotalOutputTokens: true,

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -99,21 +99,21 @@ func TestSessionFilterActiveSince(t *testing.T) {
 
 	// Session that started and ended long ago.
 	insertSession(t, d, "old", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-01-01T10:00:00Z")
-		s.EndedAt = Ptr("2024-01-01T11:00:00Z")
+		s.StartedAt = new("2024-01-01T10:00:00Z")
+		s.EndedAt = new("2024-01-01T11:00:00Z")
 		s.MessageCount = 5
 	})
 
 	// Session that started long ago but ended recently.
 	insertSession(t, d, "recent-end", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-01-01T10:00:00Z")
-		s.EndedAt = Ptr("2024-06-03T10:00:00Z")
+		s.StartedAt = new("2024-01-01T10:00:00Z")
+		s.EndedAt = new("2024-06-03T10:00:00Z")
 		s.MessageCount = 5
 	})
 
 	// Session that started recently, no ended_at.
 	insertSession(t, d, "recent-start", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-06-03T08:00:00Z")
+		s.StartedAt = new("2024-06-03T08:00:00Z")
 		s.MessageCount = 5
 	})
 
@@ -299,7 +299,7 @@ func TestListSessionsExcludesRelationshipTypes(t *testing.T) {
 	// Fork session -- should be excluded.
 	insertSession(t, d, "fork1", "proj", func(s *Session) {
 		s.MessageCount = 5
-		s.ParentSessionID = Ptr("normal")
+		s.ParentSessionID = new("normal")
 		s.RelationshipType = "fork"
 	})
 
@@ -313,8 +313,8 @@ func TestIncludeChildrenBypassesFilters(t *testing.T) {
 	// Parent session: claude agent, dated 2024-06-01, 10 messages.
 	insertSession(t, d, "parent", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-01T10:00:00Z")
-		s.EndedAt = Ptr("2024-06-01T11:00:00Z")
+		s.StartedAt = new("2024-06-01T10:00:00Z")
+		s.EndedAt = new("2024-06-01T11:00:00Z")
 		s.MessageCount = 10
 		s.UserMessageCount = 5
 	})
@@ -322,22 +322,22 @@ func TestIncludeChildrenBypassesFilters(t *testing.T) {
 	// Subagent child: different agent, different date, 1 message.
 	insertSession(t, d, "child-sub", "proj", func(s *Session) {
 		s.Agent = "codex"
-		s.StartedAt = Ptr("2024-07-15T10:00:00Z")
-		s.EndedAt = Ptr("2024-07-15T11:00:00Z")
+		s.StartedAt = new("2024-07-15T10:00:00Z")
+		s.EndedAt = new("2024-07-15T11:00:00Z")
 		s.MessageCount = 1
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("parent")
+		s.ParentSessionID = new("parent")
 		s.RelationshipType = "subagent"
 	})
 
 	// Fork child: same agent but fewer messages than filter.
 	insertSession(t, d, "child-fork", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-02T10:00:00Z")
-		s.EndedAt = Ptr("2024-06-02T11:00:00Z")
+		s.StartedAt = new("2024-06-02T10:00:00Z")
+		s.EndedAt = new("2024-06-02T11:00:00Z")
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("parent")
+		s.ParentSessionID = new("parent")
 		s.RelationshipType = "fork"
 	})
 
@@ -401,7 +401,7 @@ func TestIncludeChildrenScopesToMatchingParent(t *testing.T) {
 		s.Agent = "codex"
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("parentA")
+		s.ParentSessionID = new("parentA")
 		s.RelationshipType = "subagent"
 	})
 
@@ -416,7 +416,7 @@ func TestIncludeChildrenScopesToMatchingParent(t *testing.T) {
 		s.Agent = "gemini"
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("parentB")
+		s.ParentSessionID = new("parentB")
 		s.RelationshipType = "subagent"
 	})
 
@@ -433,7 +433,7 @@ func TestIncludeChildrenScopesToMatchingParent(t *testing.T) {
 		s.Agent = "gemini"
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("parentC")
+		s.ParentSessionID = new("parentC")
 		s.RelationshipType = "subagent"
 	})
 
@@ -510,7 +510,7 @@ func TestIncludeChildrenExcludesOrphanSubagents(t *testing.T) {
 	insertSession(t, d, "root-sub", "proj", func(s *Session) {
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("root")
+		s.ParentSessionID = new("root")
 		s.RelationshipType = "subagent"
 	})
 
@@ -519,7 +519,7 @@ func TestIncludeChildrenExcludesOrphanSubagents(t *testing.T) {
 	insertSession(t, d, "orphan-sub", "proj", func(s *Session) {
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("missing-parent-id")
+		s.ParentSessionID = new("missing-parent-id")
 		s.RelationshipType = "subagent"
 	})
 
@@ -534,7 +534,7 @@ func TestIncludeChildrenExcludesOrphanSubagents(t *testing.T) {
 	insertSession(t, d, "auto-sub", "proj", func(s *Session) {
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("auto-root")
+		s.ParentSessionID = new("auto-root")
 		s.RelationshipType = "subagent"
 	})
 
@@ -542,7 +542,7 @@ func TestIncludeChildrenExcludesOrphanSubagents(t *testing.T) {
 	insertSession(t, d, "orphan-fork", "proj", func(s *Session) {
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("also-missing")
+		s.ParentSessionID = new("also-missing")
 		s.RelationshipType = "fork"
 	})
 
@@ -577,7 +577,7 @@ func TestIncludeChildrenKeepsNestedDescendants(t *testing.T) {
 		s.Agent = "claude"
 		s.MessageCount = 4
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("root")
+		s.ParentSessionID = new("root")
 		s.RelationshipType = "subagent"
 	})
 	// Fork spawned inside the subagent thread (depth-2).
@@ -585,7 +585,7 @@ func TestIncludeChildrenKeepsNestedDescendants(t *testing.T) {
 		s.Agent = "claude"
 		s.MessageCount = 3
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("sub")
+		s.ParentSessionID = new("sub")
 		s.RelationshipType = "fork"
 	})
 
@@ -620,14 +620,14 @@ func TestIncludeChildrenExcludesFilteredNestedRoots(t *testing.T) {
 		s.Agent = "codex"
 		s.MessageCount = 4
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("root")
+		s.ParentSessionID = new("root")
 		s.RelationshipType = "subagent"
 	})
 	insertSession(t, d, "nested-fork", "proj", func(s *Session) {
 		s.Agent = "codex"
 		s.MessageCount = 3
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("sub")
+		s.ParentSessionID = new("sub")
 		s.RelationshipType = "fork"
 	})
 
@@ -656,13 +656,13 @@ func TestIncludeChildrenNoFiltersExcludesOrphanChildren(t *testing.T) {
 	insertSession(t, d, "child", "proj", func(s *Session) {
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("root")
+		s.ParentSessionID = new("root")
 		s.RelationshipType = "subagent"
 	})
 	insertSession(t, d, "orphan", "proj", func(s *Session) {
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("nowhere")
+		s.ParentSessionID = new("nowhere")
 		s.RelationshipType = "subagent"
 	})
 
@@ -687,7 +687,7 @@ func TestIncludeChildrenExcludeOneShotAgent(t *testing.T) {
 		s.Agent = "codex"
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("root")
+		s.ParentSessionID = new("root")
 		s.RelationshipType = "subagent"
 	})
 	// One-shot fork (claude) — should be included via parent.
@@ -695,7 +695,7 @@ func TestIncludeChildrenExcludeOneShotAgent(t *testing.T) {
 		s.Agent = "claude"
 		s.MessageCount = 2
 		s.UserMessageCount = 1
-		s.ParentSessionID = Ptr("root")
+		s.ParentSessionID = new("root")
 		s.RelationshipType = "fork"
 	})
 	// One-shot standalone (not a child) — should be excluded.
@@ -751,8 +751,8 @@ func TestActiveSinceUsesEndedAtOverStartedAt(t *testing.T) {
 	// A date_from filter for June would miss it (started too early),
 	// but active_since should catch it via ended_at.
 	insertSession(t, d, "s1", "proj", func(s *Session) {
-		s.StartedAt = Ptr("2024-01-15T10:00:00Z")
-		s.EndedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-01-15T10:00:00Z")
+		s.EndedAt = new("2024-06-15T10:00:00Z")
 		s.MessageCount = 5
 	})
 

--- a/internal/db/insights_test.go
+++ b/internal/db/insights_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func ptr(s string) *string { return &s }
-
 func TestInsights_InsertAndGet(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
@@ -19,10 +17,10 @@ func TestInsights_InsertAndGet(t *testing.T) {
 		Type:     "daily_activity",
 		DateFrom: "2025-01-15",
 		DateTo:   "2025-01-15",
-		Project:  ptr("my-app"),
+		Project:  new("my-app"),
 		Agent:    "claude",
-		Model:    ptr("claude-sonnet-4-20250514"),
-		Prompt:   ptr("What happened today?"),
+		Model:    new("claude-sonnet-4-20250514"),
+		Prompt:   new("What happened today?"),
 		Content:  "# Summary\nStuff happened.",
 	}
 
@@ -100,10 +98,10 @@ func TestListInsights(t *testing.T) {
 
 	seedFiltersData := func(t *testing.T, d *DB) []int64 {
 		entries := []Insight{
-			{Type: "daily_activity", DateFrom: "2025-01-15", DateTo: "2025-01-15", Project: ptr("app-a"), Agent: "claude", Content: "Day 1 app-a"},
-			{Type: "daily_activity", DateFrom: "2025-01-15", DateTo: "2025-01-15", Project: ptr("app-b"), Agent: "claude", Content: "Day 1 app-b"},
+			{Type: "daily_activity", DateFrom: "2025-01-15", DateTo: "2025-01-15", Project: new("app-a"), Agent: "claude", Content: "Day 1 app-a"},
+			{Type: "daily_activity", DateFrom: "2025-01-15", DateTo: "2025-01-15", Project: new("app-b"), Agent: "claude", Content: "Day 1 app-b"},
 			{Type: "agent_analysis", DateFrom: "2025-01-15", DateTo: "2025-01-15", Agent: "claude", Content: "Analysis"},
-			{Type: "daily_activity", DateFrom: "2025-01-16", DateTo: "2025-01-16", Project: ptr("app-a"), Agent: "claude", Content: "Day 2 app-a"},
+			{Type: "daily_activity", DateFrom: "2025-01-16", DateTo: "2025-01-16", Project: new("app-a"), Agent: "claude", Content: "Day 2 app-a"},
 		}
 		var ids []int64
 		for _, s := range entries {

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -14,26 +14,26 @@ func TestSearch(t *testing.T) {
 	insertSession(t, d, "s1", "proj-a",
 		func(s *Session) {
 			s.Agent = "claude"
-			s.FirstMessage = Ptr("alpha beta gamma")
-			s.StartedAt = Ptr("2024-01-01T10:00:00Z")
-			s.EndedAt = Ptr("2024-01-01T11:00:00Z")
+			s.FirstMessage = new("alpha beta gamma")
+			s.StartedAt = new("2024-01-01T10:00:00Z")
+			s.EndedAt = new("2024-01-01T11:00:00Z")
 		},
 	)
 	// Session s2: newer ended_at, agent "codex"
 	insertSession(t, d, "s2", "proj-b",
 		func(s *Session) {
 			s.Agent = "codex"
-			s.FirstMessage = Ptr("alpha delta epsilon")
-			s.StartedAt = Ptr("2024-01-02T10:00:00Z")
-			s.EndedAt = Ptr("2024-01-02T11:00:00Z")
+			s.FirstMessage = new("alpha delta epsilon")
+			s.StartedAt = new("2024-01-02T10:00:00Z")
+			s.EndedAt = new("2024-01-02T11:00:00Z")
 		},
 	)
 	// Session s3: system messages only — should be excluded
 	insertSession(t, d, "s3", "proj-c",
 		func(s *Session) {
 			s.Agent = "claude"
-			s.StartedAt = Ptr("2024-01-03T10:00:00Z")
-			s.EndedAt = Ptr("2024-01-03T11:00:00Z")
+			s.StartedAt = new("2024-01-03T10:00:00Z")
+			s.EndedAt = new("2024-01-03T11:00:00Z")
 		},
 	)
 
@@ -55,10 +55,10 @@ func TestSearch(t *testing.T) {
 	insertSession(t, d, "s-sysonly-dn", "proj-sysonly",
 		func(s *Session) {
 			s.Agent = "claude"
-			s.DisplayName = Ptr("sysonlydnterm unique display")
-			s.FirstMessage = Ptr("no match here")
-			s.StartedAt = Ptr("2024-01-04T10:00:00Z")
-			s.EndedAt = Ptr("2024-01-04T11:00:00Z")
+			s.DisplayName = new("sysonlydnterm unique display")
+			s.FirstMessage = new("no match here")
+			s.StartedAt = new("2024-01-04T10:00:00Z")
+			s.EndedAt = new("2024-01-04T11:00:00Z")
 		},
 	)
 	sysonlyDN := userMsg("s-sysonly-dn", 0, "irrelevant content")
@@ -69,9 +69,9 @@ func TestSearch(t *testing.T) {
 	insertSession(t, d, "s-sysonly-fm", "proj-sysonly",
 		func(s *Session) {
 			s.Agent = "claude"
-			s.FirstMessage = Ptr("sysonlyfmterm unique first")
-			s.StartedAt = Ptr("2024-01-05T10:00:00Z")
-			s.EndedAt = Ptr("2024-01-05T11:00:00Z")
+			s.FirstMessage = new("sysonlyfmterm unique first")
+			s.StartedAt = new("2024-01-05T10:00:00Z")
+			s.EndedAt = new("2024-01-05T11:00:00Z")
 		},
 	)
 	sysonlyFM := userMsg("s-sysonly-fm", 0, "irrelevant content")
@@ -83,9 +83,9 @@ func TestSearch(t *testing.T) {
 	insertSession(t, d, "s-prefixonly", "proj-prefixonly",
 		func(s *Session) {
 			s.Agent = "claude"
-			s.DisplayName = Ptr("prefixonlydnterm unique display")
-			s.StartedAt = Ptr("2024-01-06T10:00:00Z")
-			s.EndedAt = Ptr("2024-01-06T11:00:00Z")
+			s.DisplayName = new("prefixonlydnterm unique display")
+			s.StartedAt = new("2024-01-06T10:00:00Z")
+			s.EndedAt = new("2024-01-06T11:00:00Z")
 		},
 	)
 	insertMessages(t, d, userMsg("s-prefixonly", 0,
@@ -245,9 +245,9 @@ func TestSearch(t *testing.T) {
 		// The name branch must strip those quotes before LIKE matching.
 		insertSession(t, d, "s6", "proj-f", func(s *Session) {
 			s.Agent = "claude"
-			s.StartedAt = Ptr("2024-01-06T10:00:00Z")
+			s.StartedAt = new("2024-01-06T10:00:00Z")
 		})
-		if err := d.RenameSession("s6", Ptr("unique phrase session")); err != nil {
+		if err := d.RenameSession("s6", new("unique phrase session")); err != nil {
 			t.Fatalf("RenameSession: %v", err)
 		}
 		insertMessages(t, d, userMsg("s6", 0, "no match here"))
@@ -274,9 +274,9 @@ func TestSearch(t *testing.T) {
 		// s4: display_name contains "uniquename", no messages match
 		insertSession(t, d, "s4", "proj-d", func(s *Session) {
 			s.Agent = "claude"
-			s.StartedAt = Ptr("2024-01-04T10:00:00Z")
+			s.StartedAt = new("2024-01-04T10:00:00Z")
 		})
-		if err := d.RenameSession("s4", Ptr("my uniquename session")); err != nil {
+		if err := d.RenameSession("s4", new("my uniquename session")); err != nil {
 			t.Fatalf("RenameSession: %v", err)
 		}
 		// message that does NOT contain "uniquename"
@@ -321,10 +321,10 @@ func TestSearch(t *testing.T) {
 		// s7: display_name is set to something else; only first_message matches
 		insertSession(t, d, "s7", "proj-g", func(s *Session) {
 			s.Agent = "claude"
-			s.FirstMessage = Ptr("firstmsgonlyterm present here")
-			s.StartedAt = Ptr("2024-01-07T10:00:00Z")
+			s.FirstMessage = new("firstmsgonlyterm present here")
+			s.StartedAt = new("2024-01-07T10:00:00Z")
 		})
-		if err := d.RenameSession("s7", Ptr("unrelated display name")); err != nil {
+		if err := d.RenameSession("s7", new("unrelated display name")); err != nil {
 			t.Fatalf("RenameSession: %v", err)
 		}
 		// message that does NOT contain the search term
@@ -356,9 +356,9 @@ func TestSearch(t *testing.T) {
 		// s5: display_name AND message content both contain "doublehit"
 		insertSession(t, d, "s5", "proj-e", func(s *Session) {
 			s.Agent = "claude"
-			s.StartedAt = Ptr("2024-01-05T10:00:00Z")
+			s.StartedAt = new("2024-01-05T10:00:00Z")
 		})
-		if err := d.RenameSession("s5", Ptr("doublehit session")); err != nil {
+		if err := d.RenameSession("s5", new("doublehit session")); err != nil {
 			t.Fatalf("RenameSession: %v", err)
 		}
 		insertMessages(t, d, userMsg("s5", 0, "doublehit in message too"))
@@ -418,8 +418,8 @@ func TestSearchDeduplicationManyMessages(t *testing.T) {
 
 	insertSession(t, d, "s1", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-01-01T10:00:00Z")
-		s.EndedAt = Ptr("2024-01-01T11:00:00Z")
+		s.StartedAt = new("2024-01-01T10:00:00Z")
+		s.EndedAt = new("2024-01-01T11:00:00Z")
 	})
 
 	// Insert enough messages to force multiple FTS5 internal segments.
@@ -715,8 +715,8 @@ func TestSearchPaginationStability(t *testing.T) {
 	for _, id := range []string{"stab-a", "stab-b", "stab-c"} {
 		insertSession(t, d, id, "proj-stab", func(s *Session) {
 			s.Agent = "claude"
-			s.StartedAt = Ptr("2024-06-01T12:00:00Z")
-			s.EndedAt = Ptr("2024-06-01T13:00:00Z")
+			s.StartedAt = new("2024-06-01T12:00:00Z")
+			s.EndedAt = new("2024-06-01T13:00:00Z")
 		})
 		insertMessages(t, d, userMsg(id, 0, "stability test keyword"))
 	}

--- a/internal/db/session_stats_test.go
+++ b/internal/db/session_stats_test.go
@@ -96,10 +96,10 @@ func insertSessionFixture(t *testing.T, d *DB, f sessionFixture) {
 		s.UserMessageCount = f.userMsgs
 		s.MessageCount = mc
 		if f.startedAt != "" {
-			s.StartedAt = Ptr(f.startedAt)
+			s.StartedAt = new(f.startedAt)
 		}
 		if endedAt != "" {
-			s.EndedAt = Ptr(endedAt)
+			s.EndedAt = new(endedAt)
 		}
 		s.PeakContextTokens = f.peakContext
 		s.HasPeakContextTokens = f.hasPeakContext
@@ -2128,7 +2128,7 @@ func TestGetSessionStats_Outcomes_Happy(t *testing.T) {
 	})
 	updateSignals(t, d, "s-a", SessionSignalUpdate{
 		Outcome:         "completed",
-		HealthGrade:     Ptr("A"),
+		HealthGrade:     new("A"),
 		ToolRetryCount:  1,
 		CompactionCount: 3,
 		EditChurnCount:  5,
@@ -2141,7 +2141,7 @@ func TestGetSessionStats_Outcomes_Happy(t *testing.T) {
 	})
 	updateSignals(t, d, "s-b", SessionSignalUpdate{
 		Outcome:         "completed",
-		HealthGrade:     Ptr("B"),
+		HealthGrade:     new("B"),
 		ToolRetryCount:  0,
 		CompactionCount: 1,
 		EditChurnCount:  0,
@@ -2154,7 +2154,7 @@ func TestGetSessionStats_Outcomes_Happy(t *testing.T) {
 	})
 	updateSignals(t, d, "s-c", SessionSignalUpdate{
 		Outcome:         "abandoned",
-		HealthGrade:     Ptr("C"),
+		HealthGrade:     new("C"),
 		ToolRetryCount:  3,
 		CompactionCount: 0,
 		EditChurnCount:  4,
@@ -2167,7 +2167,7 @@ func TestGetSessionStats_Outcomes_Happy(t *testing.T) {
 	})
 	updateSignals(t, d, "s-d", SessionSignalUpdate{
 		Outcome:         "errored",
-		HealthGrade:     Ptr("D"),
+		HealthGrade:     new("D"),
 		ToolRetryCount:  2,
 		CompactionCount: 2,
 		EditChurnCount:  6,
@@ -2258,7 +2258,7 @@ func TestGetSessionStats_Outcomes_NoClaude(t *testing.T) {
 	})
 	updateSignals(t, d, "cx1", SessionSignalUpdate{
 		Outcome:        "completed",
-		HealthGrade:    Ptr("A"),
+		HealthGrade:    new("A"),
 		ToolRetryCount: 5,
 	})
 

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -61,8 +61,8 @@ func TestListSessions_OutcomeFilter(t *testing.T) {
 		{"out-4", "completed"},
 	} {
 		insertSession(t, d, tc.id, "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T10:00:00Z")
-			s.EndedAt = Ptr("2024-06-01T11:00:00Z")
+			s.StartedAt = new("2024-06-01T10:00:00Z")
+			s.EndedAt = new("2024-06-01T11:00:00Z")
 			s.MessageCount = 5
 			s.UserMessageCount = 3
 		})
@@ -99,14 +99,14 @@ func TestListSessions_HealthGradeFilter(t *testing.T) {
 		{"hg-4", "A", 90},
 	} {
 		insertSession(t, d, tc.id, "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T10:00:00Z")
-			s.EndedAt = Ptr("2024-06-01T11:00:00Z")
+			s.StartedAt = new("2024-06-01T10:00:00Z")
+			s.EndedAt = new("2024-06-01T11:00:00Z")
 			s.MessageCount = 5
 			s.UserMessageCount = 3
 		})
 		err := d.UpdateSessionSignals(tc.id, SessionSignalUpdate{
-			HealthGrade: Ptr(tc.grade),
-			HealthScore: Ptr(tc.score),
+			HealthGrade: new(tc.grade),
+			HealthScore: new(tc.score),
 		})
 		if err != nil {
 			t.Fatalf("UpdateSessionSignals %s: %v", tc.id, err)
@@ -134,8 +134,8 @@ func TestListSessions_MinToolFailuresFilter(t *testing.T) {
 		{"tf-3", 7},
 	} {
 		insertSession(t, d, tc.id, "proj", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-01T10:00:00Z")
-			s.EndedAt = Ptr("2024-06-01T11:00:00Z")
+			s.StartedAt = new("2024-06-01T10:00:00Z")
+			s.EndedAt = new("2024-06-01T11:00:00Z")
 			s.MessageCount = 5
 			s.UserMessageCount = 3
 		})
@@ -148,16 +148,16 @@ func TestListSessions_MinToolFailuresFilter(t *testing.T) {
 	}
 
 	requireSessions(t, d, filterWith(func(f *SessionFilter) {
-		f.MinToolFailures = Ptr(3)
+		f.MinToolFailures = new(3)
 	}), []string{"tf-2", "tf-3"})
 
 	requireSessions(t, d, filterWith(func(f *SessionFilter) {
-		f.MinToolFailures = Ptr(5)
+		f.MinToolFailures = new(5)
 	}), []string{"tf-3"})
 
 	// Zero threshold returns all.
 	requireSessions(t, d, filterWith(func(f *SessionFilter) {
-		f.MinToolFailures = Ptr(0)
+		f.MinToolFailures = new(0)
 	}), []string{"tf-1", "tf-2", "tf-3"})
 }
 

--- a/internal/db/signals_test.go
+++ b/internal/db/signals_test.go
@@ -26,9 +26,9 @@ func TestUpdateSessionSignals(t *testing.T) {
 		FinalFailureStreak:     0,
 		SignalsPendingSince:    nil,
 		CompactionCount:        2,
-		ContextPressureMax:     Ptr(0.85),
-		HealthScore:            Ptr(72),
-		HealthGrade:            Ptr("B"),
+		ContextPressureMax:     new(0.85),
+		HealthScore:            new(72),
+		HealthGrade:            new("B"),
 	}
 	if err := d.UpdateSessionSignals("sig-1", update); err != nil {
 		t.Fatalf("UpdateSessionSignals: %v", err)
@@ -201,7 +201,7 @@ func TestPendingSignalSessions(t *testing.T) {
 	old := SessionSignalUpdate{
 		Outcome:             "unknown",
 		OutcomeConfidence:   "low",
-		SignalsPendingSince: Ptr("2024-06-01T10:00:00Z"),
+		SignalsPendingSince: new("2024-06-01T10:00:00Z"),
 	}
 	if err := d.UpdateSessionSignals("ps-old", old); err != nil {
 		t.Fatalf("UpdateSessionSignals ps-old: %v", err)
@@ -212,7 +212,7 @@ func TestPendingSignalSessions(t *testing.T) {
 	newer := SessionSignalUpdate{
 		Outcome:             "unknown",
 		OutcomeConfidence:   "low",
-		SignalsPendingSince: Ptr("2024-06-01T14:00:00Z"),
+		SignalsPendingSince: new("2024-06-01T14:00:00Z"),
 	}
 	if err := d.UpdateSessionSignals("ps-new", newer); err != nil {
 		t.Fatalf("UpdateSessionSignals ps-new: %v", err)

--- a/internal/db/token_usage_test.go
+++ b/internal/db/token_usage_test.go
@@ -484,9 +484,9 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 		PeakContextTokens:    8000,
 		HasTotalOutputTokens: true,
 		HasPeakContextTokens: true,
-		FilePath:             Ptr("/tmp/s.jsonl"),
-		FileSize:             Ptr(int64(2048)),
-		FileMtime:            Ptr(int64(100)),
+		FilePath:             new("/tmp/s.jsonl"),
+		FileSize:             new(int64(2048)),
+		FileMtime:            new(int64(100)),
 	}
 	requireNoError(t, d.UpsertSession(s), "upsert")
 

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -49,8 +49,8 @@ func TestGetDailyUsageWithData(t *testing.T) {
 
 	insertSession(t, d, "sess1", "proj1", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
-		s.EndedAt = Ptr("2024-06-15T11:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
+		s.EndedAt = new("2024-06-15T11:00:00Z")
 	})
 
 	tokenUsage := `{
@@ -164,7 +164,7 @@ func TestGetDailyUsage_CacheSavingsUsesPerModelRates(t *testing.T) {
 
 	insertSession(t, d, "s-opus", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "s-opus", Ordinal: 0,
@@ -174,7 +174,7 @@ func TestGetDailyUsage_CacheSavingsUsesPerModelRates(t *testing.T) {
 
 	insertSession(t, d, "s-sonnet", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:05:00Z")
+		s.StartedAt = new("2024-06-15T10:05:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "s-sonnet", Ordinal: 0,
@@ -234,7 +234,7 @@ func TestGetDailyUsageAgentFilter(t *testing.T) {
 	// Claude session
 	insertSession(t, d, "sess-claude", "proj1", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess-claude",
@@ -248,7 +248,7 @@ func TestGetDailyUsageAgentFilter(t *testing.T) {
 	// Codex session
 	insertSession(t, d, "sess-codex", "proj1", func(s *Session) {
 		s.Agent = "codex"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess-codex",
@@ -303,7 +303,7 @@ func TestGetDailyUsageMultipleDaysAndModels(t *testing.T) {
 	// Day 1: two models
 	insertSession(t, d, "sess-d1", "proj1", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-10T08:00:00Z")
+		s.StartedAt = new("2024-06-10T08:00:00Z")
 	})
 	insertMessages(t, d,
 		Message{
@@ -327,7 +327,7 @@ func TestGetDailyUsageMultipleDaysAndModels(t *testing.T) {
 	// Day 2: one model
 	insertSession(t, d, "sess-d2", "proj1", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-11T08:00:00Z")
+		s.StartedAt = new("2024-06-11T08:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess-d2",
@@ -406,7 +406,7 @@ func TestGetDailyUsageNoPricing(t *testing.T) {
 
 	insertSession(t, d, "sess1", "proj1", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess1",
@@ -466,7 +466,7 @@ func TestGetDailyUsageTruncatedTokenJSON(t *testing.T) {
 
 	insertSession(t, d, "sess1", "proj1", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 
 	insertMessages(t, d,
@@ -636,7 +636,7 @@ func TestGetDailyUsageLongLivedSession(t *testing.T) {
 	requireNoError(t, d.UpsertSession(Session{
 		ID: "long-lived", Project: "proj", Machine: "local",
 		Agent:     "claude",
-		StartedAt: Ptr("2026-04-01T10:00:00Z"),
+		StartedAt: new("2026-04-01T10:00:00Z"),
 	}), "upsert session")
 
 	insertMessages(t, d,
@@ -698,7 +698,7 @@ func TestGetDailyUsageProjectFilter(t *testing.T) {
 
 	insertSession(t, d, "sess-a", "proj-a", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess-a",
@@ -711,7 +711,7 @@ func TestGetDailyUsageProjectFilter(t *testing.T) {
 
 	insertSession(t, d, "sess-b", "proj-b", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess-b",
@@ -757,7 +757,7 @@ func TestGetDailyUsageModelFilter(t *testing.T) {
 
 	insertSession(t, d, "sess1", "proj1", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d,
 		Message{
@@ -812,7 +812,7 @@ func TestGetDailyUsageProjectBreakdowns(t *testing.T) {
 
 	insertSession(t, d, "sess-a", "proj-a", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess-a",
@@ -825,7 +825,7 @@ func TestGetDailyUsageProjectBreakdowns(t *testing.T) {
 
 	insertSession(t, d, "sess-b", "proj-b", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess-b",
@@ -888,7 +888,7 @@ func TestGetDailyUsageAgentBreakdowns(t *testing.T) {
 
 	insertSession(t, d, "sess-claude", "proj1", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess-claude",
@@ -901,7 +901,7 @@ func TestGetDailyUsageAgentBreakdowns(t *testing.T) {
 
 	insertSession(t, d, "sess-codex", "proj1", func(s *Session) {
 		s.Agent = "codex"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID:  "sess-codex",
@@ -979,7 +979,7 @@ func TestGetDailyUsageBreakdownInvariant(t *testing.T) {
 		sid := "sess-" + strconv.Itoa(i)
 		insertSession(t, d, sid, c.project, func(s *Session) {
 			s.Agent = c.agent
-			s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+			s.StartedAt = new("2024-06-15T10:00:00Z")
 		})
 		insertMessages(t, d,
 			Message{
@@ -1071,8 +1071,8 @@ func TestGetTopSessionsByCost(t *testing.T) {
 	// Expensive session
 	insertSession(t, d, "sBig", "proj-a", func(s *Session) {
 		s.Agent = "claude"
-		s.DisplayName = Ptr("Big Session")
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.DisplayName = new("Big Session")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "sBig", Ordinal: 0,
@@ -1087,8 +1087,8 @@ func TestGetTopSessionsByCost(t *testing.T) {
 	// Cheap session
 	insertSession(t, d, "sSmall", "proj-b", func(s *Session) {
 		s.Agent = "codex"
-		s.DisplayName = Ptr("Small Session")
-		s.StartedAt = Ptr("2024-06-15T11:00:00Z")
+		s.DisplayName = new("Small Session")
+		s.StartedAt = new("2024-06-15T11:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "sSmall", Ordinal: 0,
@@ -1164,9 +1164,9 @@ func TestGetTopSessionsByCost_DisplayNameFallback(t *testing.T) {
 	// Session with display_name set — should use display_name.
 	insertSession(t, d, "s-dn", "proj-a", func(s *Session) {
 		s.Agent = "claude"
-		s.DisplayName = Ptr("My Custom Name")
-		s.FirstMessage = Ptr("some first message")
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.DisplayName = new("My Custom Name")
+		s.FirstMessage = new("some first message")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "s-dn", Ordinal: 0,
@@ -1178,8 +1178,8 @@ func TestGetTopSessionsByCost_DisplayNameFallback(t *testing.T) {
 	// Session with no display_name — should fall back to first_message.
 	insertSession(t, d, "s-fm", "proj-a", func(s *Session) {
 		s.Agent = "claude"
-		s.FirstMessage = Ptr("fix the login bug")
-		s.StartedAt = Ptr("2024-06-15T11:00:00Z")
+		s.FirstMessage = new("fix the login bug")
+		s.StartedAt = new("2024-06-15T11:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "s-fm", Ordinal: 0,
@@ -1192,7 +1192,7 @@ func TestGetTopSessionsByCost_DisplayNameFallback(t *testing.T) {
 	// fall back to project.
 	insertSession(t, d, "s-proj", "my-project", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T12:00:00Z")
+		s.StartedAt = new("2024-06-15T12:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "s-proj", Ordinal: 0,
@@ -1205,7 +1205,7 @@ func TestGetTopSessionsByCost_DisplayNameFallback(t *testing.T) {
 	// project — should fall back to session ID.
 	insertSession(t, d, "s-id", "", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T13:00:00Z")
+		s.StartedAt = new("2024-06-15T13:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "s-id", Ordinal: 0,
@@ -1272,13 +1272,13 @@ func TestGetTopSessionsByCost_DedupesByClaudeMessageAndRequestID(
 	// Parent session starts first.
 	insertSession(t, d, "s-parent", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	// Forked session starts a minute later.
 	insertSession(t, d, "s-fork", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:01:00Z")
-		s.ParentSessionID = Ptr("s-parent")
+		s.StartedAt = new("2024-06-15T10:01:00Z")
+		s.ParentSessionID = new("s-parent")
 		s.RelationshipType = "fork"
 	})
 
@@ -1374,7 +1374,7 @@ func TestGetTopSessionsByCostLimit(t *testing.T) {
 		sid := "sess-" + strconv.Itoa(i)
 		insertSession(t, d, sid, "proj", func(s *Session) {
 			s.Agent = "claude"
-			s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+			s.StartedAt = new("2024-06-15T10:00:00Z")
 		})
 		insertMessages(t, d, Message{
 			SessionID: sid, Ordinal: 0,
@@ -1403,7 +1403,7 @@ func TestGetUsageSessionCounts(t *testing.T) {
 	// s1: proj-a / claude — TWO messages across TWO days
 	insertSession(t, d, "s1", "proj-a", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d,
 		Message{
@@ -1425,7 +1425,7 @@ func TestGetUsageSessionCounts(t *testing.T) {
 	// s2: proj-a / codex
 	insertSession(t, d, "s2", "proj-a", func(s *Session) {
 		s.Agent = "codex"
-		s.StartedAt = Ptr("2024-06-15T11:00:00Z")
+		s.StartedAt = new("2024-06-15T11:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "s2", Ordinal: 0,
@@ -1438,7 +1438,7 @@ func TestGetUsageSessionCounts(t *testing.T) {
 	// s3: proj-b / claude
 	insertSession(t, d, "s3", "proj-b", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T12:00:00Z")
+		s.StartedAt = new("2024-06-15T12:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "s3", Ordinal: 0,
@@ -1492,13 +1492,13 @@ func TestGetUsageSessionCounts_DedupesByClaudeMessageAndRequestID(
 	// Parent starts first.
 	insertSession(t, d, "s-parent", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	// Fork starts a minute later.
 	insertSession(t, d, "s-fork", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:01:00Z")
-		s.ParentSessionID = Ptr("s-parent")
+		s.StartedAt = new("2024-06-15T10:01:00Z")
+		s.ParentSessionID = new("s-parent")
 		s.RelationshipType = "fork"
 	})
 
@@ -1563,7 +1563,7 @@ func TestUsageQueryEligibilityParity(t *testing.T) {
 	// Good session — should be visible to all queries.
 	insertSession(t, d, "good", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "good", Ordinal: 0,
@@ -1576,7 +1576,7 @@ func TestUsageQueryEligibilityParity(t *testing.T) {
 	// Bad: empty token_usage
 	insertSession(t, d, "bad-empty", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "bad-empty", Ordinal: 0,
@@ -1588,7 +1588,7 @@ func TestUsageQueryEligibilityParity(t *testing.T) {
 	// Bad: synthetic model
 	insertSession(t, d, "bad-synth", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "bad-synth", Ordinal: 0,
@@ -1601,7 +1601,7 @@ func TestUsageQueryEligibilityParity(t *testing.T) {
 	// Bad: soft-deleted session
 	insertSession(t, d, "bad-deleted", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertMessages(t, d, Message{
 		SessionID: "bad-deleted", Ordinal: 0,
@@ -1663,15 +1663,15 @@ func TestExcludeProjectFilter(t *testing.T) {
 
 	insertSession(t, d, "sA", "proj-a", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertSession(t, d, "sB", "proj-b", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertSession(t, d, "sC", "proj-c", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 
 	usage := `{"input_tokens":1000,"output_tokens":500}`
@@ -1746,11 +1746,11 @@ func TestExcludeAgentFilter(t *testing.T) {
 
 	insertSession(t, d, "s1", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 	insertSession(t, d, "s2", "proj", func(s *Session) {
 		s.Agent = "codex"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 
 	usage := `{"input_tokens":1000,"output_tokens":500}`
@@ -1790,7 +1790,7 @@ func TestExcludeModelFilter(t *testing.T) {
 
 	insertSession(t, d, "s1", "proj", func(s *Session) {
 		s.Agent = "claude"
-		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
 
 	insertMessages(t, d,
@@ -1885,7 +1885,7 @@ func BenchmarkGetDailyUsage(b *testing.B) {
 			Machine:      defaultMachine,
 			Agent:        agent,
 			MessageCount: msgsPerSession,
-			StartedAt:    Ptr(startTime.Format(time.RFC3339)),
+			StartedAt:    new(startTime.Format(time.RFC3339)),
 		}
 		if err := d.UpsertSession(s); err != nil {
 			b.Fatalf("UpsertSession: %v", err)
@@ -1938,20 +1938,20 @@ func TestGetDailyUsage_PricingPrecedence(t *testing.T) {
 			wantCost: 1.4, // 1M*$1/M + 100k*$4/M
 		},
 		{
-			name:    "custom overrides db for same model",
-			dbRates: []ModelPricing{{ModelPattern: "acme-ultra-2.1", InputPerMTok: 1.0, OutputPerMTok: 4.0}},
-			custom:  map[string]config.CustomModelRate{"acme-ultra-2.1": {Input: 2.0, Output: 8.0}},
-			model:   "acme-ultra-2.1",
-			input:   1_000_000,
-			output:  100_000,
+			name:     "custom overrides db for same model",
+			dbRates:  []ModelPricing{{ModelPattern: "acme-ultra-2.1", InputPerMTok: 1.0, OutputPerMTok: 4.0}},
+			custom:   map[string]config.CustomModelRate{"acme-ultra-2.1": {Input: 2.0, Output: 8.0}},
+			model:    "acme-ultra-2.1",
+			input:    1_000_000,
+			output:   100_000,
 			wantCost: 2.8, // 1M*$2/M + 100k*$8/M
 		},
 		{
-			name:    "custom for unknown model, no db entry",
-			custom:  map[string]config.CustomModelRate{"my-custom-model": {Input: 1.5, Output: 6.0}},
-			model:   "my-custom-model",
-			input:   500_000,
-			output:  50_000,
+			name:     "custom for unknown model, no db entry",
+			custom:   map[string]config.CustomModelRate{"my-custom-model": {Input: 1.5, Output: 6.0}},
+			model:    "my-custom-model",
+			input:    500_000,
+			output:   50_000,
 			wantCost: 1.05, // 500k*$1.5/M + 50k*$6/M
 		},
 		{
@@ -1962,12 +1962,12 @@ func TestGetDailyUsage_PricingPrecedence(t *testing.T) {
 			wantCost: 0.0,
 		},
 		{
-			name:    "custom only affects targeted model",
-			dbRates: []ModelPricing{{ModelPattern: "db-model", InputPerMTok: 3.0, OutputPerMTok: 10.0}},
-			custom:  map[string]config.CustomModelRate{"other-model": {Input: 99.0, Output: 99.0}},
-			model:   "db-model",
-			input:   1_000_000,
-			output:  100_000,
+			name:     "custom only affects targeted model",
+			dbRates:  []ModelPricing{{ModelPattern: "db-model", InputPerMTok: 3.0, OutputPerMTok: 10.0}},
+			custom:   map[string]config.CustomModelRate{"other-model": {Input: 99.0, Output: 99.0}},
+			model:    "db-model",
+			input:    1_000_000,
+			output:   100_000,
 			wantCost: 4.0, // 1M*$3/M + 100k*$10/M -- db rates, not custom
 		},
 	}
@@ -1983,7 +1983,7 @@ func TestGetDailyUsage_PricingPrecedence(t *testing.T) {
 			}
 
 			insertSession(t, d, "s1", "proj", func(s *Session) {
-				s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+				s.StartedAt = new("2024-06-15T10:00:00Z")
 			})
 			insertMessages(t, d, Message{
 				SessionID:  "s1",

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -11,7 +11,9 @@ import (
 )
 
 // Ptr returns a pointer to v.
-func Ptr[T any](v T) *T { return &v }
+//
+//go:fix inline
+func Ptr[T any](v T) *T { return new(v) }
 
 // WriteTestFile creates a file at path with the given content,
 // creating parent directories as needed. Fails the test on

--- a/internal/insight/prompt_test.go
+++ b/internal/insight/prompt_test.go
@@ -29,15 +29,15 @@ func TestBuildPrompt(t *testing.T) {
 			seed: func(t *testing.T, d *db.DB) {
 				dbtest.SeedSession(t, d, "s1", "my-app", func(s *db.Session) {
 					s.MessageCount = 5
-					s.StartedAt = dbtest.Ptr("2025-01-15T10:00:00Z")
-					s.EndedAt = dbtest.Ptr("2025-01-15T11:00:00Z")
-					s.FirstMessage = dbtest.Ptr("Fix the login bug")
+					s.StartedAt = new("2025-01-15T10:00:00Z")
+					s.EndedAt = new("2025-01-15T11:00:00Z")
+					s.FirstMessage = new("Fix the login bug")
 				})
 				dbtest.SeedSession(t, d, "s2", "other-app", func(s *db.Session) {
 					s.MessageCount = 3
-					s.StartedAt = dbtest.Ptr("2025-01-15T14:00:00Z")
-					s.EndedAt = dbtest.Ptr("2025-01-15T15:00:00Z")
-					s.FirstMessage = dbtest.Ptr("Add tests")
+					s.StartedAt = new("2025-01-15T14:00:00Z")
+					s.EndedAt = new("2025-01-15T15:00:00Z")
+					s.FirstMessage = new("Add tests")
 				})
 			},
 			wantContains: []string{
@@ -62,13 +62,13 @@ func TestBuildPrompt(t *testing.T) {
 			seed: func(t *testing.T, d *db.DB) {
 				dbtest.SeedSession(t, d, "s1", "my-app", func(s *db.Session) {
 					s.MessageCount = 5
-					s.StartedAt = dbtest.Ptr("2025-01-15T10:00:00Z")
-					s.EndedAt = dbtest.Ptr("2025-01-15T11:00:00Z")
+					s.StartedAt = new("2025-01-15T10:00:00Z")
+					s.EndedAt = new("2025-01-15T11:00:00Z")
 				})
 				dbtest.SeedSession(t, d, "s2", "other-app", func(s *db.Session) {
 					s.MessageCount = 3
-					s.StartedAt = dbtest.Ptr("2025-01-15T14:00:00Z")
-					s.EndedAt = dbtest.Ptr("2025-01-15T15:00:00Z")
+					s.StartedAt = new("2025-01-15T14:00:00Z")
+					s.EndedAt = new("2025-01-15T15:00:00Z")
 				})
 			},
 			wantContains: []string{"Project: my-app"},
@@ -111,8 +111,8 @@ func TestBuildPrompt(t *testing.T) {
 						fmt.Sprintf("s%d", i), "my-app",
 						func(s *db.Session) {
 							s.MessageCount = 1
-							s.StartedAt = dbtest.Ptr("2025-01-15T10:00:00Z")
-							s.EndedAt = dbtest.Ptr(fmt.Sprintf("2025-01-15T11:%02d:00Z", i))
+							s.StartedAt = new("2025-01-15T10:00:00Z")
+							s.EndedAt = new(fmt.Sprintf("2025-01-15T11:%02d:00Z", i))
 						},
 					)
 				}
@@ -135,11 +135,11 @@ func TestBuildPrompt(t *testing.T) {
 			seed: func(t *testing.T, d *db.DB) {
 				dbtest.SeedSession(t, d, "s1", "my-app", func(s *db.Session) {
 					s.MessageCount = 3
-					s.StartedAt = dbtest.Ptr("2025-01-13T10:00:00Z")
+					s.StartedAt = new("2025-01-13T10:00:00Z")
 				})
 				dbtest.SeedSession(t, d, "s2", "my-app", func(s *db.Session) {
 					s.MessageCount = 2
-					s.StartedAt = dbtest.Ptr("2025-01-17T14:00:00Z")
+					s.StartedAt = new("2025-01-17T14:00:00Z")
 				})
 			},
 			wantContains: []string{"Date Range: 2025-01-13 to 2025-01-17"},
@@ -175,18 +175,18 @@ func TestBuildPrompt(t *testing.T) {
 				dbtest.SeedSession(t, d, "user-session", "my-app", func(s *db.Session) {
 					s.MessageCount = 5
 					s.UserMessageCount = 2
-					s.StartedAt = dbtest.Ptr("2025-01-15T10:00:00Z")
-					s.EndedAt = dbtest.Ptr("2025-01-15T11:00:00Z")
-					s.FirstMessage = dbtest.Ptr("Fix the login bug")
+					s.StartedAt = new("2025-01-15T10:00:00Z")
+					s.EndedAt = new("2025-01-15T11:00:00Z")
+					s.FirstMessage = new("Fix the login bug")
 				})
 				// An automated session: roborev review, single-turn,
 				// is_automated must be true.
 				dbtest.SeedSession(t, d, "auto-session", "my-app", func(s *db.Session) {
 					s.MessageCount = 2
 					s.UserMessageCount = 1
-					s.StartedAt = dbtest.Ptr("2025-01-15T12:00:00Z")
-					s.EndedAt = dbtest.Ptr("2025-01-15T12:05:00Z")
-					s.FirstMessage = dbtest.Ptr(
+					s.StartedAt = new("2025-01-15T12:00:00Z")
+					s.EndedAt = new("2025-01-15T12:05:00Z")
+					s.FirstMessage = new(
 						"You are a code reviewer. Review the diff.",
 					)
 					s.IsAutomated = true

--- a/internal/parser/chatgpt_test.go
+++ b/internal/parser/chatgpt_test.go
@@ -487,7 +487,7 @@ func TestLinearizeDAG(t *testing.T) {
 		},
 		"b": {
 			ID:     "b",
-			Parent: strPtr("a"),
+			Parent: new("a"),
 		},
 	}
 
@@ -753,8 +753,6 @@ func rawParts(ss ...string) []json.RawMessage {
 	}
 	return parts
 }
-
-func strPtr(s string) *string { return &s }
 
 type mockAssetResolver struct {
 	files   map[string]string

--- a/internal/server/analytics_test.go
+++ b/internal/server/analytics_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
 )
 
 const basePath = "/api/v1/analytics/"
@@ -64,7 +63,7 @@ func seedAnalyticsEnv(t *testing.T, te *testEnv) seedStats {
 				sess.Agent = s.agent
 				sess.StartedAt = &started
 				sess.EndedAt = &started
-				sess.FirstMessage = dbtest.Ptr("Hello")
+				sess.FirstMessage = new("Hello")
 			},
 		)
 		te.seedMessages(t, s.id, s.msgs,
@@ -126,7 +125,7 @@ func seedAnalyticsTokenEnv(t *testing.T, te *testEnv) seedStats {
 				sess.Agent = s.agent
 				sess.StartedAt = &s.started
 				sess.EndedAt = &s.started
-				sess.FirstMessage = dbtest.Ptr("Token seeded")
+				sess.FirstMessage = new("Token seeded")
 				sess.TotalOutputTokens = s.outputTokens
 				sess.HasTotalOutputTokens = s.hasTokens
 			},
@@ -856,9 +855,9 @@ func TestSessionCountConsistency(t *testing.T) {
 		te.seedSession(t, id, "proj-a", 10,
 			func(s *db.Session) {
 				s.Agent = "claude"
-				s.StartedAt = dbtest.Ptr(
+				s.StartedAt = new(
 					"2024-06-01T09:00:00Z")
-				s.EndedAt = dbtest.Ptr(
+				s.EndedAt = new(
 					"2024-06-01T10:00:00Z")
 			},
 		)
@@ -871,11 +870,11 @@ func TestSessionCountConsistency(t *testing.T) {
 		te.seedSession(t, id, "proj-a", 8,
 			func(s *db.Session) {
 				s.Agent = "claude"
-				s.ParentSessionID = dbtest.Ptr("root-0")
+				s.ParentSessionID = new("root-0")
 				s.RelationshipType = "subagent"
-				s.StartedAt = dbtest.Ptr(
+				s.StartedAt = new(
 					"2024-06-01T09:00:00Z")
-				s.EndedAt = dbtest.Ptr(
+				s.EndedAt = new(
 					"2024-06-01T10:00:00Z")
 			},
 		)
@@ -888,11 +887,11 @@ func TestSessionCountConsistency(t *testing.T) {
 		te.seedSession(t, id, "proj-a", 6,
 			func(s *db.Session) {
 				s.Agent = "claude"
-				s.ParentSessionID = dbtest.Ptr("root-1")
+				s.ParentSessionID = new("root-1")
 				s.RelationshipType = "fork"
-				s.StartedAt = dbtest.Ptr(
+				s.StartedAt = new(
 					"2024-06-01T09:00:00Z")
-				s.EndedAt = dbtest.Ptr(
+				s.EndedAt = new(
 					"2024-06-01T10:00:00Z")
 			},
 		)
@@ -905,9 +904,9 @@ func TestSessionCountConsistency(t *testing.T) {
 		te.seedSession(t, id, "proj-a", 0,
 			func(s *db.Session) {
 				s.Agent = "claude"
-				s.StartedAt = dbtest.Ptr(
+				s.StartedAt = new(
 					"2024-06-01T09:00:00Z")
-				s.EndedAt = dbtest.Ptr(
+				s.EndedAt = new(
 					"2024-06-01T10:00:00Z")
 			},
 		)
@@ -917,11 +916,11 @@ func TestSessionCountConsistency(t *testing.T) {
 	te.seedSession(t, "cont-0", "proj-a", 5,
 		func(s *db.Session) {
 			s.Agent = "claude"
-			s.ParentSessionID = dbtest.Ptr("root-2")
+			s.ParentSessionID = new("root-2")
 			s.RelationshipType = "continuation"
-			s.StartedAt = dbtest.Ptr(
+			s.StartedAt = new(
 				"2024-06-01T09:00:00Z")
-			s.EndedAt = dbtest.Ptr(
+			s.EndedAt = new(
 				"2024-06-01T10:00:00Z")
 		},
 	)

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
 )
 
 // testSession returns a *db.Session with sensible defaults.
@@ -23,7 +22,7 @@ func testSession(
 		Project:      "proj",
 		Agent:        "claude",
 		MessageCount: 0,
-		StartedAt:    dbtest.Ptr("2025-01-15T10:00:00Z"),
+		StartedAt:    new("2025-01-15T10:00:00Z"),
 	}
 	for _, o := range opts {
 		o(s)
@@ -148,20 +147,20 @@ func TestFormatDateShort(t *testing.T) {
 		want string
 	}{
 		{"Nil", nil, "unknown"},
-		{"Empty", dbtest.Ptr(""), "unknown"},
+		{"Empty", new(""), "unknown"},
 		{
 			"Valid",
-			dbtest.Ptr("2025-01-15T10:30:00Z"),
+			new("2025-01-15T10:30:00Z"),
 			"20250115",
 		},
 		{
 			"Nano",
-			dbtest.Ptr("2025-06-01T08:15:30.999Z"),
+			new("2025-06-01T08:15:30.999Z"),
 			"20250601",
 		},
 		{
 			"Unparseable",
-			dbtest.Ptr("garbage"),
+			new("garbage"),
 			"unknown",
 		},
 	}
@@ -361,7 +360,7 @@ func TestGenerateExportHTML_Structure(t *testing.T) {
 	session := testSession(func(s *db.Session) {
 		s.Project = "my-project"
 		s.MessageCount = 2
-		s.FirstMessage = dbtest.Ptr("Hello")
+		s.FirstMessage = new("Hello")
 	})
 	msgs := []db.Message{
 		{
@@ -555,7 +554,7 @@ func TestGenerateExportMarkdown_OmitsEmptyOptionalAttributes(t *testing.T) {
 				ID:              "child-1",
 				Project:         "proj",
 				Agent:           "claude",
-				ParentSessionID: dbtest.Ptr("test-id"),
+				ParentSessionID: new("test-id"),
 				StartedAt:       &childStarted,
 			},
 		}},
@@ -632,7 +631,7 @@ func TestGenerateExportMarkdown_SanitizesHeadingAndAvoidsDuplicateAnchors(t *tes
 			ID:               "child-a",
 			Project:          "proj",
 			Agent:            "claude",
-			ParentSessionID:  dbtest.Ptr("test-id"),
+			ParentSessionID:  new("test-id"),
 			RelationshipType: "subagent",
 		},
 		Messages: []db.Message{{

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -77,8 +77,8 @@ func TestListInsights(t *testing.T) {
 		{
 			name: "WithData",
 			seed: func(t *testing.T, te *testEnv) {
-				te.seedInsight(t, "daily_activity", "2025-01-15", strPtr("my-app"))
-				te.seedInsight(t, "daily_activity", "2025-01-15", strPtr("other-app"))
+				te.seedInsight(t, "daily_activity", "2025-01-15", new("my-app"))
+				te.seedInsight(t, "daily_activity", "2025-01-15", new("other-app"))
 				te.seedInsight(t, "agent_analysis", "2025-01-15", nil)
 			},
 			path:       "/api/v1/insights",
@@ -88,7 +88,7 @@ func TestListInsights(t *testing.T) {
 		{
 			name: "TypeFilter",
 			seed: func(t *testing.T, te *testEnv) {
-				te.seedInsight(t, "daily_activity", "2025-01-15", strPtr("my-app"))
+				te.seedInsight(t, "daily_activity", "2025-01-15", new("my-app"))
 				te.seedInsight(t, "agent_analysis", "2025-01-15", nil)
 			},
 			path:       "/api/v1/insights?type=daily_activity",
@@ -98,8 +98,8 @@ func TestListInsights(t *testing.T) {
 		{
 			name: "ReturnsAll",
 			seed: func(t *testing.T, te *testEnv) {
-				te.seedInsight(t, "daily_activity", "2025-01-15", strPtr("my-app"))
-				te.seedInsight(t, "daily_activity", "2025-01-16", strPtr("my-app"))
+				te.seedInsight(t, "daily_activity", "2025-01-15", new("my-app"))
+				te.seedInsight(t, "daily_activity", "2025-01-16", new("my-app"))
 			},
 			path:       "/api/v1/insights",
 			wantStatus: http.StatusOK,
@@ -140,7 +140,7 @@ func TestGetInsight_Found(t *testing.T) {
 	te := setup(t)
 
 	id := te.seedInsight(t, "daily_activity", "2025-01-15",
-		strPtr("my-app"))
+		new("my-app"))
 
 	w := te.get(t, fmt.Sprintf("/api/v1/insights/%d", id))
 	assertStatus(t, w, http.StatusOK)
@@ -870,7 +870,7 @@ func TestDeleteInsight_Found(t *testing.T) {
 	te := setup(t)
 
 	id := te.seedInsight(t, "daily_activity", "2025-01-15",
-		strPtr("my-app"))
+		new("my-app"))
 
 	w := te.del(t, fmt.Sprintf("/api/v1/insights/%d", id))
 	assertStatus(t, w, http.StatusNoContent)
@@ -908,8 +908,6 @@ func TestInsight_ResourceErrors(t *testing.T) {
 }
 
 // --- helpers ---
-
-func strPtr(s string) *string { return &s }
 
 func (te *testEnv) seedInsight(
 	t *testing.T,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -378,9 +378,9 @@ func (te *testEnv) seedSession(
 		s.Machine = "test"
 		s.MessageCount = msgCount
 		s.UserMessageCount = max(msgCount, 2)
-		s.StartedAt = dbtest.Ptr(tsSeed)
-		s.EndedAt = dbtest.Ptr(tsSeedEnd)
-		s.FirstMessage = dbtest.Ptr("Hello world")
+		s.StartedAt = new(tsSeed)
+		s.EndedAt = new(tsSeedEnd)
+		s.FirstMessage = new("Hello world")
 		for _, opt := range opts {
 			opt(s)
 		}
@@ -869,16 +869,16 @@ func TestGetChildSessions_Found(t *testing.T) {
 	te := setup(t)
 	te.seedSession(t, "parent-1", "my-app", 10)
 	te.seedSession(t, "child-a", "my-app", 3, func(s *db.Session) {
-		s.ParentSessionID = dbtest.Ptr("parent-1")
+		s.ParentSessionID = new("parent-1")
 		s.RelationshipType = "subagent"
-		s.StartedAt = dbtest.Ptr("2025-01-15T10:05:00Z")
-		s.EndedAt = dbtest.Ptr("2025-01-15T10:10:00Z")
+		s.StartedAt = new("2025-01-15T10:05:00Z")
+		s.EndedAt = new("2025-01-15T10:10:00Z")
 	})
 	te.seedSession(t, "child-b", "my-app", 2, func(s *db.Session) {
-		s.ParentSessionID = dbtest.Ptr("parent-1")
+		s.ParentSessionID = new("parent-1")
 		s.RelationshipType = "fork"
-		s.StartedAt = dbtest.Ptr("2025-01-15T10:15:00Z")
-		s.EndedAt = dbtest.Ptr("2025-01-15T10:20:00Z")
+		s.StartedAt = new("2025-01-15T10:15:00Z")
+		s.EndedAt = new("2025-01-15T10:20:00Z")
 	})
 
 	w := te.get(t, "/api/v1/sessions/parent-1/children")
@@ -2148,7 +2148,7 @@ func TestMarkdownSessionExport_DepthOneIncludesChildSessions(t *testing.T) {
 		}}
 	})
 	te.seedSession(t, "child-a", "my-app", 1, func(s *db.Session) {
-		s.ParentSessionID = dbtest.Ptr("parent")
+		s.ParentSessionID = new("parent")
 		s.RelationshipType = "subagent"
 	})
 	te.seedMessages(t, "child-a", 1)
@@ -2175,7 +2175,7 @@ func TestMarkdownSessionExport_DefaultOmitsChildSessions(t *testing.T) {
 		}}
 	})
 	te.seedSession(t, "child-a", "my-app", 1, func(s *db.Session) {
-		s.ParentSessionID = dbtest.Ptr("parent")
+		s.ParentSessionID = new("parent")
 		s.RelationshipType = "subagent"
 	})
 	te.seedMessages(t, "child-a", 1)
@@ -2203,7 +2203,7 @@ func TestMarkdownSessionExport_DepthAllRecurses(t *testing.T) {
 		}}
 	})
 	te.seedSession(t, "child-a", "my-app", 1, func(s *db.Session) {
-		s.ParentSessionID = dbtest.Ptr("root")
+		s.ParentSessionID = new("root")
 		s.RelationshipType = "subagent"
 	})
 	te.seedMessages(t, "child-a", 1, func(i int, m *db.Message) {
@@ -2219,7 +2219,7 @@ func TestMarkdownSessionExport_DepthAllRecurses(t *testing.T) {
 		}}
 	})
 	te.seedSession(t, "child-b", "my-app", 1, func(s *db.Session) {
-		s.ParentSessionID = dbtest.Ptr("child-a")
+		s.ParentSessionID = new("child-a")
 		s.RelationshipType = "subagent"
 	})
 	te.seedMessages(t, "child-b", 1)

--- a/internal/server/usage_test.go
+++ b/internal/server/usage_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
 	"github.com/wesm/agentsview/internal/server"
 )
 
@@ -89,7 +88,7 @@ func seedUsageEnv(t *testing.T, te *testEnv) {
 				sess.Agent = e.agent
 				sess.StartedAt = &e.started
 				sess.EndedAt = &e.started
-				sess.FirstMessage = dbtest.Ptr("Usage test")
+				sess.FirstMessage = new("Usage test")
 			},
 		)
 		started := e.started

--- a/internal/signals/score_test.go
+++ b/internal/signals/score_test.go
@@ -4,10 +4,6 @@ import (
 	"testing"
 )
 
-func floatPtr(f float64) *float64 { return &f }
-
-func intPtr(i int) *int { return &i }
-
 func TestComputeHealthScore(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -24,7 +20,7 @@ func TestComputeHealthScore(t *testing.T) {
 				OutcomeConfidence: "high",
 				HasToolCalls:      true,
 			},
-			wantScore:     intPtr(100),
+			wantScore:     new(100),
 			wantGrade:     "A",
 			wantBasis:     []string{"outcome", "tool_health"},
 			wantPenalties: nil,
@@ -36,7 +32,7 @@ func TestComputeHealthScore(t *testing.T) {
 				OutcomeConfidence: "medium",
 				HasToolCalls:      true,
 			},
-			wantScore: intPtr(70),
+			wantScore: new(70),
 			wantGrade: "C",
 			wantBasis: []string{"outcome", "tool_health"},
 			wantPenalties: map[string]int{
@@ -50,7 +46,7 @@ func TestComputeHealthScore(t *testing.T) {
 				OutcomeConfidence: "high",
 				HasToolCalls:      true,
 			},
-			wantScore: intPtr(85),
+			wantScore: new(85),
 			wantGrade: "B",
 			wantBasis: []string{"outcome", "tool_health"},
 			wantPenalties: map[string]int{
@@ -65,7 +61,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasToolCalls:       true,
 				FailureSignalCount: 20,
 			},
-			wantScore: intPtr(70),
+			wantScore: new(70),
 			wantGrade: "C",
 			wantBasis: []string{"outcome", "tool_health"},
 			wantPenalties: map[string]int{
@@ -80,7 +76,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasToolCalls:      true,
 				RetryCount:        3,
 			},
-			wantScore: intPtr(85),
+			wantScore: new(85),
 			wantGrade: "B",
 			wantBasis: []string{"outcome", "tool_health"},
 			wantPenalties: map[string]int{
@@ -95,7 +91,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasToolCalls:      true,
 				EditChurnCount:    2,
 			},
-			wantScore: intPtr(92),
+			wantScore: new(92),
 			wantGrade: "A",
 			wantBasis: []string{"outcome", "tool_health"},
 			wantPenalties: map[string]int{
@@ -110,7 +106,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasToolCalls:       true,
 				ConsecutiveFailMax: 3,
 			},
-			wantScore: intPtr(90),
+			wantScore: new(90),
 			wantGrade: "A",
 			wantBasis: []string{"outcome", "tool_health"},
 			wantPenalties: map[string]int{
@@ -125,7 +121,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasToolCalls:       true,
 				ConsecutiveFailMax: 2,
 			},
-			wantScore:     intPtr(100),
+			wantScore:     new(100),
 			wantGrade:     "A",
 			wantBasis:     []string{"outcome", "tool_health"},
 			wantPenalties: nil,
@@ -137,9 +133,9 @@ func TestComputeHealthScore(t *testing.T) {
 				OutcomeConfidence: "high",
 				HasContextData:    true,
 				CompactionCount:   3,
-				PressureMax:       floatPtr(0.95),
+				PressureMax:       new(0.95),
 			},
-			wantScore: intPtr(80),
+			wantScore: new(80),
 			wantGrade: "B",
 			wantBasis: []string{"outcome", "context_pressure"},
 			wantPenalties: map[string]int{
@@ -155,7 +151,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasContextData:    true,
 				CompactionCount:   1,
 			},
-			wantScore:     intPtr(100),
+			wantScore:     new(100),
 			wantGrade:     "A",
 			wantBasis:     []string{"outcome", "context_pressure"},
 			wantPenalties: nil,
@@ -172,9 +168,9 @@ func TestComputeHealthScore(t *testing.T) {
 				EditChurnCount:     10,
 				ConsecutiveFailMax: 5,
 				CompactionCount:    10,
-				PressureMax:        floatPtr(0.99),
+				PressureMax:        new(0.99),
 			},
-			wantScore: intPtr(0),
+			wantScore: new(0),
 			wantGrade: "F",
 			wantBasis: []string{
 				"outcome", "tool_health", "context_pressure",
@@ -207,7 +203,7 @@ func TestComputeHealthScore(t *testing.T) {
 				OutcomeConfidence: "low",
 				HasToolCalls:      true,
 			},
-			wantScore:     intPtr(100),
+			wantScore:     new(100),
 			wantGrade:     "A",
 			wantBasis:     []string{"outcome", "tool_health"},
 			wantPenalties: nil,
@@ -219,7 +215,7 @@ func TestComputeHealthScore(t *testing.T) {
 				OutcomeConfidence: "low",
 				HasContextData:    true,
 			},
-			wantScore:     intPtr(100),
+			wantScore:     new(100),
 			wantGrade:     "A",
 			wantBasis:     []string{"outcome", "context_pressure"},
 			wantPenalties: nil,
@@ -230,7 +226,7 @@ func TestComputeHealthScore(t *testing.T) {
 				Outcome:           "unknown",
 				OutcomeConfidence: "high",
 			},
-			wantScore:     intPtr(100),
+			wantScore:     new(100),
 			wantGrade:     "A",
 			wantBasis:     []string{"outcome"},
 			wantPenalties: nil,
@@ -241,7 +237,7 @@ func TestComputeHealthScore(t *testing.T) {
 				Outcome:           "completed",
 				OutcomeConfidence: "high",
 			},
-			wantScore:     intPtr(100),
+			wantScore:     new(100),
 			wantGrade:     "A",
 			wantBasis:     []string{"outcome"},
 			wantPenalties: nil,
@@ -252,9 +248,9 @@ func TestComputeHealthScore(t *testing.T) {
 				Outcome:           "completed",
 				OutcomeConfidence: "high",
 				HasContextData:    true,
-				PressureMax:       floatPtr(0.9),
+				PressureMax:       new(0.9),
 			},
-			wantScore:     intPtr(100),
+			wantScore:     new(100),
 			wantGrade:     "A",
 			wantBasis:     []string{"outcome", "context_pressure"},
 			wantPenalties: nil,
@@ -267,7 +263,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasToolCalls:       true,
 				FailureSignalCount: 10,
 			},
-			wantScore: intPtr(40),
+			wantScore: new(40),
 			wantGrade: "D",
 			wantBasis: []string{"outcome", "tool_health"},
 			wantPenalties: map[string]int{
@@ -283,7 +279,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasToolCalls:      true,
 				RetryCount:        10,
 			},
-			wantScore: intPtr(75),
+			wantScore: new(75),
 			wantGrade: "B",
 			wantBasis: []string{"outcome", "tool_health"},
 			wantPenalties: map[string]int{
@@ -298,7 +294,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasToolCalls:      true,
 				EditChurnCount:    10,
 			},
-			wantScore: intPtr(80),
+			wantScore: new(80),
 			wantGrade: "B",
 			wantBasis: []string{"outcome", "tool_health"},
 			wantPenalties: map[string]int{
@@ -313,7 +309,7 @@ func TestComputeHealthScore(t *testing.T) {
 				HasContextData:    true,
 				CompactionCount:   10,
 			},
-			wantScore: intPtr(85),
+			wantScore: new(85),
 			wantGrade: "B",
 			wantBasis: []string{"outcome", "context_pressure"},
 			wantPenalties: map[string]int{

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -5,10 +5,6 @@ import (
 	"time"
 )
 
-func ptr(s string) *string {
-	return &s
-}
-
 func TestPtr(t *testing.T) {
 	tests := []struct {
 		name string
@@ -23,12 +19,12 @@ func TestPtr(t *testing.T) {
 		{
 			name: "non-zero returns RFC3339Nano UTC",
 			in:   time.Date(2024, 6, 15, 12, 30, 45, 123000000, time.UTC),
-			want: ptr("2024-06-15T12:30:45.123Z"),
+			want: new("2024-06-15T12:30:45.123Z"),
 		},
 		{
 			name: "converts to UTC",
 			in:   time.Date(2024, 6, 15, 7, 30, 0, 0, time.FixedZone("EST", -5*60*60)),
-			want: ptr("2024-06-15T12:30:00Z"),
+			want: new("2024-06-15T12:30:00Z"),
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Update the module Go directive to 1.26.2 and configure golangci-lint for Go 1.26.
- Bump the golangci-lint pin and install hints to v2.11.4.
- Apply `golangci-lint run --fix ./...` Go 1.26 modernizations, including `new(value)` pointer helper inlining.
- Retry ETXTBSY (Linux execve race when a parallel test thread's fork briefly holds a writable fd for the temp shell script) in `run_login_shell_env_handles_large_stdout`, mirroring the existing retry in the sibling `run_login_shell_env_timeout_returns_when_stdout_fd_stays_open` test. Removes a recurring arm64 desktop CI flake.
- Strip every repo-local Git env var (via `git rev-parse --local-env-vars`) and disable VCS stamping before `golangci-lint custom` in `nilaway-golangci-build`. When `make nilaway` runs from a pre-commit hook, git exports `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_CONFIG_PARAMETERS`, etc. pointing at the parent repo, which made the inner `git clone` and `go build` fail with exit 128.