### PR TITLE
fix(parser): filter synthetic copilot skill messages

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,15 +27,21 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 18: Claude parser now skips /clear and /effort
+// Bumped to 19: Copilot parser now filters synthetic skill
+// context user messages (source "skill-*" or content
+// starting with "<skill-context"), so full resync drops
+// injected skill definitions from stored transcripts and
+// first_message.
+//
+// (18: Claude parser now skips /clear and /effort
 // command envelopes when computing first_message, so sessions
 // that opened with one of those commands show the next real
 // user message in the sidebar instead of the command text.
-// Re-parsing rewrites first_message with the new logic.
+// Re-parsing rewrites first_message with the new logic.)
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 18
+const dataVersion = 19
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -94,6 +94,9 @@ func (b *copilotSessionBuilder) handleUserMessage(
 	if content == "" {
 		return
 	}
+	if isCopilotSyntheticSkillMessage(data, content) {
+		return
+	}
 
 	if b.firstMessage == "" {
 		b.firstMessage = truncate(
@@ -109,6 +112,16 @@ func (b *copilotSessionBuilder) handleUserMessage(
 		ContentLength: len(content),
 	})
 	b.ordinal++
+}
+
+func isCopilotSyntheticSkillMessage(
+	data gjson.Result, content string,
+) bool {
+	source := strings.TrimSpace(data.Get("source").Str)
+	if strings.HasPrefix(source, "skill-") {
+		return true
+	}
+	return strings.HasPrefix(content, "<skill-context")
 }
 
 func (b *copilotSessionBuilder) handleAssistantMessage(

--- a/internal/parser/copilot_test.go
+++ b/internal/parser/copilot_test.go
@@ -313,6 +313,46 @@ func TestCopilotUserMessageCount(t *testing.T) {
 	assertEqual(t, 2, sess.UserMessageCount, "UserMessageCount")
 }
 
+func TestParseCopilotSession_SkipsSyntheticSkillMessages(t *testing.T) {
+	tests := []struct {
+		name     string
+		dataJSON string
+	}{
+		{
+			name:     "SourceAndContent",
+			dataJSON: `{"content":"<skill-context name=\"gh-cli\">\nbody\n</skill-context>","source":"skill-gh-cli"}`,
+		},
+		{
+			name:     "SourceOnly",
+			dataJSON: `{"content":"skill payload without wrapper","source":"skill-prd"}`,
+		},
+		{
+			name:     "ContentOnly",
+			dataJSON: `{"content":"<skill-context name=\"daily-summary\">\nbody\n</skill-context>"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeCopilotJSONL(t,
+				`{"type":"session.start","data":{"sessionId":"skill-filter"},"timestamp":"2025-01-15T10:00:00Z"}`,
+				`{"type":"user.message","data":`+tt.dataJSON+`,"timestamp":"2025-01-15T10:00:01Z"}`,
+				`{"type":"user.message","data":{"content":"Fix the parser"},"timestamp":"2025-01-15T10:00:02Z"}`,
+				`{"type":"assistant.message","data":{"content":"Working on it."},"timestamp":"2025-01-15T10:00:03Z"}`,
+			)
+
+			sess, msgs := parseAndValidateHelper(t, path, "m", 2)
+
+			assertEqual(t, "Fix the parser", sess.FirstMessage, "FirstMessage")
+			assertEqual(t, 1, sess.UserMessageCount, "UserMessageCount")
+			assertEqual(t, RoleUser, msgs[0].Role, "msgs[0].Role")
+			assertEqual(t, "Fix the parser", msgs[0].Content, "msgs[0].Content")
+			assertEqual(t, 0, msgs[0].Ordinal, "msgs[0].Ordinal")
+			assertEqual(t, 1, msgs[1].Ordinal, "msgs[1].Ordinal")
+		})
+	}
+}
+
 func TestParseCopilotSession_ModelChange(t *testing.T) {
 	path := writeCopilotJSONL(t,
 		`{"type":"session.start","data":{"sessionId":"model-test"},"timestamp":"2025-01-15T10:00:00Z"}`,


### PR DESCRIPTION
Skip Copilot user.message entries injected by skills when `data.source` starts with `skill-` or `data.content` starts with `<skill-context` so they do not appear as user transcript content or set firstMessage.

Add regression coverage for source-only, content-only, and combined synthetic skill messages, and bump dataVersion to 19 so existing databases resync and drop persisted skill definitions.

Fixes #394
