### PR TITLE
fix(parser): sync opencode sqlite sessions in hybrid roots

### DIFF
--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -178,6 +178,12 @@ func FindOpenCodeSourceFile(root, sessionID string) string {
 				return path
 			}
 		}
+		if info, err := os.Stat(src.DBPath); err == nil &&
+			!info.IsDir() {
+			return OpenCodeSQLiteVirtualPath(
+				src.DBPath, sessionID,
+			)
+		}
 		return ""
 	case OpenCodeSourceSQLite:
 		return OpenCodeSQLiteVirtualPath(
@@ -189,20 +195,25 @@ func FindOpenCodeSourceFile(root, sessionID string) string {
 }
 
 // ResolveOpenCodeWatchRoots returns the directories that should be
-// watched for live OpenCode updates under a configured root. Storage
-// mode targets the storage/ subtree so fsnotify does not recurse over
-// unrelated opencode state (binaries, logs, caches, the SQLite DB),
+// watched for live OpenCode updates under a configured root. Pure
+// storage mode targets the storage/ subtree so fsnotify does not
+// recurse over unrelated opencode state (binaries, logs, caches),
 // while still covering the session/message/part subdirs — including
 // ones that OpenCode creates lazily after the watcher starts, since
-// the watcher auto-adds new subdirectories on Create events. SQLite
-// mode keeps the root as the watch target since the DB sits directly
-// under it.
+// the watcher auto-adds new subdirectories on Create events. Hybrid
+// storage+SQLite roots and pure SQLite mode watch the root so DB/WAL
+// updates are observed too.
 func ResolveOpenCodeWatchRoots(root string) []string {
 	if root == "" {
 		return nil
 	}
-	switch ResolveOpenCodeSource(root).Mode {
+	src := ResolveOpenCodeSource(root)
+	switch src.Mode {
 	case OpenCodeSourceStorage:
+		if info, err := os.Stat(src.DBPath); err == nil &&
+			!info.IsDir() {
+			return []string{root}
+		}
 		return []string{filepath.Join(root, "storage")}
 	case OpenCodeSourceSQLite:
 		return []string{root}

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -194,6 +194,46 @@ func FindOpenCodeSourceFile(root, sessionID string) string {
 	}
 }
 
+// OpenCodeStorageSessionIDs returns the set of session IDs that
+// have a JSON file under storage/session/*/ in the given root.
+// Returns nil for non-storage roots. In hybrid roots (storage and
+// SQLite both present) the storage transcript is canonical, so
+// callers use this to skip duplicate SQLite metas during sync.
+func OpenCodeStorageSessionIDs(root string) map[string]struct{} {
+	src := ResolveOpenCodeSource(root)
+	if src.Mode != OpenCodeSourceStorage {
+		return nil
+	}
+	entries, err := os.ReadDir(src.SessionRoot)
+	if err != nil {
+		return nil
+	}
+	ids := make(map[string]struct{})
+	for _, entry := range entries {
+		if !isDirOrSymlink(entry, src.SessionRoot) {
+			continue
+		}
+		projectDir := filepath.Join(src.SessionRoot, entry.Name())
+		sessionEntries, err := os.ReadDir(projectDir)
+		if err != nil {
+			continue
+		}
+		for _, sessionEntry := range sessionEntries {
+			name := sessionEntry.Name()
+			if sessionEntry.IsDir() ||
+				!strings.HasSuffix(name, ".json") {
+				continue
+			}
+			id := strings.TrimSuffix(name, ".json")
+			if id == "" {
+				continue
+			}
+			ids[id] = struct{}{}
+		}
+	}
+	return ids
+}
+
 // ResolveOpenCodeWatchRoots returns the directories that should be
 // watched for live OpenCode updates under a configured root. Pure
 // storage mode targets the storage/ subtree so fsnotify does not

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -152,7 +152,11 @@ func DiscoverOpenCodeSessions(root string) []DiscoveredFile {
 }
 
 // FindOpenCodeSourceFile locates a single OpenCode session source
-// path or SQLite backing file by raw session ID.
+// path or SQLite backing file by raw session ID. Returns "" when
+// the session is not present under this root so the caller
+// (Engine.FindSourceFile) can continue searching later configured
+// roots — important when an early hybrid root with an unrelated
+// opencode.db could otherwise shadow a session in a later root.
 func FindOpenCodeSourceFile(root, sessionID string) string {
 	if !IsValidSessionID(sessionID) {
 		return ""
@@ -161,34 +165,34 @@ func FindOpenCodeSourceFile(root, sessionID string) string {
 	src := ResolveOpenCodeSource(root)
 	switch src.Mode {
 	case OpenCodeSourceStorage:
-		entries, err := os.ReadDir(src.SessionRoot)
-		if err != nil {
-			return ""
-		}
-		for _, entry := range entries {
-			if !isDirOrSymlink(entry, src.SessionRoot) {
-				continue
-			}
-			path := filepath.Join(
-				src.SessionRoot, entry.Name(),
-				sessionID+".json",
-			)
-			if info, err := os.Stat(path); err == nil &&
-				!info.IsDir() {
-				return path
+		if entries, err := os.ReadDir(src.SessionRoot); err == nil {
+			for _, entry := range entries {
+				if !isDirOrSymlink(entry, src.SessionRoot) {
+					continue
+				}
+				path := filepath.Join(
+					src.SessionRoot, entry.Name(),
+					sessionID+".json",
+				)
+				if info, err := os.Stat(path); err == nil &&
+					!info.IsDir() {
+					return path
+				}
 			}
 		}
-		if info, err := os.Stat(src.DBPath); err == nil &&
-			!info.IsDir() {
+		if OpenCodeSQLiteSessionExists(src.DBPath, sessionID) {
 			return OpenCodeSQLiteVirtualPath(
 				src.DBPath, sessionID,
 			)
 		}
 		return ""
 	case OpenCodeSourceSQLite:
-		return OpenCodeSQLiteVirtualPath(
-			src.DBPath, sessionID,
-		)
+		if OpenCodeSQLiteSessionExists(src.DBPath, sessionID) {
+			return OpenCodeSQLiteVirtualPath(
+				src.DBPath, sessionID,
+			)
+		}
+		return ""
 	default:
 		return ""
 	}

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -32,6 +32,34 @@ type OpenCodeSessionMeta struct {
 	FileMtime   int64
 }
 
+// OpenCodeSQLiteSessionExists reports whether a session row with
+// the given ID is present in the OpenCode SQLite database at
+// dbPath. Returns false when the file is missing, the schema is
+// unexpected, or no row matches. Used by FindOpenCodeSourceFile
+// so callers can distinguish "this DB has the session" from
+// "this DB exists but doesn't have it" — the latter must let
+// resolution continue to other configured roots.
+func OpenCodeSQLiteSessionExists(dbPath, sessionID string) bool {
+	if dbPath == "" || sessionID == "" {
+		return false
+	}
+	info, err := os.Stat(dbPath)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	db, err := openOpenCodeDB(dbPath)
+	if err != nil {
+		return false
+	}
+	defer db.Close()
+	var found int
+	err = db.QueryRow(
+		"SELECT 1 FROM session WHERE id = ? LIMIT 1",
+		sessionID,
+	).Scan(&found)
+	return err == nil
+}
+
 // ListOpenCodeSessionMeta returns lightweight metadata for
 // all sessions without parsing messages or parts. Used by
 // the sync engine to detect which sessions have changed.

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -122,6 +122,38 @@ func newTestDB(t *testing.T) (string, *OpenCodeSeeder, *sql.DB) {
 	return dbPath, seeder, db
 }
 
+// seedHybridSQLiteDB creates an OpenCode-shaped SQLite DB at
+// dbPath containing a single session row with the given ID. Used
+// by tests that exercise FindOpenCodeSourceFile in hybrid and
+// pure-SQLite roots, where a real DB file (not just a marker) is
+// required.
+func seedHybridSQLiteDB(t *testing.T, dbPath, sessionID string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open hybrid db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(openCodeSchema); err != nil {
+		t.Fatalf("create hybrid schema: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO project (id, worktree)
+		 VALUES (?, ?)`,
+		"prj_seed", "/tmp/seed",
+	); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO session
+			(id, project_id, time_created, time_updated)
+		 VALUES (?, ?, ?, ?)`,
+		sessionID, "prj_seed", int64(1), int64(2),
+	); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+}
+
 func seedStandardSession(t *testing.T, seeder *OpenCodeSeeder) {
 	t.Helper()
 	seeder.AddProject("prj_1", "/home/user/code/myapp")

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -575,14 +575,52 @@ func TestFindOpenCodeSourceFileFallsBackToSQLiteInHybridRoot(t *testing.T) {
 		t.Fatalf("mkdir session dir: %v", err)
 	}
 	dbPath := filepath.Join(root, "opencode.db")
-	if err := os.WriteFile(dbPath, []byte("x"), 0o644); err != nil {
-		t.Fatalf("write db marker: %v", err)
-	}
+	seedHybridSQLiteDB(t, dbPath, "ses_456")
 
 	got := FindOpenCodeSourceFile(root, "ses_456")
 	want := OpenCodeSQLiteVirtualPath(dbPath, "ses_456")
 	if got != want {
 		t.Fatalf("FindOpenCodeSourceFile() = %q, want %q", got, want)
+	}
+}
+
+// TestFindOpenCodeSourceFileReturnsEmptyWhenSessionMissing covers
+// the multi-root shadowing case: an early hybrid root with an
+// opencode.db file that does NOT contain the session must return
+// "" so the engine's FindSourceFile loop continues to later roots
+// where the session actually lives.
+func TestFindOpenCodeSourceFileReturnsEmptyWhenSessionMissing(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(
+		filepath.Join(root, "storage", "session", "global"),
+		0o755,
+	); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	dbPath := filepath.Join(root, "opencode.db")
+	seedHybridSQLiteDB(t, dbPath, "ses_unrelated")
+
+	if got := FindOpenCodeSourceFile(root, "ses_missing"); got != "" {
+		t.Fatalf("FindOpenCodeSourceFile() = %q, want empty", got)
+	}
+}
+
+func TestFindOpenCodeSourceFilePureSQLiteOnlyForExistingSession(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "opencode.db")
+	seedHybridSQLiteDB(t, dbPath, "ses_present")
+
+	if got := FindOpenCodeSourceFile(root, "ses_present"); got !=
+		OpenCodeSQLiteVirtualPath(dbPath, "ses_present") {
+		t.Fatalf(
+			"FindOpenCodeSourceFile(present) = %q, want virtual path",
+			got,
+		)
+	}
+	if got := FindOpenCodeSourceFile(root, "ses_absent"); got != "" {
+		t.Fatalf(
+			"FindOpenCodeSourceFile(absent) = %q, want empty", got,
+		)
 	}
 }
 

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -566,6 +566,26 @@ func TestFindOpenCodeSourceFilePrefersStorage(t *testing.T) {
 	}
 }
 
+func TestFindOpenCodeSourceFileFallsBackToSQLiteInHybridRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(
+		filepath.Join(root, "storage", "session", "global"),
+		0o755,
+	); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	dbPath := filepath.Join(root, "opencode.db")
+	if err := os.WriteFile(dbPath, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write db marker: %v", err)
+	}
+
+	got := FindOpenCodeSourceFile(root, "ses_456")
+	want := OpenCodeSQLiteVirtualPath(dbPath, "ses_456")
+	if got != want {
+		t.Fatalf("FindOpenCodeSourceFile() = %q, want %q", got, want)
+	}
+}
+
 func TestResolveOpenCodeWatchRootsStorage(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(
@@ -577,6 +597,27 @@ func TestResolveOpenCodeWatchRootsStorage(t *testing.T) {
 
 	got := ResolveOpenCodeWatchRoots(root)
 	want := []string{filepath.Join(root, "storage")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
+	}
+}
+
+func TestResolveOpenCodeWatchRootsHybrid(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(
+		filepath.Join(root, "storage", "session", "global"),
+		0o755,
+	); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, "opencode.db"), []byte("x"), 0o644,
+	); err != nil {
+		t.Fatalf("write db marker: %v", err)
+	}
+
+	got := ResolveOpenCodeWatchRoots(root)
+	want := []string{root}
 	if !slices.Equal(got, want) {
 		t.Fatalf("ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
 	}

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -586,6 +586,58 @@ func TestFindOpenCodeSourceFileFallsBackToSQLiteInHybridRoot(t *testing.T) {
 	}
 }
 
+func TestOpenCodeStorageSessionIDsCollectsJSONFiles(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "storage", "session")
+	if err := os.MkdirAll(
+		filepath.Join(sessionDir, "global"), 0o755,
+	); err != nil {
+		t.Fatalf("mkdir global: %v", err)
+	}
+	if err := os.MkdirAll(
+		filepath.Join(sessionDir, "proj-x"), 0o755,
+	); err != nil {
+		t.Fatalf("mkdir proj-x: %v", err)
+	}
+	for _, p := range []string{
+		filepath.Join(sessionDir, "global", "ses_a.json"),
+		filepath.Join(sessionDir, "global", "ses_b.json"),
+		filepath.Join(sessionDir, "proj-x", "ses_c.json"),
+		filepath.Join(sessionDir, "global", "skip.txt"),
+	} {
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	got := OpenCodeStorageSessionIDs(root)
+	want := map[string]struct{}{
+		"ses_a": {},
+		"ses_b": {},
+		"ses_c": {},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d ids, want %d: %v", len(got), len(want), got)
+	}
+	for id := range want {
+		if _, ok := got[id]; !ok {
+			t.Errorf("missing %q in result %v", id, got)
+		}
+	}
+}
+
+func TestOpenCodeStorageSessionIDsNilForNonStorageRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(root, "opencode.db"), []byte("x"), 0o644,
+	); err != nil {
+		t.Fatalf("write db marker: %v", err)
+	}
+	if got := OpenCodeStorageSessionIDs(root); got != nil {
+		t.Fatalf("got %v, want nil for SQLite-only root", got)
+	}
+}
+
 func TestResolveOpenCodeWatchRootsStorage(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -792,27 +792,25 @@ func (e *Engine) classifyOpenCodePath(
 		if openCodeDir == "" {
 			continue
 		}
-		src := parser.ResolveOpenCodeSource(openCodeDir)
-		if src.Mode != parser.OpenCodeSourceStorage {
-			if src.Mode != parser.OpenCodeSourceSQLite {
-				continue
-			}
-			rel, ok := isUnder(openCodeDir, path)
-			if !ok {
-				continue
-			}
-			base := filepath.Base(rel)
-			if rel == "opencode.db" ||
-				strings.HasPrefix(base, "opencode.db-") {
+		rel, ok := isUnder(openCodeDir, path)
+		if !ok {
+			continue
+		}
+		base := filepath.Base(rel)
+		if rel == "opencode.db" ||
+			strings.HasPrefix(base, "opencode.db-") {
+			dbPath := filepath.Join(openCodeDir, "opencode.db")
+			if info, err := os.Stat(dbPath); err == nil &&
+				!info.IsDir() {
 				return parser.DiscoveredFile{
-					Path:  src.DBPath,
+					Path:  dbPath,
 					Agent: parser.AgentOpenCode,
 				}, true
 			}
 			continue
 		}
-		rel, ok := isUnder(openCodeDir, path)
-		if !ok {
+		if parser.ResolveOpenCodeSource(openCodeDir).Mode !=
+			parser.OpenCodeSourceStorage {
 			continue
 		}
 		parts := strings.Split(rel, sep)
@@ -1581,11 +1579,10 @@ func (e *Engine) syncOpenCode(
 func (e *Engine) syncOneOpenCode(
 	ctx context.Context, dir string,
 ) []pendingWrite {
-	src := parser.ResolveOpenCodeSource(dir)
-	if src.Mode != parser.OpenCodeSourceSQLite {
+	dbPath := filepath.Join(dir, "opencode.db")
+	if info, err := os.Stat(dbPath); err != nil || info.IsDir() {
 		return nil
 	}
-	dbPath := filepath.Join(dir, "opencode.db")
 
 	metas, err := parser.ListOpenCodeSessionMeta(dbPath)
 	if err != nil {
@@ -3902,11 +3899,11 @@ func (e *Engine) syncSingleOpenCode(
 		if dir == "" {
 			continue
 		}
-		if parser.ResolveOpenCodeSource(dir).Mode !=
-			parser.OpenCodeSourceSQLite {
+		dbPath := filepath.Join(dir, "opencode.db")
+		if info, err := os.Stat(dbPath); err != nil ||
+			info.IsDir() {
 			continue
 		}
-		dbPath := filepath.Join(dir, "opencode.db")
 		sess, msgs, err := parser.ParseOpenCodeSession(
 			dbPath, rawID, e.machine,
 		)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1593,8 +1593,13 @@ func (e *Engine) syncOneOpenCode(
 		return nil
 	}
 
+	storageIDs := parser.OpenCodeStorageSessionIDs(dir)
+
 	var changed []string
 	for _, m := range metas {
+		if _, ok := storageIDs[m.SessionID]; ok {
+			continue
+		}
 		_, storedMtime, ok :=
 			e.db.GetFileInfoByPath(m.VirtualPath)
 		if ok && storedMtime == m.FileMtime &&
@@ -2390,8 +2395,14 @@ func (e *Engine) processOpenCode(
 		if err != nil {
 			return processResult{err: err}
 		}
+		storageIDs := parser.OpenCodeStorageSessionIDs(
+			filepath.Dir(file.Path),
+		)
 		var results []parser.ParseResult
 		for _, meta := range metas {
+			if _, ok := storageIDs[meta.SessionID]; ok {
+				continue
+			}
 			_, storedMtime, ok := e.db.GetFileInfoByPath(meta.VirtualPath)
 			if ok && storedMtime == meta.FileMtime &&
 				e.db.GetDataVersionByPath(meta.VirtualPath) >=

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2375,6 +2375,102 @@ func TestSourceMtimeOpenCodeSQLiteUsesSessionTime(t *testing.T) {
 	}
 }
 
+func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
+	env := setupTestEnv(t)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	storage.addSession(
+		t, "global", "oc-hybrid-storage",
+		"/home/user/code/storage-app", "Hybrid Storage",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, "oc-hybrid-storage", "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, "oc-hybrid-storage", "msg-a1", "part-a1",
+		"storage reply", 1704067201000,
+	)
+
+	sqlite := createOpenCodeDB(t, env.opencodeDir)
+	sqlite.addProject(t, "proj-1", "/home/user/code/sqlite-app")
+	sessionID := "oc-hybrid-sqlite"
+	timeCreated := int64(1704067200000)
+	timeUpdated := int64(1704067205000)
+	sqlite.addSession(
+		t, sessionID, "proj-1",
+		timeCreated, timeUpdated,
+	)
+	sqlite.addMessage(
+		t, "sqlite-msg-u1", sessionID, "user", timeCreated,
+	)
+	sqlite.addMessage(
+		t, "sqlite-msg-a1", sessionID, "assistant", timeCreated+1,
+	)
+	sqlite.addTextPart(
+		t, "sqlite-part-u1", sessionID, "sqlite-msg-u1",
+		"original sqlite question", timeCreated,
+	)
+	sqlite.addTextPart(
+		t, "sqlite-part-a1", sessionID, "sqlite-msg-a1",
+		"original sqlite answer", timeCreated+1,
+	)
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2,
+		Synced:        2,
+		Skipped:       0,
+	})
+
+	assertMessageContent(
+		t, env.db, "opencode:oc-hybrid-storage",
+		"storage reply",
+	)
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID,
+		"original sqlite question",
+		"original sqlite answer",
+	)
+
+	virtualPath := parser.OpenCodeSQLiteVirtualPath(sqlite.path, sessionID)
+	if got := env.engine.FindSourceFile("opencode:" + sessionID); got != virtualPath {
+		t.Fatalf("FindSourceFile() = %q, want %q", got, virtualPath)
+	}
+	if got := env.engine.SourceMtime("opencode:" + sessionID); got != timeUpdated*1_000_000 {
+		t.Fatalf("SourceMtime() = %d, want %d", got, timeUpdated*1_000_000)
+	}
+
+	sqlite.replaceTextContent(
+		t, sessionID,
+		"updated by sync paths",
+		"updated sqlite answer",
+		timeCreated,
+	)
+	sqlite.updateSessionTime(t, sessionID, timeUpdated+1000)
+	env.engine.SyncPaths([]string{sqlite.path})
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID,
+		"updated by sync paths",
+		"updated sqlite answer",
+	)
+
+	sqlite.replaceTextContent(
+		t, sessionID,
+		"updated by single sync",
+		"updated sqlite answer again",
+		timeCreated,
+	)
+	sqlite.updateSessionTime(t, sessionID, timeUpdated+2000)
+	if err := env.engine.SyncSingleSession("opencode:" + sessionID); err != nil {
+		t.Fatalf("SyncSingleSession: %v", err)
+	}
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID,
+		"updated by single sync",
+		"updated sqlite answer again",
+	)
+}
+
 func TestSyncAllSinceOpenCodeStorageRequiresSessionMtime(t *testing.T) {
 	env := setupTestEnv(t)
 	oc := createOpenCodeStorageFixture(t, env.opencodeDir)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2471,6 +2471,92 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 	)
 }
 
+// TestOpenCodeHybridRootStorageWinsOnDuplicateID covers a hybrid
+// OpenCode root where the same session ID exists in both
+// storage/session and opencode.db. Storage is the canonical
+// transcript, so the SQLite duplicate must be skipped during sync
+// even when its time_updated is newer than the storage file mtime
+// — otherwise a stale SQLite row could overwrite live storage data.
+func TestOpenCodeHybridRootStorageWinsOnDuplicateID(t *testing.T) {
+	env := setupTestEnv(t)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-hybrid-dup"
+	storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/storage-app", "Hybrid Dup",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-storage-a1", "assistant",
+		1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, sessionID, "msg-storage-a1", "part-storage-a1",
+		"canonical storage reply", 1704067201000,
+	)
+
+	sqlite := createOpenCodeDB(t, env.opencodeDir)
+	sqlite.addProject(t, "proj-1", "/home/user/code/storage-app")
+	// Use a much newer time_updated so that without the
+	// duplicate-ID filter, shouldPreserveOpenCodeArchive's
+	// mtime check would not save the storage transcript.
+	timeCreated := int64(1704067200000)
+	timeUpdated := int64(1804067200000)
+	sqlite.addSession(
+		t, sessionID, "proj-1",
+		timeCreated, timeUpdated,
+	)
+	sqlite.addMessage(
+		t, "sqlite-msg-u1", sessionID, "user", timeCreated,
+	)
+	sqlite.addMessage(
+		t, "sqlite-msg-a1", sessionID, "assistant", timeCreated+1,
+	)
+	sqlite.addTextPart(
+		t, "sqlite-part-u1", sessionID, "sqlite-msg-u1",
+		"stale sqlite question", timeCreated,
+	)
+	sqlite.addTextPart(
+		t, "sqlite-part-a1", sessionID, "sqlite-msg-a1",
+		"stale sqlite answer", timeCreated+1,
+	)
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID,
+		"canonical storage reply",
+	)
+
+	storagePath := filepath.Join(
+		env.opencodeDir, "storage", "session", "global",
+		sessionID+".json",
+	)
+	if got := env.engine.FindSourceFile("opencode:" + sessionID); got != storagePath {
+		t.Fatalf("FindSourceFile() = %q, want %q", got, storagePath)
+	}
+
+	// SyncPaths on opencode.db must also leave the storage
+	// transcript untouched, even though the SQLite session was
+	// just modified.
+	sqlite.replaceTextContent(
+		t, sessionID,
+		"newer stale sqlite question",
+		"newer stale sqlite answer",
+		timeCreated,
+	)
+	sqlite.updateSessionTime(t, sessionID, timeUpdated+1000)
+	env.engine.SyncPaths([]string{sqlite.path})
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID,
+		"canonical storage reply",
+	)
+}
+
 func TestSyncAllSinceOpenCodeStorageRequiresSessionMtime(t *testing.T) {
 	env := setupTestEnv(t)
 	oc := createOpenCodeStorageFixture(t, env.opencodeDir)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2471,6 +2471,67 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 	)
 }
 
+// TestFindSourceFileSkipsHybridRootMissingSession covers the
+// multi-root shadowing case: an early hybrid root with an
+// opencode.db that lacks the requested session must not shadow a
+// later pure-storage root that contains it. Without the
+// session-existence gate in FindOpenCodeSourceFile, the engine
+// would return a virtual SQLite path pointing at the wrong DB.
+func TestFindSourceFileSkipsHybridRootMissingSession(t *testing.T) {
+	hybridRoot := t.TempDir()
+	storageRoot := t.TempDir()
+	if err := os.MkdirAll(
+		filepath.Join(hybridRoot, "storage", "session", "global"),
+		0o755,
+	); err != nil {
+		t.Fatalf("mkdir hybrid storage: %v", err)
+	}
+	if err := os.MkdirAll(
+		filepath.Join(storageRoot, "storage", "session", "global"),
+		0o755,
+	); err != nil {
+		t.Fatalf("mkdir storage root: %v", err)
+	}
+
+	hybridDB := createOpenCodeDB(t, hybridRoot)
+	hybridDB.addProject(t, "proj-x", "/tmp/x")
+	hybridDB.addSession(
+		t, "oc-only-in-hybrid-db", "proj-x",
+		1704067200000, 1704067205000,
+	)
+
+	const wantedID = "oc-real-in-storage"
+	storage := createOpenCodeStorageFixture(t, storageRoot)
+	storage.addSession(
+		t, "global", wantedID,
+		"/home/user/code/realapp", "Real Storage",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, wantedID, "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, wantedID, "msg-a1", "part-a1",
+		"real storage reply", 1704067201000,
+	)
+
+	env := setupTestEnv(
+		t,
+		WithOpenCodeDirs([]string{hybridRoot, storageRoot}),
+	)
+	wantPath := filepath.Join(
+		storageRoot, "storage", "session", "global",
+		wantedID+".json",
+	)
+	if got := env.engine.FindSourceFile("opencode:" + wantedID); got != wantPath {
+		t.Fatalf(
+			"FindSourceFile() = %q, want %q (hybrid root must not shadow)",
+			got, wantPath,
+		)
+	}
+}
+
 // TestOpenCodeHybridRootStorageWinsOnDuplicateID covers a hybrid
 // OpenCode root where the same session ID exists in both
 // storage/session and opencode.db. Storage is the canonical


### PR DESCRIPTION
## Summary
- sync OpenCode SQLite sessions whenever `opencode.db` exists, even when `storage/` is also present in the same root
- fall back to SQLite virtual paths in hybrid roots so source lookup, single-session sync, and DB change handling keep working for sqlite-only sessions
- add parser and integration regression coverage for hybrid storage+SQLite OpenCode roots

## Testing
- go test ./internal/parser ./internal/sync