### PR TITLE
ci: gate frontend with svelte-check and vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,29 @@ jobs:
       - name: Run Go linters
         run: make lint-ci
 
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Type-check (svelte-check)
+        run: npm run check
+        working-directory: frontend
+
+      - name: Run frontend tests
+        run: npm test
+        working-directory: frontend
+
   test:
     name: Go Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/frontend/src/lib/components/analytics/HealthTrend.svelte
+++ b/frontend/src/lib/components/analytics/HealthTrend.svelte
@@ -42,10 +42,10 @@
     </div>
     <div class="x-axis">
       {#if trend.length > 0}
-        <span>{trend[0].date}</span>
+        <span>{trend[0]!.date}</span>
       {/if}
       {#if trend.length > 1}
-        <span>{trend[trend.length - 1].date}</span>
+        <span>{trend[trend.length - 1]!.date}</span>
       {/if}
     </div>
     <div class="chart-caption">

--- a/frontend/src/lib/components/analytics/TopSessions.test.ts
+++ b/frontend/src/lib/components/analytics/TopSessions.test.ts
@@ -58,6 +58,7 @@ describe("TopSessions", () => {
           project: "proj",
           first_message: "hello",
           message_count: 10,
+          output_tokens: 0,
           duration_min: 5,
         },
       ],
@@ -86,6 +87,7 @@ describe("TopSessions", () => {
 
   it("sets filter and navigates when analytics includeOneShot is enabled", async () => {
     analytics.includeOneShot = true;
+    sessions.filters.includeOneShot = false;
     const component = mountWithData();
     await tick();
 

--- a/frontend/src/lib/components/content/SubagentInline.test.ts
+++ b/frontend/src/lib/components/content/SubagentInline.test.ts
@@ -53,6 +53,7 @@ function makeSession(
     peak_context_tokens: 0,
     has_total_output_tokens: true,
     has_peak_context_tokens: false,
+    is_automated: false,
     created_at: "2026-02-20T12:30:00Z",
     ...overrides,
   };

--- a/frontend/src/lib/components/content/ToolBlock.test.ts
+++ b/frontend/src/lib/components/content/ToolBlock.test.ts
@@ -201,8 +201,8 @@ describe("ToolBlock output section", () => {
 
     const historyEntries = Array.from(document.querySelectorAll(".history-content"));
     expect(historyEntries).toHaveLength(2);
-    expect(historyEntries[0].textContent).toBe("First finished");
-    expect(historyEntries[1].textContent).toBe("Second finished");
+    expect(historyEntries[0]!.textContent).toBe("First finished");
+    expect(historyEntries[1]!.textContent).toBe("Second finished");
   });
 });
 

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -46,6 +46,7 @@ function makeSession(
     user_message_count: 1,
     total_output_tokens: 0,
     peak_context_tokens: 0,
+    is_automated: false,
     created_at: "2026-02-20T12:30:00Z",
     ...overrides,
   };

--- a/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
@@ -53,7 +53,13 @@
   }}
 />
 
+<!--
+  Overlay is closed via Escape (svelte:window above) and via the
+  Cancel/× buttons inside the modal, so a separate keydown handler
+  here would be redundant.
+-->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div class="confirm-overlay" onclick={handleOverlayClick}>
   <div class="confirm-modal">
     <div class="confirm-header">

--- a/frontend/src/lib/components/sidebar/session-list-utils.test.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.test.ts
@@ -32,6 +32,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     user_message_count: 5,
     total_output_tokens: 0,
     peak_context_tokens: 0,
+    is_automated: false,
     created_at: "2025-01-01T00:00:00Z",
     ...overrides,
   };

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -252,7 +252,7 @@
       result.push({ key, d, color });
 
       for (let i = 0; i < points.length; i++) {
-        baselines[i] += points[i]!.values[key] ?? 0;
+        baselines[i] = baselines[i]! + (points[i]!.values[key] ?? 0);
       }
     }
 

--- a/frontend/src/lib/stores/messages.test.ts
+++ b/frontend/src/lib/stores/messages.test.ts
@@ -39,6 +39,7 @@ function makeSession(
     user_message_count: messageCount,
     total_output_tokens: 0,
     peak_context_tokens: 0,
+    is_automated: false,
     created_at: new Date(0).toISOString(),
   };
 }

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -408,6 +408,7 @@ describe("SessionsStore", () => {
               peak_context_tokens: 0,
               has_total_output_tokens: false,
               has_peak_context_tokens: false,
+              is_automated: false,
               created_at: "2024-01-01T00:00:00Z",
             },
           ],
@@ -430,6 +431,7 @@ describe("SessionsStore", () => {
               peak_context_tokens: 0,
               has_total_output_tokens: false,
               has_peak_context_tokens: false,
+              is_automated: false,
               created_at: "2024-01-01T00:00:01Z",
             },
           ],
@@ -1187,6 +1189,7 @@ function makeSession(
     user_message_count: 1,
     total_output_tokens: 0,
     peak_context_tokens: 0,
+    is_automated: false,
     created_at: "2024-01-01T00:00:00Z",
     ...overrides,
   };

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -34,6 +34,16 @@ vi.mock("../api/client.js", () => ({
   getSession: vi.fn(),
   getProjects: vi.fn(),
   getAgents: vi.fn(),
+  // invalidateFilterCaches() triggers sync.loadStats() which calls
+  // getStats(). Provide a default so the stale-state guards we
+  // exercise don't trip noisy "no export" stderr from the mock.
+  getStats: vi.fn().mockResolvedValue({
+    session_count: 0,
+    message_count: 0,
+    project_count: 0,
+    machine_count: 0,
+    earliest_session: null,
+  }),
   // Live-refresh subscription opens an EventSource via watchEvents.
   // Stub it so the mocked client doesn't blow up when the store
   // calls events.subscribeDebounced() during load().

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -38,6 +38,14 @@ function mockResyncSuccess(): void {
     machine_count: 1,
     earliest_session: null,
   });
+  // triggerResync schedules loadStatus() as a side effect.
+  // loadStatus() reads getSyncStatus and unconditionally sets
+  // lastSyncStats from the response, so mirror MOCK_STATS here so
+  // the post-resync state matches what the resync just produced.
+  vi.mocked(api.getSyncStatus).mockResolvedValue({
+    last_sync: "2024-01-01T00:00:00Z",
+    stats: MOCK_STATS,
+  });
 }
 
 function mockResyncFailure(error: Error): void {

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -212,6 +212,7 @@ describe("registerShortcuts", () => {
         user_message_count: 1,
         total_output_tokens: 0,
         peak_context_tokens: 0,
+        is_automated: false,
         created_at: "2024-01-01T00:00:00Z",
       };
     }

--- a/frontend/src/lib/virtual/CacheTestWrapper.svelte
+++ b/frontend/src/lib/virtual/CacheTestWrapper.svelte
@@ -13,9 +13,15 @@
   }
 
   let { type, controller, onInstanceChange }: Props = $props();
-  
+
+  // Test scaffolding: read the initial options off the controller once,
+  // then attach a mutator the test can call to drive option changes.
+  // The controller is a stable per-test object; we don't expect the
+  // prop reference itself to change during a test run.
+  // svelte-ignore state_referenced_locally
   let options = $state(controller.initialOptions);
 
+  // svelte-ignore state_referenced_locally
   controller.updateOptions = (newOpts: Options) => {
     options = newOpts;
   };

--- a/frontend/src/lib/virtual/VirtualizerTest.svelte
+++ b/frontend/src/lib/virtual/VirtualizerTest.svelte
@@ -9,12 +9,19 @@
 
   let { type, options, onInstanceChange } = $props();
 
+  // Test scaffolding: capture initial options into local state so
+  // setOptions() can override from outside. The $effect below keeps
+  // the local state in sync with prop changes.
+  // svelte-ignore state_referenced_locally
   let currentOptions = $state(options);
 
   $effect(() => {
     currentOptions = options;
   });
 
+  // Test scaffolding: type is selected once at mount; tests that need
+  // to switch type remount the component.
+  // svelte-ignore state_referenced_locally
   const virtualizer = type === 'window'
     ? createWindowVirtualizer(() => currentOptions)
     : createVirtualizer(() => currentOptions);


### PR DESCRIPTION
## Summary

Adds a `frontend` CI job running `npm run check` and `npm test`. Previously only `npm run build` was gated, so type errors and test failures didn't block merges.

## Changes

- **CI:** new `frontend` job runs svelte-check + vitest on every push/PR.
- **Type errors:** clears 24 pre-existing svelte-check errors — 3 production (`HealthTrend.svelte`, `CostTimeSeriesChart.svelte`) and 21 test fixtures missing `Session.is_automated` (required since #391) or `TopSession.output_tokens`.
- **Warnings:** silences 5 svelte-check warnings — `ConfirmDeleteModal` overlay (Escape + Cancel already cover keyboard) and `VirtualizerTest`/`CacheTestWrapper` test scaffolding (capture-once + manual-sync pattern is intentional).

## Latent test bugs uncovered

`npm test` appears to have never run in CI — the 999-test frontend suite was orphaned. Three problems surface once it runs:

- **`TopSessions.test.ts > sets filter and navigates...`** — was failing every run. `sessions.filters.includeOneShot` defaults to `true` in the store; test never reset it, so the click handler's invalidation branch never fired.
- **`sessions.test.ts > discards stale projects response...`** — passing by accident. The mock didn't expose `getStats`; `invalidateFilterCaches` → `loadStats` → `getStats` failed loudly on stderr but was swallowed by `loadStats`'s try/catch.
- **`sync.test.ts > triggerResync` (3 tests)** — passing by accident. `getSyncStatus` was bare `vi.fn()`; reading `status.last_sync` threw and was caught by `loadStatus`'s try/catch.