### PR TITLE
Fix/gemini jsonl import

### DIFF
--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -621,8 +621,14 @@ func IsAmpThreadFileName(name string) bool {
 	return isValidAmpThreadID(strings.TrimSuffix(name, ".json"))
 }
 
-// DiscoverGeminiSessions finds all session JSON files under
-// the Gemini directory (~/.gemini/tmp/*/chats/session-*.json).
+func isGeminiSessionFilename(name string) bool {
+	return strings.HasPrefix(name, "session-") &&
+		(strings.HasSuffix(name, ".json") ||
+			strings.HasSuffix(name, ".jsonl"))
+}
+
+// DiscoverGeminiSessions finds all Gemini session files under
+// the Gemini directory (~/.gemini/tmp/*/chats/session-*).
 func DiscoverGeminiSessions(
 	geminiDir string,
 ) []DiscoveredFile {
@@ -657,8 +663,7 @@ func DiscoverGeminiSessions(
 				continue
 			}
 			name := sf.Name()
-			if !strings.HasPrefix(name, "session-") ||
-				!strings.HasSuffix(name, ".json") {
+			if !isGeminiSessionFilename(name) {
 				continue
 			}
 			files = append(files, DiscoveredFile{
@@ -705,8 +710,7 @@ func FindGeminiSourceFile(
 				continue
 			}
 			name := sf.Name()
-			if !strings.HasPrefix(name, "session-") ||
-				!strings.HasSuffix(name, ".json") {
+			if !isGeminiSessionFilename(name) {
 				continue
 			}
 			if strings.Contains(name, sessionID[:8]) {

--- a/internal/parser/discovery_test.go
+++ b/internal/parser/discovery_test.go
@@ -485,12 +485,14 @@ func TestDiscoverGeminiSessions(t *testing.T) {
 		{
 			name: "SkipsNonSessionFiles",
 			files: map[string]string{
-				filepath.Join("tmp", "hash1", geminiChatsDir, "session-abc.json"): "{}",
-				filepath.Join("tmp", "hash1", geminiChatsDir, "other.json"):       "{}",
-				filepath.Join("tmp", "hash1", geminiChatsDir, "session-def.txt"):  "{}",
+				filepath.Join("tmp", "hash1", geminiChatsDir, "session-abc.json"):  "{}",
+				filepath.Join("tmp", "hash1", geminiChatsDir, "session-def.jsonl"): "{}",
+				filepath.Join("tmp", "hash1", geminiChatsDir, "other.json"):        "{}",
+				filepath.Join("tmp", "hash1", geminiChatsDir, "session-def.txt"):   "{}",
 			},
 			wantFiles: []string{
 				filepath.Join("tmp", "hash1", geminiChatsDir, "session-abc.json"),
+				filepath.Join("tmp", "hash1", geminiChatsDir, "session-def.jsonl"),
 			},
 		},
 		{
@@ -571,6 +573,14 @@ func TestFindGeminiSourceFile(t *testing.T) {
 			},
 			targetID: "b0a4eadd-cb99-4165-94d9-64cad5a66d24",
 			wantFile: filepath.Join("tmp", "hash1", geminiChatsDir, "session-2026-01-19T18-21-b0a4eadd.json"),
+		},
+		{
+			name: "FoundJSONL",
+			files: map[string]string{
+				filepath.Join("tmp", "hash1", geminiChatsDir, "session-2026-01-19T18-21-b0a4eadd.jsonl"): "{\"sessionId\":\"b0a4eadd-cb99-4165-94d9-64cad5a66d24\",\"kind\":\"main\"}\n",
+			},
+			targetID: "b0a4eadd-cb99-4165-94d9-64cad5a66d24",
+			wantFile: filepath.Join("tmp", "hash1", geminiChatsDir, "session-2026-01-19T18-21-b0a4eadd.jsonl"),
 		},
 		{
 			name: "Nonexistent",

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -55,7 +55,8 @@ func ParseGeminiSession(
 	var root gjson.Result
 	if valid {
 		root = gjson.ParseBytes(data)
-		if root.Get("messages").IsArray() {
+		if root.Get("messages").IsArray() ||
+			root.Get("sessionId").Exists() {
 			return parseGeminiJSONObject(
 				path, project, machine, info, root,
 			)
@@ -64,11 +65,6 @@ func ParseGeminiSession(
 	if bytes.IndexByte(data, '\n') >= 0 {
 		return parseGeminiJSONL(
 			path, project, machine, info, data,
-		)
-	}
-	if valid && root.Get("sessionId").Exists() {
-		return parseGeminiJSONObject(
-			path, project, machine, info, root,
 		)
 	}
 	return nil, nil, fmt.Errorf("invalid Gemini session in %s", path)

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -138,9 +138,11 @@ func parseGeminiJSONL(
 			continue
 		}
 		if !gjson.ValidBytes(line) {
-			return nil, nil, fmt.Errorf(
-				"invalid JSONL record in %s", path,
-			)
+			// Tolerate malformed lines: Gemini appends to this
+			// file while the session is live, so a watcher scan
+			// can race a partial trailing write. Matches the
+			// Claude JSONL parser's skip-invalid behavior.
+			continue
 		}
 		rec := gjson.ParseBytes(line)
 		if id := rec.Get("sessionId").Str; id != "" {

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -4,6 +4,7 @@ package parser
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -50,24 +51,22 @@ func ParseGeminiSession(
 		return nil, nil, fmt.Errorf("read %s: %w", path, err)
 	}
 
-	if gjson.ValidBytes(data) {
-		root := gjson.ParseBytes(data)
+	valid := gjson.ValidBytes(data)
+	var root gjson.Result
+	if valid {
+		root = gjson.ParseBytes(data)
 		if root.Get("messages").IsArray() {
 			return parseGeminiJSONObject(
 				path, project, machine, info, root,
 			)
 		}
 	}
-	if strings.ContainsRune(string(data), '\n') {
+	if bytes.IndexByte(data, '\n') >= 0 {
 		return parseGeminiJSONL(
 			path, project, machine, info, data,
 		)
 	}
-	if !gjson.ValidBytes(data) {
-		return nil, nil, fmt.Errorf("invalid JSON or JSONL in %s", path)
-	}
-	root := gjson.ParseBytes(data)
-	if root.Get("sessionId").Exists() {
+	if valid && root.Get("sessionId").Exists() {
 		return parseGeminiJSONObject(
 			path, project, machine, info, root,
 		)
@@ -135,7 +134,7 @@ func parseGeminiJSONL(
 		firstMessage   string
 		records        []gjson.Result
 		recordIDs      = make(map[string]int)
-		scanner        = bufio.NewScanner(strings.NewReader(string(data)))
+		scanner        = bufio.NewScanner(bytes.NewReader(data))
 		maxScanBufSize = 16 * 1024 * 1024
 	)
 	scanner.Buffer(make([]byte, 0, 64*1024), maxScanBufSize)
@@ -177,6 +176,10 @@ func parseGeminiJSONL(
 		}
 		msgID := rec.Get("id").Str
 		if msgID != "" {
+			// Later record with same id replaces the earlier one in
+			// place. Assumes Gemini does not reuse ids across roles
+			// (user vs gemini); collisions would silently flip the
+			// slot's role while keeping its chronological position.
 			if idx, ok := recordIDs[msgID]; ok {
 				records[idx] = rec
 				continue
@@ -444,7 +447,7 @@ func GeminiSessionID(data []byte) string {
 	if id := gjson.GetBytes(data, "sessionId").Str; id != "" {
 		return id
 	}
-	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -3,10 +3,12 @@
 package parser
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/tidwall/gjson"
 )
@@ -48,12 +50,36 @@ func ParseGeminiSession(
 		return nil, nil, fmt.Errorf("read %s: %w", path, err)
 	}
 
-	if !gjson.ValidBytes(data) {
-		return nil, nil, fmt.Errorf("invalid JSON in %s", path)
+	if gjson.ValidBytes(data) {
+		root := gjson.ParseBytes(data)
+		if root.Get("messages").IsArray() {
+			return parseGeminiJSONObject(
+				path, project, machine, info, root,
+			)
+		}
 	}
-
+	if strings.ContainsRune(string(data), '\n') {
+		return parseGeminiJSONL(
+			path, project, machine, info, data,
+		)
+	}
+	if !gjson.ValidBytes(data) {
+		return nil, nil, fmt.Errorf("invalid JSON or JSONL in %s", path)
+	}
 	root := gjson.ParseBytes(data)
+	if root.Get("sessionId").Exists() {
+		return parseGeminiJSONObject(
+			path, project, machine, info, root,
+		)
+	}
+	return nil, nil, fmt.Errorf("invalid Gemini session in %s", path)
+}
 
+func parseGeminiJSONObject(
+	path, project, machine string,
+	info os.FileInfo,
+	root gjson.Result,
+) (*ParsedSession, []ParsedMessage, error) {
 	sessionID := root.Get("sessionId").Str
 	if sessionID == "" {
 		return nil, nil, fmt.Errorf(
@@ -69,64 +95,179 @@ func ParseGeminiSession(
 		firstMessage string
 		ordinal      int
 	)
+	appendMessage := func(msg gjson.Result) {
+		parsed, ok := parseGeminiMessage(msg, ordinal)
+		if !ok {
+			return
+		}
+		if parsed.Role == RoleUser && firstMessage == "" {
+			firstMessage = truncate(
+				strings.ReplaceAll(parsed.Content, "\n", " "),
+				300,
+			)
+		}
+		messages = append(messages, parsed)
+		ordinal++
+	}
 
 	root.Get("messages").ForEach(
 		func(_, msg gjson.Result) bool {
-			msgType := msg.Get("type").Str
-			if msgType != "user" && msgType != "gemini" {
-				return true
-			}
-
-			ts := parseTimestamp(msg.Get("timestamp").Str)
-
-			role := RoleUser
-			if msgType == "gemini" {
-				role = RoleAssistant
-			}
-
-			content, hasThinking, hasToolUse, tcs, trs :=
-				extractGeminiContent(msg)
-			if strings.TrimSpace(content) == "" {
-				return true
-			}
-
-			if role == RoleUser && firstMessage == "" {
-				firstMessage = truncate(
-					strings.ReplaceAll(content, "\n", " "),
-					300,
-				)
-			}
-
-			tok := extractGeminiTokens(msg)
-			var tokenUsage json.RawMessage
-			tokResult := msg.Get("tokens")
-			if tokResult.Exists() {
-				tokenUsage = json.RawMessage(tokResult.Raw)
-			}
-			messages = append(messages, ParsedMessage{
-				Ordinal:       ordinal,
-				Role:          role,
-				Content:       content,
-				Timestamp:     ts,
-				HasThinking:   hasThinking,
-				HasToolUse:    hasToolUse,
-				ContentLength: len(content),
-				ToolCalls:     tcs,
-				ToolResults:   trs,
-				Model:         msg.Get("model").String(),
-				TokenUsage:    tokenUsage,
-				ContextTokens: tok.Input + tok.Cached,
-				OutputTokens:  tok.Output,
-				HasContextTokens: tokResult.Get("input").Exists() ||
-					tokResult.Get("cached").Exists(),
-				HasOutputTokens:    tokResult.Get("output").Exists(),
-				tokenPresenceKnown: true,
-			})
-			ordinal++
+			appendMessage(msg)
 			return true
 		},
 	)
+	return buildGeminiSession(
+		path, project, machine, info,
+		sessionID, startTime, lastUpdated,
+		firstMessage, messages,
+	), messages, nil
+}
 
+func parseGeminiJSONL(
+	path, project, machine string,
+	info os.FileInfo,
+	data []byte,
+) (*ParsedSession, []ParsedMessage, error) {
+	var (
+		sessionID      string
+		startTime      time.Time
+		lastUpdated    time.Time
+		firstMessage   string
+		records        []gjson.Result
+		recordIDs      = make(map[string]int)
+		scanner        = bufio.NewScanner(strings.NewReader(string(data)))
+		maxScanBufSize = 16 * 1024 * 1024
+	)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxScanBufSize)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if !gjson.Valid(line) {
+			return nil, nil, fmt.Errorf(
+				"invalid JSONL record in %s", path,
+			)
+		}
+		rec := gjson.Parse(line)
+		if id := rec.Get("sessionId").Str; id != "" {
+			if sessionID == "" {
+				sessionID = id
+			}
+			if startTime.IsZero() {
+				startTime = parseTimestamp(
+					rec.Get("startTime").Str,
+				)
+			}
+			if ts := parseTimestamp(
+				rec.Get("lastUpdated").Str,
+			); ts.After(lastUpdated) {
+				lastUpdated = ts
+			}
+		}
+		if ts := parseTimestamp(
+			rec.Get("$set.lastUpdated").Str,
+		); ts.After(lastUpdated) {
+			lastUpdated = ts
+		}
+
+		msgType := rec.Get("type").Str
+		if msgType != "user" && msgType != "gemini" {
+			continue
+		}
+		msgID := rec.Get("id").Str
+		if msgID != "" {
+			if idx, ok := recordIDs[msgID]; ok {
+				records[idx] = rec
+				continue
+			}
+			recordIDs[msgID] = len(records)
+		}
+		records = append(records, rec)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, nil, fmt.Errorf("scan %s: %w", path, err)
+	}
+	if sessionID == "" {
+		return nil, nil, fmt.Errorf(
+			"missing sessionId in %s", path,
+		)
+	}
+
+	messages := make([]ParsedMessage, 0, len(records))
+	for _, rec := range records {
+		parsed, ok := parseGeminiMessage(rec, len(messages))
+		if !ok {
+			continue
+		}
+		if parsed.Role == RoleUser && firstMessage == "" {
+			firstMessage = truncate(
+				strings.ReplaceAll(parsed.Content, "\n", " "),
+				300,
+			)
+		}
+		messages = append(messages, parsed)
+	}
+	return buildGeminiSession(
+		path, project, machine, info,
+		sessionID, startTime, lastUpdated,
+		firstMessage, messages,
+	), messages, nil
+}
+
+func parseGeminiMessage(
+	msg gjson.Result, ordinal int,
+) (ParsedMessage, bool) {
+	msgType := msg.Get("type").Str
+	if msgType != "user" && msgType != "gemini" {
+		return ParsedMessage{}, false
+	}
+
+	role := RoleUser
+	if msgType == "gemini" {
+		role = RoleAssistant
+	}
+	content, hasThinking, hasToolUse, tcs, trs :=
+		extractGeminiContent(msg)
+	if strings.TrimSpace(content) == "" {
+		return ParsedMessage{}, false
+	}
+
+	tok := extractGeminiTokens(msg)
+	var tokenUsage json.RawMessage
+	tokResult := msg.Get("tokens")
+	if tokResult.Exists() {
+		tokenUsage = json.RawMessage(tokResult.Raw)
+	}
+	return ParsedMessage{
+		Ordinal:       ordinal,
+		Role:          role,
+		Content:       content,
+		Timestamp:     parseTimestamp(msg.Get("timestamp").Str),
+		HasThinking:   hasThinking,
+		HasToolUse:    hasToolUse,
+		ContentLength: len(content),
+		ToolCalls:     tcs,
+		ToolResults:   trs,
+		Model:         msg.Get("model").String(),
+		TokenUsage:    tokenUsage,
+		ContextTokens: tok.Input + tok.Cached,
+		OutputTokens:  tok.Output,
+		HasContextTokens: tokResult.Get("input").Exists() ||
+			tokResult.Get("cached").Exists(),
+		HasOutputTokens:    tokResult.Get("output").Exists(),
+		tokenPresenceKnown: true,
+	}, true
+}
+
+func buildGeminiSession(
+	path, project, machine string,
+	info os.FileInfo,
+	sessionID string,
+	startTime, lastUpdated time.Time,
+	firstMessage string,
+	messages []ParsedMessage,
+) *ParsedSession {
 	var userCount int
 	for _, m := range messages {
 		if m.Role == RoleUser && m.Content != "" {
@@ -151,8 +292,7 @@ func ParseGeminiSession(
 		},
 	}
 	accumulateMessageTokenUsage(sess, messages)
-
-	return sess, messages, nil
+	return sess
 }
 
 // extractGeminiContent builds readable text from a Gemini
@@ -301,5 +441,19 @@ func formatGeminiToolCall(tc gjson.Result) string {
 // GeminiSessionID extracts the sessionId field from raw
 // Gemini session JSON data without fully parsing.
 func GeminiSessionID(data []byte) string {
-	return gjson.GetBytes(data, "sessionId").Str
+	if id := gjson.GetBytes(data, "sessionId").Str; id != "" {
+		return id
+	}
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || !gjson.Valid(line) {
+			continue
+		}
+		if id := gjson.Get(line, "sessionId").Str; id != "" {
+			return id
+		}
+	}
+	return ""
 }

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -3,7 +3,6 @@
 package parser
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -124,27 +123,26 @@ func parseGeminiJSONL(
 	data []byte,
 ) (*ParsedSession, []ParsedMessage, error) {
 	var (
-		sessionID      string
-		startTime      time.Time
-		lastUpdated    time.Time
-		firstMessage   string
-		records        = make([]gjson.Result, 0)
-		recordIDs      = make(map[string]int)
-		scanner        = bufio.NewScanner(bytes.NewReader(data))
-		maxScanBufSize = 16 * 1024 * 1024
+		sessionID    string
+		startTime    time.Time
+		lastUpdated  time.Time
+		firstMessage string
+		records      = make([]gjson.Result, 0)
+		recordIDs    = make(map[string]int)
 	)
-	scanner.Buffer(make([]byte, 0, 64*1024), maxScanBufSize)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
+	for len(data) > 0 {
+		line, rest, _ := bytes.Cut(data, []byte("\n"))
+		data = rest
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
 			continue
 		}
-		if !gjson.Valid(line) {
+		if !gjson.ValidBytes(line) {
 			return nil, nil, fmt.Errorf(
 				"invalid JSONL record in %s", path,
 			)
 		}
-		rec := gjson.Parse(line)
+		rec := gjson.ParseBytes(line)
 		if id := rec.Get("sessionId").Str; id != "" {
 			if sessionID == "" {
 				sessionID = id
@@ -183,9 +181,6 @@ func parseGeminiJSONL(
 			recordIDs[msgID] = len(records)
 		}
 		records = append(records, rec)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, nil, fmt.Errorf("scan %s: %w", path, err)
 	}
 	if sessionID == "" {
 		return nil, nil, fmt.Errorf(
@@ -443,14 +438,14 @@ func GeminiSessionID(data []byte) string {
 	if id := gjson.GetBytes(data, "sessionId").Str; id != "" {
 		return id
 	}
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || !gjson.Valid(line) {
+	for len(data) > 0 {
+		line, rest, _ := bytes.Cut(data, []byte("\n"))
+		data = rest
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || !gjson.ValidBytes(line) {
 			continue
 		}
-		if id := gjson.Get(line, "sessionId").Str; id != "" {
+		if id := gjson.GetBytes(line, "sessionId").Str; id != "" {
 			return id
 		}
 	}

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -128,7 +128,7 @@ func parseGeminiJSONL(
 		startTime      time.Time
 		lastUpdated    time.Time
 		firstMessage   string
-		records        []gjson.Result
+		records        = make([]gjson.Result, 0)
 		recordIDs      = make(map[string]int)
 		scanner        = bufio.NewScanner(bytes.NewReader(data))
 		maxScanBufSize = 16 * 1024 * 1024

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -34,6 +34,38 @@ func TestParseGeminiSession_Basic(t *testing.T) {
 	assert.Equal(t, 1, msgs[1].Ordinal)
 }
 
+func TestParseGeminiSession_JSONLStream(t *testing.T) {
+	content := strings.Join([]string{
+		`{"sessionId":"sess-jsonl-1","projectHash":"hash","startTime":"2026-04-23T16:12:42.783Z","lastUpdated":"2026-04-23T16:12:42.783Z","kind":"main"}`,
+		`{"id":"u1","timestamp":"2026-04-23T16:12:43.085Z","type":"user","content":[{"text":"Fix the import path"}]}`,
+		`{"$set":{"lastUpdated":"2026-04-23T16:12:43.085Z"}}`,
+		`{"id":"a1","timestamp":"2026-04-23T16:12:50.158Z","type":"gemini","content":"","thoughts":[{"subject":"Planning","description":"Looking for the failure.","timestamp":"2026-04-23T16:12:46.795Z"}],"tokens":{"input":9184,"output":26,"cached":0},"model":"gemini-3.1-pro-preview"}`,
+		`{"id":"a1","timestamp":"2026-04-23T16:12:50.158Z","type":"gemini","content":"I found the issue.","thoughts":[{"subject":"Planning","description":"Looking for the failure.","timestamp":"2026-04-23T16:12:46.795Z"}],"tokens":{"input":9184,"output":26,"cached":0},"model":"gemini-3.1-pro-preview","toolCalls":[{"id":"read_file_1","name":"read_file","args":{"file_path":"main.go"},"result":[{"functionResponse":{"id":"read_file_1","name":"read_file","response":{"output":"package main"}}}],"displayName":"ReadFile"}]}`,
+		`{"$set":{"lastUpdated":"2026-04-23T16:12:50.158Z"}}`,
+	}, "\n")
+	path := createTestFile(t, "session.jsonl", content)
+	sess, msgs, err := ParseGeminiSession(path, "my_project", "local")
+	require.NoError(t, err)
+
+	require.NotNil(t, sess)
+	require.Equal(t, 2, len(msgs))
+	assertSessionMeta(t, sess, "gemini:sess-jsonl-1", "my_project", AgentGemini)
+	assert.Equal(t, "Fix the import path", sess.FirstMessage)
+	assertMessage(t, msgs[0], RoleUser, "Fix the import path")
+	assertMessage(t, msgs[1], RoleAssistant, "I found the issue.")
+	assert.True(t, msgs[1].HasThinking)
+	assert.True(t, msgs[1].HasToolUse)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "read_file_1", msgs[1].ToolCalls[0].ToolUseID)
+	require.Len(t, msgs[1].ToolResults, 1)
+	assert.Equal(t, "package main", DecodeContent(msgs[1].ToolResults[0].ContentRaw))
+	assert.Equal(
+		t,
+		parseTimestamp("2026-04-23T16:12:50.158Z"),
+		sess.EndedAt,
+	)
+}
+
 func TestParseGeminiSession_ToolCalls(t *testing.T) {
 	t.Run("basic tool calls", func(t *testing.T) {
 		content := loadFixture(t, "gemini/tool_calls.json")

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -66,6 +66,22 @@ func TestParseGeminiSession_JSONLStream(t *testing.T) {
 	)
 }
 
+func TestParseGeminiSession_JSONLStreamLargeRecord(t *testing.T) {
+	largeContent := strings.Repeat("x", 16*1024*1024+1)
+	content := strings.Join([]string{
+		`{"sessionId":"sess-jsonl-large","projectHash":"hash","startTime":"2026-04-23T16:12:42.783Z","lastUpdated":"2026-04-23T16:12:42.783Z","kind":"main"}`,
+		`{"id":"u1","timestamp":"2026-04-23T16:12:43.085Z","type":"user","content":[{"text":"` + largeContent + `"}]}`,
+	}, "\n")
+	path := createTestFile(t, "large-session.jsonl", content)
+	sess, msgs, err := ParseGeminiSession(path, "my_project", "local")
+	require.NoError(t, err)
+
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 1)
+	assertSessionMeta(t, sess, "gemini:sess-jsonl-large", "my_project", AgentGemini)
+	assert.Equal(t, len(largeContent), len(msgs[0].Content))
+}
+
 func TestParseGeminiSession_ToolCalls(t *testing.T) {
 	t.Run("basic tool calls", func(t *testing.T) {
 		content := loadFixture(t, "gemini/tool_calls.json")

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -82,6 +82,41 @@ func TestParseGeminiSession_JSONLStreamLargeRecord(t *testing.T) {
 	assert.Equal(t, len(largeContent), len(msgs[0].Content))
 }
 
+func TestParseGeminiSession_JSONLStreamTolerantOfPartialLines(t *testing.T) {
+	t.Run("partial trailing write", func(t *testing.T) {
+		content := strings.Join([]string{
+			`{"sessionId":"sess-jsonl-partial","projectHash":"hash","startTime":"2026-04-23T16:12:42.783Z","lastUpdated":"2026-04-23T16:12:42.783Z","kind":"main"}`,
+			`{"id":"u1","timestamp":"2026-04-23T16:12:43.085Z","type":"user","content":[{"text":"first"}]}`,
+			`{"id":"a1","timestamp":"2026-04-23T16:12:50.158Z","type":"gemini","content":"reply"`,
+		}, "\n")
+		path := createTestFile(t, "session.jsonl", content)
+		sess, msgs, err := ParseGeminiSession(path, "my_project", "local")
+		require.NoError(t, err)
+
+		require.NotNil(t, sess)
+		require.Equal(t, 1, len(msgs))
+		assertMessage(t, msgs[0], RoleUser, "first")
+	})
+
+	t.Run("malformed line mid-stream", func(t *testing.T) {
+		content := strings.Join([]string{
+			`{"sessionId":"sess-jsonl-mid","projectHash":"hash","startTime":"2026-04-23T16:12:42.783Z","lastUpdated":"2026-04-23T16:12:42.783Z","kind":"main"}`,
+			`{"id":"u1","timestamp":"2026-04-23T16:12:43.085Z","type":"user","content":[{"text":"first"}]}`,
+			`{not valid json`,
+			`{"id":"a1","timestamp":"2026-04-23T16:12:50.158Z","type":"gemini","content":"reply"}`,
+			"",
+		}, "\n")
+		path := createTestFile(t, "session.jsonl", content)
+		sess, msgs, err := ParseGeminiSession(path, "my_project", "local")
+		require.NoError(t, err)
+
+		require.NotNil(t, sess)
+		require.Equal(t, 2, len(msgs))
+		assertMessage(t, msgs[0], RoleUser, "first")
+		assertMessage(t, msgs[1], RoleAssistant, "reply")
+	})
+}
+
 func TestParseGeminiSession_ToolCalls(t *testing.T) {
 	t.Run("basic tool calls", func(t *testing.T) {
 		content := loadFixture(t, "gemini/tool_calls.json")

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1411,6 +1411,11 @@ func TestGeminiSessionID(t *testing.T) {
 		t.Errorf("GeminiSessionID = %q, want %q", got, "abc-123")
 	}
 
+	got = GeminiSessionID([]byte("{\"sessionId\":\"jsonl-123\"}\n{\"type\":\"user\"}\n"))
+	if got != "jsonl-123" {
+		t.Errorf("GeminiSessionID JSONL = %q, want %q", got, "jsonl-123")
+	}
+
 	got = GeminiSessionID([]byte(`{}`))
 	if got != "" {
 		t.Errorf("GeminiSessionID empty = %q, want empty", got)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -464,7 +464,7 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
-	// Gemini: <geminiDir>/tmp/<dir>/chats/session-*.json
+	// Gemini: <geminiDir>/tmp/<dir>/chats/session-*.json(.l)
 	// <dir> is either a SHA-256 hash (old) or project name (new).
 	for _, geminiDir := range e.agentDirs[parser.AgentGemini] {
 		if geminiDir == "" {
@@ -479,7 +479,8 @@ func (e *Engine) classifyOnePath(
 			}
 			name := parts[3]
 			if !strings.HasPrefix(name, "session-") ||
-				!strings.HasSuffix(name, ".json") {
+				(!strings.HasSuffix(name, ".json") &&
+					!strings.HasSuffix(name, ".jsonl")) {
 				continue
 			}
 			dirName := parts[1]

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1073,6 +1073,41 @@ func TestSyncPathsGemini(t *testing.T) {
 	assertSessionMessageCount(t, env.db, "gemini:"+sessionID, 2)
 }
 
+func TestSyncPathsGeminiJSONL(t *testing.T) {
+	env := setupTestEnv(t)
+
+	sessionID := "gem-test-jsonl"
+	hash := "abcdef1234567890"
+	content := strings.Join([]string{
+		`{"sessionId":"gem-test-jsonl","projectHash":"abcdef1234567890","startTime":"` + tsEarly + `","lastUpdated":"` + tsEarly + `","kind":"main"}`,
+		`{"id":"m1","timestamp":"` + tsEarly + `","type":"user","content":[{"text":"Hello Gemini"}]}`,
+		`{"$set":{"lastUpdated":"` + tsEarlyS5 + `"}}`,
+		`{"id":"m2","timestamp":"` + tsEarlyS5 + `","type":"gemini","content":"Hi there!","model":"gemini-3.1-pro-preview","tokens":{"input":10,"output":5,"cached":0}}`,
+	}, "\n")
+
+	path := env.writeGeminiSession(
+		t,
+		filepath.Join(
+			"tmp", hash, "chats",
+			"session-001.jsonl",
+		),
+		content,
+	)
+
+	env.engine.SyncPaths([]string{path})
+
+	assertSessionState(
+		t, env.db, "gemini:"+sessionID,
+		func(sess *db.Session) {
+			if sess.Agent != "gemini" {
+				t.Errorf("agent = %q, want gemini",
+					sess.Agent)
+			}
+		},
+	)
+	assertSessionMessageCount(t, env.db, "gemini:"+sessionID, 2)
+}
+
 func TestSyncPathsCodexRejectsFlat(t *testing.T) {
 	env := setupTestEnv(t)
 


### PR DESCRIPTION
Fixes #407

This updates Gemini session ingestion to support newer `.jsonl` session files.

Changes:
- discover Gemini `session-*.jsonl` files
- classify `.jsonl` Gemini sessions in sync paths
- parse the new streamed Gemini JSONL format
- preserve compatibility with legacy Gemini `.json` session files
- add regression coverage for discovery, parsing, and sync

Coded with codex, reviewed with roborev + claude and gemini