### PR TITLE
fix(sync): run remote SSH commands through POSIX shell

### DIFF
--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -13,11 +13,11 @@ import (
 // buildSSHArgs constructs args for the ssh command.
 //
 // Remote commands are always executed through a POSIX shell via
-// "sh -lc '<cmd>'" so behavior is independent of the remote user's
+// "sh -c '<cmd>'" so behavior is independent of the remote user's
 // login shell (e.g. fish).
 //
-// Returns ["ssh", "user@host", "--", "sh -lc '<cmd>'"] or
-// ["ssh", "host", "--", "sh -lc '<cmd>'"] when user is empty.
+// Returns ["ssh", "user@host", "--", "sh -c '<cmd>'"] or
+// ["ssh", "host", "--", "sh -c '<cmd>'"] when user is empty.
 // Port adds "-p N" when > 0. Extra opts are inserted before the
 // target (e.g. "-i keyfile").
 func buildSSHArgs(
@@ -27,7 +27,7 @@ func buildSSHArgs(
 	if user != "" {
 		target = user + "@" + host
 	}
-	remoteCmd := "sh -lc " + shellQuote(cmd)
+	remoteCmd := "sh -c " + shellQuote(cmd)
 	args := []string{"ssh"}
 	if port > 0 {
 		args = append(args, "-p", strconv.Itoa(port))

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -11,9 +11,15 @@ import (
 )
 
 // buildSSHArgs constructs args for the ssh command.
-// Returns ["ssh", "user@host", "--", cmd] or ["ssh", "host", "--", cmd]
-// when user is empty. Port adds "-p N" when > 0. Extra opts are
-// inserted before the target (e.g. "-i keyfile").
+//
+// Remote commands are always executed through a POSIX shell via
+// "sh -lc '<cmd>'" so behavior is independent of the remote user's
+// login shell (e.g. fish).
+//
+// Returns ["ssh", "user@host", "--", "sh -lc '<cmd>'"] or
+// ["ssh", "host", "--", "sh -lc '<cmd>'"] when user is empty.
+// Port adds "-p N" when > 0. Extra opts are inserted before the
+// target (e.g. "-i keyfile").
 func buildSSHArgs(
 	host, user string, port int, sshOpts []string, cmd string,
 ) []string {
@@ -21,12 +27,13 @@ func buildSSHArgs(
 	if user != "" {
 		target = user + "@" + host
 	}
+	remoteCmd := "sh -lc " + shellQuote(cmd)
 	args := []string{"ssh"}
 	if port > 0 {
 		args = append(args, "-p", strconv.Itoa(port))
 	}
 	args = append(args, sshOpts...)
-	return append(args, target, "--", cmd)
+	return append(args, target, "--", remoteCmd)
 }
 
 // runSSH executes a command on the remote host and returns stdout.

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -21,7 +21,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			host: "devbox1",
 			cmd:  "echo hello",
 			want: []string{
-				"ssh", "devbox1", "--", "echo hello",
+				"ssh", "devbox1", "--", "sh -lc 'echo hello'",
 			},
 		},
 		{
@@ -30,7 +30,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			user: "wes",
 			cmd:  "ls -la",
 			want: []string{
-				"ssh", "wes@devbox1", "--", "ls -la",
+				"ssh", "wes@devbox1", "--", "sh -lc 'ls -la'",
 			},
 		},
 		{
@@ -41,7 +41,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			cmd:  "echo hi",
 			want: []string{
 				"ssh", "-p", "2222",
-				"wes@devbox1", "--", "echo hi",
+				"wes@devbox1", "--", "sh -lc 'echo hi'",
 			},
 		},
 		{
@@ -49,7 +49,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			host: "devbox1",
 			cmd:  "echo hi",
 			want: []string{
-				"ssh", "devbox1", "--", "echo hi",
+				"ssh", "devbox1", "--", "sh -lc 'echo hi'",
 			},
 		},
 		{
@@ -66,7 +66,16 @@ func TestBuildSSHArgs(t *testing.T) {
 				"ssh", "-p", "2222",
 				"-i", "/tmp/key",
 				"-o", "StrictHostKeyChecking=no",
-				"wes@devbox1", "--", "ls",
+				"wes@devbox1", "--", "sh -lc 'ls'",
+			},
+		},
+		{
+			name: "escapes single quotes",
+			host: "devbox1",
+			cmd:  `printf "it's fine"`,
+			want: []string{
+				"ssh", "devbox1", "--",
+				`sh -lc 'printf "it'\''s fine"'`,
 			},
 		},
 	}

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -21,7 +21,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			host: "devbox1",
 			cmd:  "echo hello",
 			want: []string{
-				"ssh", "devbox1", "--", "sh -lc 'echo hello'",
+				"ssh", "devbox1", "--", "sh -c 'echo hello'",
 			},
 		},
 		{
@@ -30,7 +30,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			user: "wes",
 			cmd:  "ls -la",
 			want: []string{
-				"ssh", "wes@devbox1", "--", "sh -lc 'ls -la'",
+				"ssh", "wes@devbox1", "--", "sh -c 'ls -la'",
 			},
 		},
 		{
@@ -41,7 +41,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			cmd:  "echo hi",
 			want: []string{
 				"ssh", "-p", "2222",
-				"wes@devbox1", "--", "sh -lc 'echo hi'",
+				"wes@devbox1", "--", "sh -c 'echo hi'",
 			},
 		},
 		{
@@ -49,7 +49,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			host: "devbox1",
 			cmd:  "echo hi",
 			want: []string{
-				"ssh", "devbox1", "--", "sh -lc 'echo hi'",
+				"ssh", "devbox1", "--", "sh -c 'echo hi'",
 			},
 		},
 		{
@@ -66,7 +66,7 @@ func TestBuildSSHArgs(t *testing.T) {
 				"ssh", "-p", "2222",
 				"-i", "/tmp/key",
 				"-o", "StrictHostKeyChecking=no",
-				"wes@devbox1", "--", "sh -lc 'ls'",
+				"wes@devbox1", "--", "sh -c 'ls'",
 			},
 		},
 		{
@@ -75,7 +75,7 @@ func TestBuildSSHArgs(t *testing.T) {
 			cmd:  `printf "it's fine"`,
 			want: []string{
 				"ssh", "devbox1", "--",
-				`sh -lc 'printf "it'\''s fine"'`,
+				`sh -c 'printf "it'\''s fine"'`,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- execute remote sync SSH commands via `sh -lc` so command parsing is independent of the remote login shell
- preserve safe shell quoting for remote command strings, including embedded single quotes
- update `buildSSHArgs` tests to assert POSIX-shell wrapping and quote escaping behavior

## Validation
- make test
- env GOTOOLCHAIN=go1.26.2 make lint