### PR TITLE
feat(frontend): render Claude Code bash shortcut wrappers as code

### DIFF
--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -3,6 +3,7 @@
   import { sessions } from "../../stores/sessions.svelte.js";
   import { router } from "../../stores/router.svelte.js";
   import { formatTokenCount } from "../../utils/format.js";
+  import { normalizeMessagePreview } from "../../utils/messages.js";
 
   function truncate(text: string, max: number): string {
     if (text.length <= max) return text;
@@ -82,6 +83,7 @@
   {:else if analytics.topSessions && analytics.topSessions.sessions.length > 0}
     <div class="session-list">
       {#each analytics.topSessions.sessions as session, i}
+        {@const preview = normalizeMessagePreview(session.first_message)}
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
@@ -91,8 +93,8 @@
           <span class="rank">{i + 1}</span>
           <div class="session-info">
             <span class="session-label">
-              {session.first_message
-                ? truncate(session.first_message, 50)
+              {preview
+                ? truncate(preview, 50)
                 : session.id.slice(0, 12)}
             </span>
             <span class="session-project">{session.project}</span>

--- a/frontend/src/lib/components/command-palette/CommandPalette.svelte
+++ b/frontend/src/lib/components/command-palette/CommandPalette.svelte
@@ -12,6 +12,7 @@
   import { agentColor } from "../../utils/agents.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
   import { stripIdPrefix } from "../../utils/resume.js";
+  import { normalizeMessagePreview } from "../../utils/messages.js";
   import type { Session, SearchResult } from "../../api/types.js";
 
   let inputRef: HTMLInputElement | undefined = $state(undefined);
@@ -224,6 +225,7 @@
       {:else}
         <div class="palette-section-label">Recent Sessions</div>
         {#each recentSessions as session, i}
+          {@const preview = normalizeMessagePreview(session.first_message)}
           <button
             class="palette-item"
             class:selected={i === selectedIndex}
@@ -232,8 +234,8 @@
           >
             <span class="item-dot" style:background={agentColor(session.agent)}></span>
             <span class="item-body">
-              <span class="item-name">{session.first_message
-                ? truncate(session.first_message, 60)
+              <span class="item-name">{preview
+                ? truncate(preview, 60)
                 : session.project}</span>
             </span>
             <span class="item-meta">

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -11,6 +11,7 @@
   import { copyToClipboard } from "../../utils/clipboard.js";
   import { agentColor, agentLabel } from "../../utils/agents.js";
   import { formatTokenUsage } from "../../utils/format.js";
+  import { normalizeMessagePreview } from "../../utils/messages.js";
   import { getGradeStyle, getGradeLabel } from "../../utils/grade.js";
   import SignalPanel from "../content/SignalPanel.svelte";
   import { sessions } from "../../stores/sessions.svelte.js";
@@ -158,7 +159,8 @@
   function startRename() {
     if (!session) return;
     renameValue =
-      session.display_name ?? session.first_message ?? "";
+      session.display_name
+      ?? normalizeMessagePreview(session.first_message);
     renaming = true;
     closeMenu();
     requestAnimationFrame(() => renameInput?.select());

--- a/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
@@ -3,6 +3,7 @@
   import { ui } from "../../stores/ui.svelte.js";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { truncate } from "../../utils/format.js";
+  import { normalizeMessagePreview } from "../../utils/messages.js";
 
   let deleting = $state(false);
   let deleteBtn = $state<HTMLButtonElement>();
@@ -10,10 +11,14 @@
   let sessionName = $derived.by(() => {
     const s = sessions.activeSession;
     if (!s) return "this session";
-    return truncate(
-      s.display_name ?? s.first_message ?? s.project ?? "this session",
-      60,
-    );
+    const raw =
+      s.display_name
+      ?? (
+        normalizeMessagePreview(s.first_message)
+        || s.project
+        || "this session"
+      );
+    return truncate(raw, 60);
   });
 
   function close() {

--- a/frontend/src/lib/components/pinned/PinnedPage.svelte
+++ b/frontend/src/lib/components/pinned/PinnedPage.svelte
@@ -6,6 +6,7 @@
   import { formatRelativeTime, truncate } from "../../utils/format.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
+  import { normalizeMessagePreview } from "../../utils/messages.js";
 
   $effect(() => {
     pins.loadAll(sessions.filters.project || undefined);
@@ -33,7 +34,13 @@
       return {
         project: pin.session_project ?? "unknown",
         agent: pin.session_agent ?? "unknown",
-        name: pin.session_display_name ?? pin.session_first_message ?? pin.session_project ?? pin.session_id.slice(0, 12),
+        name:
+          pin.session_display_name
+          ?? (
+            normalizeMessagePreview(pin.session_first_message)
+            || pin.session_project
+            || pin.session_id.slice(0, 12)
+          ),
       };
     }
     const s = sessions.sessions.find((s) => s.id === pin.session_id);
@@ -41,7 +48,9 @@
       ? {
           project: s.project,
           agent: s.agent,
-          name: s.display_name ?? s.first_message ?? s.project,
+          name:
+            s.display_name
+            ?? (normalizeMessagePreview(s.first_message) || s.project),
         }
       : {
           project: "unknown",

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -540,12 +540,11 @@
 
   .session-name.shell > code {
     font-family: var(--font-mono);
-    font-size: 0.92em;
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    border-radius: 3px;
-    padding: 1px 5px;
-    color: var(--text-primary);
+    font-size: 0.95em;
+    background: transparent;
+    border: none;
+    padding: 0;
+    color: var(--text-secondary);
     letter-spacing: 0;
   }
 

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -4,7 +4,10 @@
   import { starred } from "../../stores/starred.svelte.js";
   import { formatRelativeTime, truncate } from "../../utils/format.js";
   import { agentColor as getAgentColor, agentLabel } from "../../utils/agents.js";
-  import { normalizeMessagePreview } from "../../utils/messages.js";
+  import {
+    normalizeMessagePreview,
+    previewMessage,
+  } from "../../utils/messages.js";
 
   interface Props {
     session: Session;
@@ -78,8 +81,13 @@
    * description (e.g. "Task #2: Align ROADMAP.md...") instead of the
    * repetitive "You are a teammate on..." boilerplate.
    */
-  let displayName = $derived.by(() => {
-    if (session.display_name) return truncate(session.display_name, 50);
+  let displayLabel = $derived.by((): { text: string; isShell: boolean } => {
+    if (session.display_name) {
+      return {
+        text: truncate(session.display_name, 50),
+        isShell: false,
+      };
+    }
     let msg = session.first_message ?? "";
     if (msg.includes("<teammate-message")) {
       msg = msg
@@ -89,17 +97,18 @@
       // Extract "Task #N: description" from the boilerplate.
       const taskMatch = msg.match(/Task\s*#?\d+[:\s]+(.+?)(?:\s+\d+\.|$)/s);
       if (taskMatch) {
-        return truncate(taskMatch[1]!.trim(), 50);
+        return { text: truncate(taskMatch[1]!.trim(), 50), isShell: false };
       }
       // Fallback: skip the "You are a teammate on ..." boilerplate.
       const afterTeam = msg.match(/team[."]\s*[^.]*?[.]\s+(.+)/s)
         ?? msg.match(/You are a teammate[^.]*\.\s+(.+)/s);
       if (afterTeam) {
-        return truncate(afterTeam[1]!.trim(), 50);
+        return { text: truncate(afterTeam[1]!.trim(), 50), isShell: false };
       }
     }
-    msg = normalizeMessagePreview(msg);
-    return msg ? truncate(msg, 50) : truncate(session.project, 30);
+    const p = previewMessage(msg);
+    if (p.text) return { text: truncate(p.text, 50), isShell: p.isShell };
+    return { text: truncate(session.project, 30), isShell: false };
   });
 
   let timeStr = $derived(
@@ -291,7 +300,17 @@
       />
     {:else}
       <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div class="session-name" ondblclick={handleDblClick}>{displayName}</div>
+      <div
+        class="session-name"
+        class:shell={displayLabel.isShell}
+        ondblclick={handleDblClick}
+      >
+        {#if displayLabel.isShell}
+          <code>{displayLabel.text}</code>
+        {:else}
+          {displayLabel.text}
+        {/if}
+      </div>
     {/if}
     <div class="session-meta">
       {#if !hideProject}
@@ -517,6 +536,17 @@
     text-overflow: ellipsis;
     line-height: 1.3;
     letter-spacing: -0.005em;
+  }
+
+  .session-name.shell > code {
+    font-family: var(--font-mono);
+    font-size: 0.92em;
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    border-radius: 3px;
+    padding: 1px 5px;
+    color: var(--text-primary);
+    letter-spacing: 0;
   }
 
   .compact .session-name {

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -4,6 +4,7 @@
   import { starred } from "../../stores/starred.svelte.js";
   import { formatRelativeTime, truncate } from "../../utils/format.js";
   import { agentColor as getAgentColor, agentLabel } from "../../utils/agents.js";
+  import { normalizeMessagePreview } from "../../utils/messages.js";
 
   interface Props {
     session: Session;
@@ -97,6 +98,7 @@
         return truncate(afterTeam[1]!.trim(), 50);
       }
     }
+    msg = normalizeMessagePreview(msg);
     return msg ? truncate(msg, 50) : truncate(session.project, 30);
   });
 
@@ -154,7 +156,9 @@
   }
 
   function startRename() {
-    renameValue = session.display_name ?? session.first_message ?? "";
+    renameValue =
+      session.display_name
+      ?? normalizeMessagePreview(session.first_message);
     renaming = true;
     closeContextMenu();
     requestAnimationFrame(() => renameInput?.select());

--- a/frontend/src/lib/components/trash/TrashPage.svelte
+++ b/frontend/src/lib/components/trash/TrashPage.svelte
@@ -4,6 +4,7 @@
   import * as api from "../../api/client.js";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { formatRelativeTime, truncate } from "../../utils/format.js";
+  import { normalizeMessagePreview } from "../../utils/messages.js";
 
   let trashedSessions: Session[] = $state([]);
   let loading = $state(true);
@@ -63,9 +64,8 @@
   }
 
   function displayName(s: Session): string {
-    return s.display_name ?? s.first_message
-      ? truncate(s.display_name ?? s.first_message ?? "", 70)
-      : s.project;
+    const raw = s.display_name ?? normalizeMessagePreview(s.first_message);
+    return raw ? truncate(raw, 70) : s.project;
   }
 </script>
 

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -417,6 +417,37 @@ describe("renderMarkdown", () => {
         /<code[^>]*class="language-shell"/,
       );
     });
+
+    it("preserves leading whitespace and indentation in stdout", () => {
+      // Shell output frequently has indentation that's meaningful
+      // (tree output, table layouts, log-line columns). Trimming
+      // would corrupt the transcript.
+      const dom = parseHTML(
+        renderMarkdown(
+          "<bash-stdout>  line one\n    nested\n  line two</bash-stdout>",
+        ),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe(
+        "  line one\n    nested\n  line two\n",
+      );
+    });
+
+    it("preserves leading and trailing blank lines in stdout", () => {
+      const dom = parseHTML(
+        renderMarkdown(
+          "<bash-stdout>\n\nbody\n\n</bash-stdout>",
+        ),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      // marked normalizes the final newline but leading blanks
+      // and the interior blank-line structure are preserved.
+      expect(code!.textContent).toMatch(
+        /^\n\nbody\n/,
+      );
+    });
   });
 
   describe("edge cases", () => {

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -310,6 +310,115 @@ describe("renderMarkdown", () => {
     );
   });
 
+  describe("Claude Code shell shortcuts", () => {
+    it("renders <bash-input> as a shell code block with ! prefix", () => {
+      const dom = parseHTML(
+        renderMarkdown("<bash-input>git pull origin main</bash-input>"),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("!git pull origin main\n");
+      // Tag itself must not survive in the output.
+      expect(dom.innerHTML).not.toMatch(/<\/?bash-input>/);
+    });
+
+    it("preserves multi-line commands in <bash-input>", () => {
+      const dom = parseHTML(
+        renderMarkdown(
+          "<bash-input>cd /tmp\nls -la</bash-input>",
+        ),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("!cd /tmp\nls -la\n");
+    });
+
+    it("renders <bash-stdout> as an unlabelled code block", () => {
+      const dom = parseHTML(
+        renderMarkdown("<bash-stdout>hello world</bash-stdout>"),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("hello world\n");
+      expect(dom.innerHTML).not.toMatch(/<\/?bash-stdout>/);
+    });
+
+    it("renders <bash-stderr> as an unlabelled code block", () => {
+      const dom = parseHTML(
+        renderMarkdown("<bash-stderr>oops</bash-stderr>"),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("oops\n");
+      expect(dom.innerHTML).not.toMatch(/<\/?bash-stderr>/);
+    });
+
+    it("drops empty <bash-stdout> and <bash-stderr> blocks", () => {
+      const dom = parseHTML(
+        renderMarkdown(
+          "<bash-input>true</bash-input>" +
+            "<bash-stdout></bash-stdout>" +
+            "<bash-stderr></bash-stderr>",
+        ),
+      );
+      const codes = dom.querySelectorAll("pre > code");
+      expect(codes.length).toBe(1);
+      expect(codes[0]!.textContent).toBe("!true\n");
+    });
+
+    it("handles input with backticks by picking a longer fence", () => {
+      const dom = parseHTML(
+        renderMarkdown(
+          "<bash-input>echo ```triple``` and ` single`</bash-input>",
+        ),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe(
+        "!echo ```triple``` and ` single`\n",
+      );
+    });
+
+    it("handles consecutive input/stdout pair", () => {
+      const dom = parseHTML(
+        renderMarkdown(
+          "<bash-input>echo hi</bash-input>" +
+            "<bash-stdout>hi\n</bash-stdout>",
+        ),
+      );
+      const codes = dom.querySelectorAll("pre > code");
+      expect(codes.length).toBe(2);
+      expect(codes[0]!.textContent).toBe("!echo hi\n");
+      expect(codes[1]!.textContent).toBe("hi\n");
+    });
+
+    it("leaves wrappers inside fenced code blocks alone", () => {
+      // The user is talking ABOUT the tag, not invoking one. The
+      // marked extension runs at the lexer level, so once the
+      // fenced block consumes these characters they are never
+      // re-tokenized as wrappers.
+      const dom = parseHTML(
+        renderMarkdown(
+          "```\n<bash-input>echo hi</bash-input>\n```",
+        ),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe(
+        "<bash-input>echo hi</bash-input>\n",
+      );
+    });
+
+    it("tags the input block with language-shell", () => {
+      const html = renderMarkdown(
+        "<bash-input>echo hi</bash-input>",
+      );
+      expect(html).toMatch(
+        /<code[^>]*class="language-shell"/,
+      );
+    });
+  });
+
   describe("edge cases", () => {
     it("returns empty string for empty input", () => {
       expect(renderMarkdown("")).toBe("");

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -1,10 +1,56 @@
-import { Marked } from "marked";
+import { Marked, type TokenizerExtension } from "marked";
 import DOMPurify from "dompurify";
 import { LRUCache } from "./cache.js";
+
+/** Build a marked tokenizer extension that consumes a Claude Code
+ *  shell-shortcut wrapper tag and emits a `code` token directly.
+ *  Because this runs at the lexer level, occurrences of the tag
+ *  inside a fenced code block are never reached — marked has
+ *  already consumed those characters as a `code` token. */
+function bashWrapperExtension(
+  name: string,
+  tag: string,
+  prefix: string,
+  lang: string,
+): TokenizerExtension {
+  const startRe = new RegExp(`<${tag}>`);
+  const fullRe = new RegExp(`^<${tag}>([\\s\\S]*?)</${tag}>`);
+  return {
+    name,
+    level: "block",
+    start(src) {
+      const m = startRe.exec(src);
+      return m?.index;
+    },
+    tokenizer(src) {
+      const m = fullRe.exec(src);
+      if (!m) return undefined;
+      const inner = (m[1] ?? "").trim();
+      if (!inner) {
+        // Drop empty wrappers entirely (common for stdout/stderr).
+        return { type: "space", raw: m[0] };
+      }
+      return {
+        type: "code",
+        raw: m[0],
+        lang,
+        text: prefix + inner,
+      };
+    },
+  };
+}
 
 const parser = new Marked({
   gfm: true,
   breaks: true,
+});
+
+parser.use({
+  extensions: [
+    bashWrapperExtension("bashInput", "bash-input", "!", "shell"),
+    bashWrapperExtension("bashStdout", "bash-stdout", "", ""),
+    bashWrapperExtension("bashStderr", "bash-stderr", "", ""),
+  ],
 });
 
 const cache = new LRUCache<string, string>(6000);

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -25,16 +25,19 @@ function bashWrapperExtension(
     tokenizer(src) {
       const m = fullRe.exec(src);
       if (!m) return undefined;
-      const inner = (m[1] ?? "").trim();
-      if (!inner) {
+      const captured = m[1] ?? "";
+      if (!captured.trim()) {
         // Drop empty wrappers entirely (common for stdout/stderr).
         return { type: "space", raw: m[0] };
       }
+      // Preserve the captured whitespace verbatim — code blocks
+      // are expected to render shell output exactly, including
+      // indentation and trailing blank lines.
       return {
         type: "code",
         raw: m[0],
         lang,
-        text: prefix + inner,
+        text: prefix + captured,
       };
     },
   };

--- a/frontend/src/lib/utils/messages.test.ts
+++ b/frontend/src/lib/utils/messages.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isSystemMessage, normalizeMessagePreview } from "./messages.js";
+import {
+  isSystemMessage,
+  normalizeMessagePreview,
+  previewMessage,
+} from "./messages.js";
 import type { Message } from "../api/types.js";
 
 function msg(overrides: Partial<Message>): Message {
@@ -136,5 +140,68 @@ describe("normalizeMessagePreview", () => {
     expect(
       normalizeMessagePreview("<bash-input>  ls -la  </bash-input>"),
     ).toBe("!ls -la");
+  });
+});
+
+describe("previewMessage", () => {
+  it("returns empty text and isShell=false for nullish input", () => {
+    expect(previewMessage(null)).toEqual({ text: "", isShell: false });
+    expect(previewMessage(undefined)).toEqual({ text: "", isShell: false });
+    expect(previewMessage("")).toEqual({ text: "", isShell: false });
+  });
+
+  it("flags <bash-input> as shell and prefixes with !", () => {
+    expect(
+      previewMessage("<bash-input>git pull origin main</bash-input>"),
+    ).toEqual({ text: "!git pull origin main", isShell: true });
+  });
+
+  it("flags <bash-stdout> and <bash-stderr> as shell", () => {
+    expect(previewMessage("<bash-stdout>hi</bash-stdout>")).toEqual({
+      text: "hi",
+      isShell: true,
+    });
+    expect(previewMessage("<bash-stderr>oops</bash-stderr>")).toEqual({
+      text: "oops",
+      isShell: true,
+    });
+  });
+
+  it("does not flag plain prose as shell", () => {
+    expect(
+      previewMessage("just a regular question about the codebase"),
+    ).toEqual({
+      text: "just a regular question about the codebase",
+      isShell: false,
+    });
+  });
+
+  it("does not flag a message that merely starts with ! as shell", () => {
+    // The ! prefix is only authoritative when paired with a
+    // <bash-input> wrapper — a user message that begins with ! in
+    // plain prose must not be styled as shell.
+    const r = previewMessage("!important: read the README");
+    expect(r.isShell).toBe(false);
+    expect(r.text).toBe("!important: read the README");
+  });
+
+  it("flags shell when an input/stdout pair appears together", () => {
+    expect(
+      previewMessage(
+        "<bash-input>echo hi</bash-input>\n<bash-stdout>hi</bash-stdout>",
+      ),
+    ).toEqual({ text: "!echo hi\nhi", isShell: true });
+  });
+
+  it("normalizeMessagePreview returns previewMessage(text).text", () => {
+    const cases = [
+      "<bash-input>ls</bash-input>",
+      "<bash-stdout>ok</bash-stdout>",
+      "plain text",
+      "",
+    ];
+    for (const c of cases) {
+      expect(normalizeMessagePreview(c)).toBe(previewMessage(c).text);
+    }
   });
 });

--- a/frontend/src/lib/utils/messages.test.ts
+++ b/frontend/src/lib/utils/messages.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isSystemMessage } from "./messages.js";
+import { isSystemMessage, normalizeMessagePreview } from "./messages.js";
 import type { Message } from "../api/types.js";
 
 function msg(overrides: Partial<Message>): Message {
@@ -87,5 +87,54 @@ describe("isSystemMessage", () => {
         msg({ is_system: true, source_subtype: "future_subtype" }),
       ),
     ).toBe(true);
+  });
+});
+
+describe("normalizeMessagePreview", () => {
+  it("returns empty string for null/undefined/empty", () => {
+    expect(normalizeMessagePreview(null)).toBe("");
+    expect(normalizeMessagePreview(undefined)).toBe("");
+    expect(normalizeMessagePreview("")).toBe("");
+  });
+
+  it("strips <bash-input> tags and prefixes with !", () => {
+    expect(
+      normalizeMessagePreview(
+        "<bash-input>git pull origin main</bash-input>",
+      ),
+    ).toBe("!git pull origin main");
+  });
+
+  it("unwraps <bash-stdout> and <bash-stderr>", () => {
+    expect(
+      normalizeMessagePreview(
+        "<bash-stdout>hello</bash-stdout>",
+      ),
+    ).toBe("hello");
+    expect(
+      normalizeMessagePreview(
+        "<bash-stderr>oops</bash-stderr>",
+      ),
+    ).toBe("oops");
+  });
+
+  it("normalizes a sequence of input + stdout", () => {
+    expect(
+      normalizeMessagePreview(
+        "<bash-input>echo hi</bash-input>\n<bash-stdout>hi</bash-stdout>",
+      ),
+    ).toBe("!echo hi\nhi");
+  });
+
+  it("leaves plain prose untouched", () => {
+    expect(
+      normalizeMessagePreview("just a regular message"),
+    ).toBe("just a regular message");
+  });
+
+  it("trims whitespace inside the wrapper", () => {
+    expect(
+      normalizeMessagePreview("<bash-input>  ls -la  </bash-input>"),
+    ).toBe("!ls -la");
   });
 });

--- a/frontend/src/lib/utils/messages.ts
+++ b/frontend/src/lib/utils/messages.ts
@@ -50,26 +50,47 @@ export function isCompactBoundary(m: Message): boolean {
   return Boolean(m.is_compact_boundary);
 }
 
+export interface MessagePreview {
+  /** Display text, with Claude Code shell-shortcut wrappers
+   *  replaced: `<bash-input>cmd</bash-input>` becomes `!cmd`,
+   *  stdout/stderr are unwrapped. */
+  text: string;
+  /** True when the underlying message was a shell shortcut
+   *  (`<bash-input>` or `<bash-stdout>`/`<bash-stderr>`). Lets
+   *  the caller style the preview as code. */
+  isShell: boolean;
+}
+
 /**
- * Replace Claude Code shell-shortcut wrappers with the form a user
- * typed (or saw output as): `<bash-input>cmd</bash-input>` becomes
- * `!cmd`, and `<bash-stdout>` / `<bash-stderr>` are unwrapped.
+ * Build a one-line preview of a session's first message, replacing
+ * Claude Code's shell-shortcut wrappers with the human-typed form
+ * and flagging whether the original was a shell shortcut so the
+ * caller can render the label as code.
  *
- * Use for plain-text labels (sidebar, breadcrumbs, modals). For
- * message-body rendering use `renderMarkdown`, which emits real
- * code blocks via marked extensions.
+ * For message-body rendering use `renderMarkdown` instead — it
+ * emits real code blocks via marked extensions.
  */
-export function normalizeMessagePreview(
+export function previewMessage(
   text: string | null | undefined,
-): string {
-  if (!text) return "";
-  return text
+): MessagePreview {
+  if (!text) return { text: "", isShell: false };
+  const isShell = /<bash-(?:input|stdout|stderr)>/.test(text);
+  const out = text
     .replace(
       /<bash-input>([\s\S]*?)<\/bash-input>/g,
       (_, cmd: string) => `!${cmd.trim()}`,
     )
     .replace(
       /<bash-(?:stdout|stderr)>([\s\S]*?)<\/bash-(?:stdout|stderr)>/g,
-      (_, out: string) => out.trim(),
+      (_, body: string) => body.trim(),
     );
+  return { text: out, isShell };
+}
+
+/** Plain-text variant of `previewMessage` for non-visual callers
+ *  (rename input pre-fill, confirm-delete sentence, etc.). */
+export function normalizeMessagePreview(
+  text: string | null | undefined,
+): string {
+  return previewMessage(text).text;
 }

--- a/frontend/src/lib/utils/messages.ts
+++ b/frontend/src/lib/utils/messages.ts
@@ -49,3 +49,27 @@ export function isSystemMessage(m: Message): boolean {
 export function isCompactBoundary(m: Message): boolean {
   return Boolean(m.is_compact_boundary);
 }
+
+/**
+ * Replace Claude Code shell-shortcut wrappers with the form a user
+ * typed (or saw output as): `<bash-input>cmd</bash-input>` becomes
+ * `!cmd`, and `<bash-stdout>` / `<bash-stderr>` are unwrapped.
+ *
+ * Use for plain-text labels (sidebar, breadcrumbs, modals). For
+ * message-body rendering use `renderMarkdown`, which emits real
+ * code blocks via marked extensions.
+ */
+export function normalizeMessagePreview(
+  text: string | null | undefined,
+): string {
+  if (!text) return "";
+  return text
+    .replace(
+      /<bash-input>([\s\S]*?)<\/bash-input>/g,
+      (_, cmd: string) => `!${cmd.trim()}`,
+    )
+    .replace(
+      /<bash-(?:stdout|stderr)>([\s\S]*?)<\/bash-(?:stdout|stderr)>/g,
+      (_, out: string) => out.trim(),
+    );
+}


### PR DESCRIPTION
## Summary

Claude Code emits user `!cmd` shortcuts and their output as literal
`<bash-input>`, `<bash-stdout>`, `<bash-stderr>` tags in the session
log. The viewer was passing them through, so transcripts showed the
raw pseudo-HTML in both message bodies and session-list previews.

- **Message body** (`utils/markdown.ts`): three `marked` tokenizer
  extensions consume each wrapper at the lexer level and emit a `code`
  token directly. `<bash-input>cmd</bash-input>` becomes a
  `language-shell` block prefixed with `!cmd`; stdout/stderr become
  unlabelled code blocks; empty wrappers are dropped. Because the
  extension runs in the tokenizer, occurrences inside fenced
  code blocks stay literal. Captured content is preserved verbatim
  so indented and blank-line shell output renders exactly.

- **Session previews** (sidebar, breadcrumb rename pre-fill, trash,
  pinned, command palette recents, analytics Top Sessions,
  confirm-delete modal): a new `previewMessage` helper in
  `utils/messages.ts` returns `{ text, isShell }`. Plain-text callers
  get the normalized string; the sidebar wraps shell-shortcut entries
  in `<code>` with a subtle monospace style.