### PR TITLE
Add Docker deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+dist
+tmp
+agentsview
+coverage.out
+frontend/node_modules
+desktop/node_modules
+desktop/src-tauri/target
+testdata/ssh/test_key

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ tmp
 agentsview
 coverage.out
 frontend/node_modules
+frontend/dist
+internal/web/dist
 desktop/node_modules
 desktop/src-tauri/target
 testdata/ssh/test_key

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -35,6 +34,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "commit=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+          echo "image=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
 
@@ -49,7 +49,7 @@ jobs:
       - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         id: meta
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.vars.outputs.image }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,72 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: wesm/agentsview
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Compute image build metadata
+        id: vars
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="dev"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "commit=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+          labels: |
+            org.opencontainers.image.title=agentsview
+            org.opencontainers.image.description=Local web viewer for AI agent sessions
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.vars.outputs.version }}
+            COMMIT=${{ steps.vars.outputs.commit }}
+            BUILD_DATE=${{ steps.vars.outputs.build_date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,7 +13,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: wesm/agentsview
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -35,17 +36,17 @@ jobs:
           echo "commit=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -56,7 +57,7 @@ jobs:
             org.opencontainers.image.title=agentsview
             org.opencontainers.image.description=Local web viewer for AI agent sessions
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM --platform=$BUILDPLATFORM node:24-bookworm AS frontend-build
+
+WORKDIR /src/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+FROM golang:1.26-bookworm AS build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . ./
+COPY --from=frontend-build /src/frontend/dist ./internal/web/dist
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=
+
+RUN CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -tags fts5 -trimpath -buildvcs=false \
+      -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}" \
+      -o /out/agentsview ./cmd/agentsview
+
+RUN /out/agentsview --version
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /data /agents
+
+ENV AGENTSVIEW_DATA_DIR=/data
+
+COPY --from=build /out/agentsview /usr/local/bin/agentsview
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+RUN chmod +x /usr/local/bin/agentsview /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["--host", "0.0.0.0", "--no-browser"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or run the published Docker image:
 
 ```bash
 docker run --rm -p 127.0.0.1:8080:8080 \
-  -v "$HOME/.agentsview:/data" \
+  -v agentsview-data:/data \
   -v "$HOME/.claude/projects:/agents/claude:ro" \
   -e CLAUDE_PROJECTS_DIR=/agents/claude \
   ghcr.io/wesm/agentsview:latest
@@ -53,7 +53,10 @@ docker compose -f docker-compose.prod.yaml up -d
 ```
 
 The included compose file persists the agentsview data directory in a named
-volume and mounts Claude, Codex, and OpenCode session roots read-only.
+volume and mounts Claude, Codex, and OpenCode session roots read-only. The
+container runs as root, so prefer a named volume for `/data` over a host bind
+mount; if you do bind-mount, pre-create the directory with the desired ownership
+to avoid root-owned files in your home directory.
 
 The examples publish the UI on loopback only (`127.0.0.1`). If you need to
 expose it beyond localhost, enable `--require-auth` and publish the port

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or download the **desktop app** (macOS / Windows) from
 Or run the published Docker image:
 
 ```bash
-docker run --rm -p 8080:8080 \
+docker run --rm -p 127.0.0.1:8080:8080 \
   -v "$HOME/.agentsview:/data" \
   -v "$HOME/.claude/projects:/agents/claude:ro" \
   -e CLAUDE_PROJECTS_DIR=/agents/claude \
@@ -55,6 +55,10 @@ docker compose -f docker-compose.prod.yaml up -d
 The included compose file persists the agentsview data directory in a named
 volume and mounts Claude, Codex, and OpenCode session roots read-only.
 
+The examples publish the UI on loopback only (`127.0.0.1`). If you need to
+expose it beyond localhost, enable `--require-auth` and publish the port
+intentionally.
+
 Important: a containerized agentsview instance can only discover agent sessions
 from directories you explicitly mount into the container. If you do not mount an
 agent's session directory and point the matching env var at it, that agent will
@@ -63,7 +67,7 @@ not appear in the UI.
 Example PostgreSQL-backed startup:
 
 ```bash
-docker run --rm -p 8080:8080 \
+docker run --rm -p 127.0.0.1:8080:8080 \
   -e PG_SERVE=1 \
   -e AGENTSVIEW_PG_URL='postgres://user:password@postgres.example.com:5432/agentsview?sslmode=require' \
   ghcr.io/wesm/agentsview:latest

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ powershell -ExecutionPolicy ByPass -c "irm https://agentsview.io/install.ps1 | i
 Or download the **desktop app** (macOS / Windows) from
 [GitHub Releases](https://github.com/wesm/agentsview/releases).
 
+Or run the published Docker image:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v "$HOME/.agentsview:/data" \
+  -v "$HOME/.claude/projects:/agents/claude:ro" \
+  -e CLAUDE_PROJECTS_DIR=/agents/claude \
+  ghcr.io/wesm/agentsview:latest
+```
+
 ## Quick Start
 
 ```bash
@@ -30,6 +40,34 @@ agentsview usage daily     # print daily cost summary
 On first run, agentsview discovers sessions from every supported agent on your
 machine, syncs them into a local SQLite database, and opens a web UI at
 `http://127.0.0.1:8080`.
+
+## Docker
+
+The container image defaults to local `agentsview serve`. Set `PG_SERVE=1` to
+switch the startup command to `agentsview pg serve` instead.
+
+`docker-compose.prod.yaml` is included as a production example:
+
+```bash
+docker compose -f docker-compose.prod.yaml up -d
+```
+
+The included compose file persists the agentsview data directory in a named
+volume and mounts Claude, Codex, and OpenCode session roots read-only.
+
+Important: a containerized agentsview instance can only discover agent sessions
+from directories you explicitly mount into the container. If you do not mount an
+agent's session directory and point the matching env var at it, that agent will
+not appear in the UI.
+
+Example PostgreSQL-backed startup:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e PG_SERVE=1 \
+  -e AGENTSVIEW_PG_URL='postgres://user:password@postgres.example.com:5432/agentsview?sslmode=require' \
+  ghcr.io/wesm/agentsview:latest
+```
 
 ## Token Usage and Cost Tracking
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/wesm/agentsview:latest
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
       CLAUDE_PROJECTS_DIR: /agents/claude
       CODEX_SESSIONS_DIR: /agents/codex

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,21 @@
+services:
+  agentsview:
+    image: ghcr.io/wesm/agentsview:latest
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      CLAUDE_PROJECTS_DIR: /agents/claude
+      CODEX_SESSIONS_DIR: /agents/codex
+      OPENCODE_DIR: /agents/opencode
+      # Set both of these to serve from PostgreSQL instead of the local archive.
+      # PG_SERVE: "1"
+      # AGENTSVIEW_PG_URL: postgres://user:password@postgres.example.com:5432/agentsview?sslmode=require
+    volumes:
+      - agentsview-data:/data
+      - ${HOME}/.claude/projects:/agents/claude:ro
+      - ${HOME}/.codex/sessions:/agents/codex:ro
+      - ${HOME}/.local/share/opencode:/agents/opencode:ro
+
+volumes:
+  agentsview-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+is_truthy() {
+    case "${1:-}" in
+        1|true|TRUE|True|yes|YES|on|ON)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+if [ "$#" -gt 0 ]; then
+    case "$1" in
+        -*)
+            ;;
+        *)
+            exec /usr/local/bin/agentsview "$@"
+            ;;
+    esac
+fi
+
+if is_truthy "${PG_SERVE:-}"; then
+    exec /usr/local/bin/agentsview pg serve "$@"
+fi
+
+exec /usr/local/bin/agentsview serve "$@"


### PR DESCRIPTION
## Summary
- add a production multi-stage Docker build and entrypoint that defaults to `agentsview serve` and switches to `agentsview pg serve` when `PG_SERVE=1`
- add a GitHub Actions workflow that builds and publishes multi-arch images to `ghcr.io/wesm/agentsview` for `main` and version tags
- add a production compose example and README Docker docs covering local archive mounts and PostgreSQL-backed startup

## Testing
- `bash -n docker-entrypoint.sh`
- `docker compose -f docker-compose.prod.yaml config`
- `docker build -t agentsview:test .`
- `docker run --rm agentsview:test version`
- `docker run --rm -e PG_SERVE=1 agentsview:test --help`
- local `act` dry-run of `.github/workflows/docker.yml`
- local `act` end-to-end runs of a non-publishing workflow copy for simulated `main` and tag pushes