### PR TITLE
feat(copilot): use workspace.yaml name as session title

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,7 +27,13 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 20: Claude parser now surfaces queued_command
+// Bumped to 21: Copilot parser now reads workspace.yaml to use
+// the LLM-generated session name as first_message. Existing
+// directory-format sessions where workspace.yaml.mtime <=
+// events.jsonl.mtime would be permanently skipped without this
+// bump, leaving first_message as the raw first user message.
+//
+// (20: Claude parser now surfaces queued_command
 // attachment entries (user messages typed mid-tool-call) as
 // real user messages with source_subtype="queued_command".
 // Sessions previously parsed by older versions had these
@@ -44,7 +50,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 20
+const dataVersion = 21
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -240,6 +240,36 @@ func formatCopilotToolCalls(
 	return strings.Join(parts, "\n")
 }
 
+// readCopilotWorkspaceName reads the session name from the
+// workspace.yaml sibling file in a directory-format session.
+// Returns an empty string for flat .jsonl sessions or when
+// no name is present.
+func readCopilotWorkspaceName(eventsPath string) string {
+	if filepath.Base(eventsPath) != "events.jsonl" {
+		return ""
+	}
+	yamlPath := filepath.Join(
+		filepath.Dir(eventsPath), "workspace.yaml",
+	)
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		after, ok := strings.CutPrefix(line, "name: ")
+		if !ok {
+			continue
+		}
+		name := strings.TrimSpace(after)
+		if name != "" {
+			return truncate(
+				strings.ReplaceAll(name, "\n", " "), 300,
+			)
+		}
+	}
+	return ""
+}
+
 // ParseCopilotSession parses a Copilot JSONL session file.
 // Returns (nil, nil, nil) if the file doesn't exist or
 // contains no user/assistant messages.
@@ -297,6 +327,14 @@ func ParseCopilotSession(
 	}
 	sessionID = "copilot:" + sessionID
 
+	// Prefer the workspace.yaml name (LLM-generated or user-set
+	// title) over the raw first user message. Falls back to the
+	// first user message when no name is present.
+	firstMessage := b.firstMessage
+	if wsName := readCopilotWorkspaceName(path); wsName != "" {
+		firstMessage = wsName
+	}
+
 	userCount := 0
 	for _, m := range b.messages {
 		if m.Role == RoleUser && m.Content != "" {
@@ -309,7 +347,7 @@ func ParseCopilotSession(
 		Project:          b.project,
 		Machine:          machine,
 		Agent:            AgentCopilot,
-		FirstMessage:     b.firstMessage,
+		FirstMessage:     firstMessage,
 		StartedAt:        b.startedAt,
 		EndedAt:          b.endedAt,
 		MessageCount:     len(b.messages),

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -255,7 +255,7 @@ func readCopilotWorkspaceName(eventsPath string) string {
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		after, ok := strings.CutPrefix(line, "name: ")
 		if !ok {
 			continue

--- a/internal/parser/copilot_test.go
+++ b/internal/parser/copilot_test.go
@@ -214,6 +214,151 @@ func TestParseCopilotSession_DirectoryFormat(t *testing.T) {
 
 	sess, _ := parseAndValidateHelper(t, path, "m", 2)
 	assertEqual(t, "copilot:abc-456", sess.ID, "session ID")
+	// No workspace.yaml, so first user message is used.
+	assertEqual(t, "hello", sess.FirstMessage, "FirstMessage")
+}
+
+// writeDirSession writes events.jsonl (and optionally
+// workspace.yaml) into a temporary session directory and
+// returns the path to events.jsonl.
+func writeDirSession(
+	t *testing.T,
+	sessID string,
+	events []string,
+	workspaceYAML string,
+) string {
+	t.Helper()
+	dir := t.TempDir()
+	sessDir := filepath.Join(dir, sessID)
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	eventsPath := filepath.Join(sessDir, "events.jsonl")
+	if err := os.WriteFile(
+		eventsPath,
+		[]byte(strings.Join(events, "\n")+"\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if workspaceYAML != "" {
+		yamlPath := filepath.Join(sessDir, "workspace.yaml")
+		if err := os.WriteFile(
+			yamlPath, []byte(workspaceYAML), 0o644,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return eventsPath
+}
+
+func TestParseCopilotSession_WorkspaceName(t *testing.T) {
+	events := []string{
+		`{"type":"session.start","data":{"sessionId":"ws-name"},"timestamp":"2025-01-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"Fix the login bug"},"timestamp":"2025-01-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"Done."},"timestamp":"2025-01-15T10:00:02Z"}`,
+	}
+	yaml := "id: ws-name\nname: Fix Login Authentication Bug\nuser_named: false\nsummary_count: 1\n"
+
+	path := writeDirSession(t, "ws-name", events, yaml)
+	sess, _ := parseAndValidateHelper(t, path, "m", 2)
+
+	// workspace.yaml name takes precedence over first user message.
+	assertEqual(t, "Fix Login Authentication Bug", sess.FirstMessage, "FirstMessage")
+}
+
+func TestParseCopilotSession_WorkspaceNameUserNamed(t *testing.T) {
+	events := []string{
+		`{"type":"session.start","data":{"sessionId":"ws-user-named"},"timestamp":"2025-01-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"Original prompt"},"timestamp":"2025-01-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"Done."},"timestamp":"2025-01-15T10:00:02Z"}`,
+	}
+	yaml := "id: ws-user-named\nname: My Custom Session Name\nuser_named: true\nsummary_count: 0\n"
+
+	path := writeDirSession(t, "ws-user-named", events, yaml)
+	sess, _ := parseAndValidateHelper(t, path, "m", 2)
+
+	// user_named: true sessions also use name as FirstMessage.
+	assertEqual(t, "My Custom Session Name", sess.FirstMessage, "FirstMessage")
+}
+
+func TestParseCopilotSession_WorkspaceNameMissing(t *testing.T) {
+	// workspace.yaml exists but has no name field (older sessions).
+	events := []string{
+		`{"type":"session.start","data":{"sessionId":"ws-no-name"},"timestamp":"2025-01-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"First user message"},"timestamp":"2025-01-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"Done."},"timestamp":"2025-01-15T10:00:02Z"}`,
+	}
+	yaml := "id: ws-no-name\nsummary_count: 0\ncreated_at: 2026-03-08T12:38:01.203Z\n"
+
+	path := writeDirSession(t, "ws-no-name", events, yaml)
+	sess, _ := parseAndValidateHelper(t, path, "m", 2)
+
+	// Falls back to first user message.
+	assertEqual(t, "First user message", sess.FirstMessage, "FirstMessage")
+}
+
+func TestParseCopilotSession_WorkspaceNameWhitespaceOnly(t *testing.T) {
+	events := []string{
+		`{"type":"session.start","data":{"sessionId":"ws-blank"},"timestamp":"2025-01-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"Do something"},"timestamp":"2025-01-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"Done."},"timestamp":"2025-01-15T10:00:02Z"}`,
+	}
+	yaml := "id: ws-blank\nname:   \nsummary_count: 0\n"
+
+	path := writeDirSession(t, "ws-blank", events, yaml)
+	sess, _ := parseAndValidateHelper(t, path, "m", 2)
+
+	// Whitespace-only name falls back to first user message.
+	assertEqual(t, "Do something", sess.FirstMessage, "FirstMessage")
+}
+
+func TestParseCopilotSession_WorkspaceNoYAMLFile(t *testing.T) {
+	// Directory format session with no workspace.yaml at all.
+	events := []string{
+		`{"type":"session.start","data":{"sessionId":"ws-noyaml"},"timestamp":"2025-01-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"Hello there"},"timestamp":"2025-01-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"Hi."},"timestamp":"2025-01-15T10:00:02Z"}`,
+	}
+
+	path := writeDirSession(t, "ws-noyaml", events, "")
+	sess, _ := parseAndValidateHelper(t, path, "m", 2)
+
+	assertEqual(t, "Hello there", sess.FirstMessage, "FirstMessage")
+}
+
+func TestParseCopilotSession_FlatFileNoWorkspaceYAML(t *testing.T) {
+	// Flat .jsonl format never looks for workspace.yaml.
+	path := writeCopilotJSONL(t,
+		`{"type":"session.start","data":{"sessionId":"flat-sess"},"timestamp":"2025-01-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"Flat file prompt"},"timestamp":"2025-01-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"OK."},"timestamp":"2025-01-15T10:00:02Z"}`,
+	)
+
+	sess, _ := parseAndValidateHelper(t, path, "m", 2)
+
+	assertEqual(t, "Flat file prompt", sess.FirstMessage, "FirstMessage")
+}
+
+func TestParseCopilotSession_WorkspaceNameTruncated(t *testing.T) {
+	longName := strings.Repeat("a", 350)
+	events := []string{
+		`{"type":"session.start","data":{"sessionId":"ws-long"},"timestamp":"2025-01-15T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"original"},"timestamp":"2025-01-15T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"content":"Done."},"timestamp":"2025-01-15T10:00:02Z"}`,
+	}
+	yaml := "id: ws-long\nname: " + longName + "\nsummary_count: 1\n"
+
+	path := writeDirSession(t, "ws-long", events, yaml)
+	sess, _ := parseAndValidateHelper(t, path, "m", 2)
+
+	// truncate(s, 300) returns at most 303 bytes (300 runes + "...").
+	if len(sess.FirstMessage) > 303 {
+		t.Errorf("FirstMessage not truncated: len=%d", len(sess.FirstMessage))
+	}
+	if len(sess.FirstMessage) == len(longName) {
+		t.Error("FirstMessage was not truncated at all")
+	}
 }
 
 func TestParseCopilotSession_DirectoryFormatFallbackID(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2590,15 +2590,12 @@ func (e *Engine) shouldSkipOpenCodeByPath(path string) bool {
 func (e *Engine) processCopilot(
 	file parser.DiscoveredFile, info os.FileInfo,
 ) processResult {
-	skip := e.shouldSkipByPath(file.Path, info)
-	var yamlMtime int64
-	if skip {
-		if t := e.copilotWorkspaceYAMLNewer(file.Path); t > 0 {
-			yamlMtime = t
-			skip = false
-		}
-	}
-	if skip {
+	// Use effective mtime = max(events.jsonl, workspace.yaml) so
+	// that a new or updated workspace.yaml triggers a re-parse and
+	// the stored mtime stays consistent with what we compare against
+	// on subsequent syncs (preventing oscillation).
+	effectiveMtime := copilotEffectiveMtime(file.Path, info)
+	if e.shouldSkipCopilot(file.Path, info, effectiveMtime) {
 		return processResult{skip: true}
 	}
 
@@ -2612,11 +2609,8 @@ func (e *Engine) processCopilot(
 		return processResult{}
 	}
 
-	// When a workspace.yaml update triggered the re-parse,
-	// advance the stored mtime to max(events.jsonl, workspace.yaml)
-	// so the next sync does not re-parse unnecessarily.
-	if yamlMtime > sess.File.Mtime {
-		sess.File.Mtime = yamlMtime
+	if effectiveMtime > sess.File.Mtime {
+		sess.File.Mtime = effectiveMtime
 	}
 
 	hash, err := ComputeFileHash(file.Path)
@@ -2631,35 +2625,48 @@ func (e *Engine) processCopilot(
 	}
 }
 
-// copilotWorkspaceYAMLNewer returns the workspace.yaml mtime
-// (nanoseconds) when it is newer than the file_mtime the DB
-// has stored for the session, indicating the session name may
-// have changed. Returns 0 when the file is absent, unchanged,
-// or the session is not in directory format.
-func (e *Engine) copilotWorkspaceYAMLNewer(eventsPath string) int64 {
+// copilotEffectiveMtime returns max(events.jsonl mtime,
+// workspace.yaml mtime). For flat .jsonl sessions (no
+// workspace.yaml sibling) it returns the events.jsonl mtime.
+func copilotEffectiveMtime(eventsPath string, info os.FileInfo) int64 {
+	m := info.ModTime().UnixNano()
 	if filepath.Base(eventsPath) != "events.jsonl" {
-		return 0
+		return m
 	}
 	yamlPath := filepath.Join(
 		filepath.Dir(eventsPath), "workspace.yaml",
 	)
-	yamlInfo, err := os.Stat(yamlPath)
-	if err != nil {
-		return 0
+	if yi, err := os.Stat(yamlPath); err == nil {
+		if ym := yi.ModTime().UnixNano(); ym > m {
+			m = ym
+		}
 	}
-	lookupPath := eventsPath
+	return m
+}
+
+// shouldSkipCopilot is like shouldSkipByPath but uses the
+// pre-computed effectiveMtime (max of events.jsonl and
+// workspace.yaml) for the mtime comparison, keeping the stored
+// value consistent with what we compare against on next sync.
+func (e *Engine) shouldSkipCopilot(
+	path string, info os.FileInfo, effectiveMtime int64,
+) bool {
+	lookupPath := path
 	if e.pathRewriter != nil {
-		lookupPath = e.pathRewriter(eventsPath)
+		lookupPath = e.pathRewriter(path)
 	}
-	_, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
+	storedSize, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
 	if !ok {
-		return 0
+		return false
 	}
-	yamlMtime := yamlInfo.ModTime().UnixNano()
-	if yamlMtime > storedMtime {
-		return yamlMtime
+	if storedSize != info.Size() || storedMtime != effectiveMtime {
+		return false
 	}
-	return 0
+	if e.db.GetDataVersionByPath(lookupPath) <
+		db.CurrentDataVersion() {
+		return false
+	}
+	return true
 }
 
 func (e *Engine) processGemini(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2591,8 +2591,12 @@ func (e *Engine) processCopilot(
 	file parser.DiscoveredFile, info os.FileInfo,
 ) processResult {
 	skip := e.shouldSkipByPath(file.Path, info)
-	if skip && e.copilotWorkspaceYAMLNewer(file.Path) {
-		skip = false
+	var yamlMtime int64
+	if skip {
+		if t := e.copilotWorkspaceYAMLNewer(file.Path); t > 0 {
+			yamlMtime = t
+			skip = false
+		}
 	}
 	if skip {
 		return processResult{skip: true}
@@ -2608,6 +2612,13 @@ func (e *Engine) processCopilot(
 		return processResult{}
 	}
 
+	// When a workspace.yaml update triggered the re-parse,
+	// advance the stored mtime to max(events.jsonl, workspace.yaml)
+	// so the next sync does not re-parse unnecessarily.
+	if yamlMtime > sess.File.Mtime {
+		sess.File.Mtime = yamlMtime
+	}
+
 	hash, err := ComputeFileHash(file.Path)
 	if err == nil {
 		sess.File.Hash = hash
@@ -2620,28 +2631,35 @@ func (e *Engine) processCopilot(
 	}
 }
 
-// copilotWorkspaceYAMLNewer reports whether the workspace.yaml
-// sibling of a directory-format events.jsonl is newer than the
-// file_mtime the DB has on record for the session. When true,
-// the session should be re-parsed even if events.jsonl itself
-// has not changed, so that a freshly generated session name is
-// picked up.
-func (e *Engine) copilotWorkspaceYAMLNewer(eventsPath string) bool {
+// copilotWorkspaceYAMLNewer returns the workspace.yaml mtime
+// (nanoseconds) when it is newer than the file_mtime the DB
+// has stored for the session, indicating the session name may
+// have changed. Returns 0 when the file is absent, unchanged,
+// or the session is not in directory format.
+func (e *Engine) copilotWorkspaceYAMLNewer(eventsPath string) int64 {
 	if filepath.Base(eventsPath) != "events.jsonl" {
-		return false
+		return 0
 	}
 	yamlPath := filepath.Join(
 		filepath.Dir(eventsPath), "workspace.yaml",
 	)
 	yamlInfo, err := os.Stat(yamlPath)
 	if err != nil {
-		return false
+		return 0
 	}
-	_, storedMtime, ok := e.db.GetFileInfoByPath(eventsPath)
+	lookupPath := eventsPath
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(eventsPath)
+	}
+	_, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
 	if !ok {
-		return false
+		return 0
 	}
-	return yamlInfo.ModTime().UnixNano() > storedMtime
+	yamlMtime := yamlInfo.ModTime().UnixNano()
+	if yamlMtime > storedMtime {
+		return yamlMtime
+	}
+	return 0
 }
 
 func (e *Engine) processGemini(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -459,13 +459,26 @@ func (e *Engine) classifyOnePath(
 					Agent: parser.AgentCopilot,
 				}, true
 			case 2:
-				if parts[1] != "events.jsonl" {
-					continue
+				if parts[1] == "events.jsonl" {
+					return parser.DiscoveredFile{
+						Path:  path,
+						Agent: parser.AgentCopilot,
+					}, true
 				}
-				return parser.DiscoveredFile{
-					Path:  path,
-					Agent: parser.AgentCopilot,
-				}, true
+				// workspace.yaml changes should trigger a re-parse
+				// of the sibling events.jsonl.
+				if parts[1] == "workspace.yaml" {
+					eventsPath := filepath.Join(
+						stateDir, parts[0], "events.jsonl",
+					)
+					if _, err := os.Stat(eventsPath); err == nil {
+						return parser.DiscoveredFile{
+							Path:  eventsPath,
+							Agent: parser.AgentCopilot,
+						}, true
+					}
+				}
+				continue
 			default:
 				continue
 			}
@@ -1643,6 +1656,11 @@ func discoveredFileMtime(
 	if err != nil {
 		return 0, err
 	}
+
+	if file.Agent == parser.AgentCopilot {
+		return copilotEffectiveMtime(file.Path, info), nil
+	}
+
 	return info.ModTime().UnixNano(), nil
 }
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2590,7 +2590,11 @@ func (e *Engine) shouldSkipOpenCodeByPath(path string) bool {
 func (e *Engine) processCopilot(
 	file parser.DiscoveredFile, info os.FileInfo,
 ) processResult {
-	if e.shouldSkipByPath(file.Path, info) {
+	skip := e.shouldSkipByPath(file.Path, info)
+	if skip && e.copilotWorkspaceYAMLNewer(file.Path) {
+		skip = false
+	}
+	if skip {
 		return processResult{skip: true}
 	}
 
@@ -2614,6 +2618,30 @@ func (e *Engine) processCopilot(
 			{Session: *sess, Messages: msgs},
 		},
 	}
+}
+
+// copilotWorkspaceYAMLNewer reports whether the workspace.yaml
+// sibling of a directory-format events.jsonl is newer than the
+// file_mtime the DB has on record for the session. When true,
+// the session should be re-parsed even if events.jsonl itself
+// has not changed, so that a freshly generated session name is
+// picked up.
+func (e *Engine) copilotWorkspaceYAMLNewer(eventsPath string) bool {
+	if filepath.Base(eventsPath) != "events.jsonl" {
+		return false
+	}
+	yamlPath := filepath.Join(
+		filepath.Dir(eventsPath), "workspace.yaml",
+	)
+	yamlInfo, err := os.Stat(yamlPath)
+	if err != nil {
+		return false
+	}
+	_, storedMtime, ok := e.db.GetFileInfoByPath(eventsPath)
+	if !ok {
+		return false
+	}
+	return yamlInfo.ModTime().UnixNano() > storedMtime
 }
 
 func (e *Engine) processGemini(


### PR DESCRIPTION
This is just a quality of life change for naming copilot sessions. With the latest updates to copilot cli, I'm noticing a session name that is generated by copilot similar to OpenCode. This change simply monitors the workspace.yaml file for copilot to see if this field exists, and if so, names the session appropriately.

I intentionally tried to match our patterns for preferring the agentsview name if its renamed, and then falling back onto this name field, and then finally if the name field isn't present (and likely won't be for older versioned sessions for copilot), it will use the FirstMessage.

Happy to address any feedback that anyone has here!