### PR TITLE
fix(frontend): allow expanding compacted summaries

### DIFF
--- a/frontend/src/lib/components/content/CompactBoundaryDivider.svelte
+++ b/frontend/src/lib/components/content/CompactBoundaryDivider.svelte
@@ -8,14 +8,15 @@
 
   let { message }: Props = $props();
 
+  let content = $derived((message.content ?? "").trim());
   let preview = $derived.by(() => {
-    const text = (message.content ?? "").trim();
-    if (text.length === 0) return "";
-    const firstLine = text.split("\n")[0]!;
+    if (content.length === 0) return "";
+    const firstLine = content.split("\n")[0]!;
     return firstLine.length > 140
       ? firstLine.slice(0, 140) + "…"
       : firstLine;
   });
+  let hasMore = $derived(content.length > 0 && content !== preview);
 </script>
 
 <div class="boundary" title="Context window compacted at this point">
@@ -32,7 +33,17 @@
   <span class="boundary-line"></span>
 </div>
 {#if preview}
-  <div class="boundary-preview">{preview}</div>
+  {#if hasMore}
+    <details class="boundary-details">
+      <summary class="boundary-preview">
+        <span>{preview}</span>
+        <span class="boundary-expand-hint">Show full summary</span>
+      </summary>
+      <pre class="boundary-full">{content}</pre>
+    </details>
+  {:else}
+    <div class="boundary-preview">{preview}</div>
+  {/if}
 {/if}
 
 <style>
@@ -70,6 +81,9 @@
     text-transform: none;
     letter-spacing: 0;
   }
+  .boundary-details {
+    margin: 4px 12px 6px;
+  }
   .boundary-preview {
     margin: 4px 12px 6px;
     padding: 6px 10px;
@@ -83,5 +97,34 @@
     line-height: 1.5;
     border-radius: 0 var(--radius-sm, 4px)
       var(--radius-sm, 4px) 0;
+  }
+  .boundary-details > .boundary-preview {
+    margin: 0;
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .boundary-details > .boundary-preview::-webkit-details-marker {
+    display: none;
+  }
+  .boundary-expand-hint {
+    flex: none;
+    font-size: 11px;
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+  .boundary-full {
+    white-space: pre-wrap;
+    margin: 6px 0 0;
+    padding: 8px 10px;
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--text-primary);
+    background: var(--bg-inset);
+    border-radius: var(--radius-sm, 4px);
+    overflow-x: auto;
   }
 </style>

--- a/frontend/src/lib/components/content/CompactBoundaryDivider.test.ts
+++ b/frontend/src/lib/components/content/CompactBoundaryDivider.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { mount, unmount } from "svelte";
+// @ts-ignore
+import CompactBoundaryDivider from "./CompactBoundaryDivider.svelte";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("CompactBoundaryDivider", () => {
+  it("shows an expandable full summary when the compact summary is truncated", () => {
+    const content = [
+      "This is a long compact summary that definitely exceeds one hundred and forty characters so the preview needs truncation before users can expand the full content.",
+      "Second line with more detail.",
+    ].join("\n");
+
+    const c = mount(CompactBoundaryDivider, {
+      target: document.body,
+      props: {
+        message: {
+          id: 1,
+          session_id: "session-1",
+          ordinal: 1,
+          role: "system",
+          content,
+          timestamp: "2026-04-29T12:00:00Z",
+          has_thinking: false,
+          thinking_text: "",
+          has_tool_use: false,
+          content_length: content.length,
+          model: "",
+          context_tokens: 0,
+          output_tokens: 0,
+          is_system: true,
+          is_compact_boundary: true,
+        },
+      },
+    });
+
+    const details = document.body.querySelector("details");
+    expect(details).toBeTruthy();
+    expect(details?.querySelector("summary")?.textContent).toContain("Show full summary");
+    expect(details?.querySelector("pre")?.textContent).toBe(content);
+
+    unmount(c);
+  });
+
+  it("renders a plain preview for short single-line summaries", () => {
+    const content = "Short summary.";
+
+    const c = mount(CompactBoundaryDivider, {
+      target: document.body,
+      props: {
+        message: {
+          id: 1,
+          session_id: "session-1",
+          ordinal: 1,
+          role: "system",
+          content,
+          timestamp: "2026-04-29T12:00:00Z",
+          has_thinking: false,
+          thinking_text: "",
+          has_tool_use: false,
+          content_length: content.length,
+          model: "",
+          context_tokens: 0,
+          output_tokens: 0,
+          is_system: true,
+          is_compact_boundary: true,
+        },
+      },
+    });
+
+    expect(document.body.querySelector("details")).toBeNull();
+    expect(document.body.textContent).toContain(content);
+
+    unmount(c);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #418. Compact-boundary messages already store the full compaction summary, but the transcript UI only rendered a one-line 140-character preview with no way to inspect the rest.

This keeps the existing preview for short summaries, and turns truncated or multi-line compact summaries into an expandable details block with the full text underneath.

## Validation

- `cd frontend && npm test -- --run src/lib/components/content/CompactBoundaryDivider.test.ts`
- `cd frontend && npm run check`
