### PR TITLE
fix: return 409 for excluded or trashed uploads

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4380,6 +4380,20 @@ func TestDeleteSessionExcludes(t *testing.T) {
 	requireSessionGone(t, d, "s1")
 }
 
+func TestUpsertSessionTrashedReturnsErrSessionTrashed(t *testing.T) {
+	d := testDB(t)
+
+	insertSession(t, d, "s1", "p")
+	requireNoError(t, d.SoftDeleteSession("s1"), "SoftDeleteSession")
+
+	err := d.UpsertSession(Session{
+		ID: "s1", Project: "p", Machine: "m", Agent: "claude",
+	})
+	if !errors.Is(err, ErrSessionTrashed) {
+		t.Fatalf("UpsertSession = %v, want ErrSessionTrashed", err)
+	}
+}
+
 func TestEmptyTrashExcludes(t *testing.T) {
 	d := testDB(t)
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3923,6 +3923,62 @@ func TestCopyOrphanedDataFrom_WithToolResultEvents(t *testing.T) {
 	}
 }
 
+func TestCopyTrashedDataFromPreservesPins(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	srcPath := filepath.Join(dir, "old.db")
+	srcDB, err := Open(srcPath)
+	requireNoError(t, err, "Open src")
+	insertSession(t, srcDB, "s1", "proj")
+	insertMessages(t, srcDB,
+		userMsg("s1", 0, "keep this pinned"),
+		asstMsg("s1", 1, "reply"),
+	)
+	srcMsgs, err := srcDB.GetAllMessages(ctx, "s1")
+	requireNoError(t, err, "GetAllMessages src")
+	note := "important"
+	pinID, err := srcDB.PinMessage("s1", srcMsgs[0].ID, &note)
+	if err != nil || pinID == 0 {
+		t.Fatalf("PinMessage src: id=%d err=%v", pinID, err)
+	}
+	requireNoError(t, srcDB.SoftDeleteSession("s1"), "SoftDelete src")
+	srcDB.Close()
+
+	dstPath := filepath.Join(dir, "new.db")
+	dstDB, err := Open(dstPath)
+	requireNoError(t, err, "Open dst")
+	defer dstDB.Close()
+
+	count, err := dstDB.CopyTrashedDataFrom(srcPath)
+	requireNoError(t, err, "CopyTrashedDataFrom")
+	if count != 1 {
+		t.Fatalf("copied trashed sessions = %d, want 1", count)
+	}
+
+	pins, err := dstDB.ListPinnedMessages(ctx, "s1", "")
+	requireNoError(t, err, "ListPinnedMessages")
+	if len(pins) != 1 {
+		t.Fatalf("pins copied = %d, want 1", len(pins))
+	}
+	if pins[0].Ordinal != 0 {
+		t.Fatalf("pin ordinal = %d, want 0", pins[0].Ordinal)
+	}
+	if pins[0].Note == nil || *pins[0].Note != note {
+		t.Fatalf("pin note = %v, want %q", pins[0].Note, note)
+	}
+
+	var messageContent string
+	requireNoError(t, dstDB.getReader().QueryRow(
+		"SELECT content FROM messages WHERE id = ?",
+		pins[0].MessageID,
+	).Scan(&messageContent), "query pinned message")
+	if messageContent != "keep this pinned" {
+		t.Fatalf("pinned content = %q, want %q",
+			messageContent, "keep this pinned")
+	}
+}
+
 func TestCopyOrphanedDataFrom_AtomicOnFailure(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -476,35 +476,9 @@ func (db *DB) ReplaceSessionMessages(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Save existing pins before deletion. The ON DELETE CASCADE on
-	// pinned_messages.message_id would otherwise wipe them when
-	// messages are deleted below. source_uuid comes from the joined
-	// message row; LEFT JOIN keeps pins on legacy rows whose
-	// message_id no longer resolves cleanly.
-	pinRows, err := tx.Query(`
-		SELECT p.ordinal, COALESCE(m.source_uuid, ''),
-			p.note, p.created_at
-		FROM pinned_messages p
-		LEFT JOIN messages m ON m.id = p.message_id
-		WHERE p.session_id = ?`,
-		sessionID,
-	)
+	pins, err := savePinsTx(tx, sessionID)
 	if err != nil {
-		return fmt.Errorf("saving pins: %w", err)
-	}
-	defer pinRows.Close()
-	var pins []savedPin
-	for pinRows.Next() {
-		var sp savedPin
-		if err := pinRows.Scan(
-			&sp.ordinal, &sp.sourceUUID, &sp.note, &sp.createdAt,
-		); err != nil {
-			return fmt.Errorf("scanning pin: %w", err)
-		}
-		pins = append(pins, sp)
-	}
-	if err := pinRows.Err(); err != nil {
-		return fmt.Errorf("iterating pins: %w", err)
+		return err
 	}
 
 	if _, err := tx.Exec(
@@ -584,6 +558,50 @@ func (db *DB) ReplaceSessionMessages(
 		}
 	}
 
+	if err := restorePinsTx(tx, sessionID, pins); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func savePinsTx(tx *sql.Tx, sessionID string) ([]savedPin, error) {
+	// Save existing pins before deletion. The ON DELETE CASCADE on
+	// pinned_messages.message_id would otherwise wipe them when
+	// messages are deleted below. source_uuid comes from the joined
+	// message row; LEFT JOIN keeps pins on legacy rows whose
+	// message_id no longer resolves cleanly.
+	pinRows, err := tx.Query(`
+		SELECT p.ordinal, COALESCE(m.source_uuid, ''),
+			p.note, p.created_at
+		FROM pinned_messages p
+		LEFT JOIN messages m ON m.id = p.message_id
+		WHERE p.session_id = ?`,
+		sessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("saving pins: %w", err)
+	}
+	defer pinRows.Close()
+	var pins []savedPin
+	for pinRows.Next() {
+		var sp savedPin
+		if err := pinRows.Scan(
+			&sp.ordinal, &sp.sourceUUID, &sp.note, &sp.createdAt,
+		); err != nil {
+			return nil, fmt.Errorf("scanning pin: %w", err)
+		}
+		pins = append(pins, sp)
+	}
+	if err := pinRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating pins: %w", err)
+	}
+	return pins, nil
+}
+
+func restorePinsTx(
+	tx *sql.Tx, sessionID string, pins []savedPin,
+) error {
 	// Re-attach saved pins. Prefer source_uuid (stable across
 	// ordinal-shifting rewrites) and fall back to ordinal for
 	// legacy pins whose source row predates the source_uuid column.
@@ -619,8 +637,7 @@ func (db *DB) ReplaceSessionMessages(
 			return fmt.Errorf("restoring pin ord=%d: %w", sp.ordinal, err)
 		}
 	}
-
-	return tx.Commit()
+	return nil
 }
 
 // attachToolCalls loads tool_calls for the given messages

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -46,6 +46,13 @@ func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
 		)
 		return err
 	}), "seed excluded session")
+	requireNoError(t, d.UpsertSession(Session{
+		ID:      "trashed",
+		Project: "proj",
+		Machine: defaultMachine,
+		Agent:   defaultAgent,
+	}), "seed trashed session")
+	requireNoError(t, d.SoftDeleteSession("trashed"), "soft delete session")
 
 	health := 95
 	grade := "A"
@@ -113,6 +120,20 @@ func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
 			},
 			DataVersion: CurrentDataVersion(),
 		},
+		{
+			Session: Session{
+				ID:               "trashed",
+				Project:          "proj",
+				Machine:          defaultMachine,
+				Agent:            defaultAgent,
+				MessageCount:     1,
+				UserMessageCount: 1,
+			},
+			Messages: []Message{
+				userMsg("trashed", 0, "trashed"),
+			},
+			DataVersion: CurrentDataVersion(),
+		},
 	})
 	requireNoError(t, err, "WriteSessionBatch")
 	if result.WrittenSessions != 1 {
@@ -124,8 +145,8 @@ func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
 	if result.FailedSessions != 1 {
 		t.Fatalf("FailedSessions = %d, want 1", result.FailedSessions)
 	}
-	if result.ExcludedSessions != 1 {
-		t.Fatalf("ExcludedSessions = %d, want 1", result.ExcludedSessions)
+	if result.ExcludedSessions != 2 {
+		t.Fatalf("ExcludedSessions = %d, want 2", result.ExcludedSessions)
 	}
 
 	sess, err := d.GetSessionFull(context.Background(), "good")
@@ -147,6 +168,11 @@ func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
 	}
 	if !sess.HasToolCalls {
 		t.Error("HasToolCalls = false, want true")
+	}
+	trashed, err := d.GetSessionFull(context.Background(), "trashed")
+	requireNoError(t, err, "GetSessionFull trashed")
+	if trashed == nil || trashed.DeletedAt == nil {
+		t.Fatal("trashed session was not preserved in trash")
 	}
 
 	msgs, err := d.GetAllMessages(context.Background(), "good")

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -525,6 +525,69 @@ func copySessionDataForIDs(
 			)
 		}
 	}
+
+	if err := copyPinnedMessagesForIDs(ctx, tx, tempIDsTable); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyPinnedMessagesForIDs(
+	ctx context.Context,
+	tx *sql.Tx,
+	tempIDsTable string,
+) error {
+	if !oldDBHasTable(ctx, tx, "pinned_messages") {
+		return nil
+	}
+
+	// Re-map old message IDs to the newly inserted message rows.
+	// Prefer source_uuid when available because it survives ordinal
+	// shifts, then fall back to the same (session_id, ordinal)
+	// natural key used by tool call copying.
+	if oldDBHasColumn(ctx, tx, "messages", "source_uuid") {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO main.pinned_messages
+				(session_id, message_id, ordinal, note, created_at)
+			SELECT
+				op.session_id, new_m.id, new_m.ordinal,
+				op.note, op.created_at
+			FROM old_db.pinned_messages op
+			JOIN old_db.messages old_m
+				ON old_m.id = op.message_id
+			JOIN main.messages new_m
+				ON new_m.session_id = old_m.session_id
+				AND new_m.source_uuid = old_m.source_uuid
+			WHERE op.session_id IN (
+				SELECT id FROM `+tempIDsTable+`
+			)
+			  AND old_m.source_uuid IS NOT NULL
+			  AND old_m.source_uuid <> ''`,
+		); err != nil {
+			return fmt.Errorf(
+				"copying pinned messages by source_uuid: %w", err,
+			)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO main.pinned_messages
+			(session_id, message_id, ordinal, note, created_at)
+		SELECT
+			op.session_id, new_m.id, new_m.ordinal,
+			op.note, op.created_at
+		FROM old_db.pinned_messages op
+		JOIN old_db.messages old_m
+			ON old_m.id = op.message_id
+		JOIN main.messages new_m
+			ON new_m.session_id = old_m.session_id
+			AND new_m.ordinal = old_m.ordinal
+		WHERE op.session_id IN (
+			SELECT id FROM `+tempIDsTable+`
+		)`,
+	); err != nil {
+		return fmt.Errorf("copying pinned messages by ordinal: %w", err)
+	}
 	return nil
 }
 

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -95,117 +95,8 @@ func (d *DB) CopyOrphanedDataFrom(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Copy session rows. Build column list dynamically so
-	// older source DBs missing display_name/deleted_at don't
-	// abort the migration.
-	orphanCols := orphanSessionCols(ctx, tx)
-
-	if _, err := tx.ExecContext(ctx,
-		"INSERT OR IGNORE INTO sessions ("+orphanCols+") "+
-			"SELECT "+orphanCols+" FROM old_db.sessions "+
-			"WHERE id IN (SELECT id FROM _orphaned_ids)",
-	); err != nil {
-		return 0, fmt.Errorf(
-			"copying orphaned sessions: %w", err,
-		)
-	}
-
-	// Copy messages. Omit id to let auto-increment assign
-	// new IDs (old IDs may collide with freshly synced
-	// messages). Probe is_system so older source DBs that
-	// lack the column don't abort the migration.
-	var msgCols strings.Builder
-	msgCols.WriteString("session_id, ordinal, role, content, " +
-		"timestamp, has_thinking, has_tool_use, " +
-		"content_length")
-	if oldDBHasColumn(ctx, tx, "messages", "is_system") {
-		msgCols.WriteString(", is_system")
-	}
-	for _, c := range []string{
-		"model", "token_usage", "context_tokens",
-		"output_tokens", "has_context_tokens",
-		"has_output_tokens",
-		"claude_message_id", "claude_request_id",
-		"source_type", "source_subtype",
-		"source_uuid", "source_parent_uuid",
-		"is_sidechain", "is_compact_boundary",
-		"thinking_text",
-	} {
-		if oldDBHasColumn(ctx, tx, "messages", c) {
-			msgCols.WriteString(", " + c)
-		}
-	}
-	if _, err := tx.ExecContext(ctx,
-		"INSERT INTO messages ("+msgCols.String()+") "+
-			"SELECT "+msgCols.String()+" FROM old_db.messages "+
-			"WHERE session_id IN (SELECT id FROM _orphaned_ids)",
-	); err != nil {
-		return 0, fmt.Errorf(
-			"copying orphaned messages: %w", err,
-		)
-	}
-
-	// Copy tool_calls. Map old message_id to new
-	// message_id via the (session_id, ordinal) natural key.
-	toolCallCols := []string{
-		"message_id", "session_id", "tool_name", "category",
-		"tool_use_id", "input_json", "skill_name",
-		"result_content_length",
-	}
-	toolCallSelect := []string{
-		"new_m.id", "otc.session_id", "otc.tool_name",
-		"otc.category", "otc.tool_use_id", "otc.input_json",
-		"otc.skill_name", "otc.result_content_length",
-	}
-	if oldDBHasColumn(ctx, tx, "tool_calls", "result_content") {
-		toolCallCols = append(toolCallCols, "result_content")
-		toolCallSelect = append(toolCallSelect, "otc.result_content")
-	}
-	toolCallCols = append(toolCallCols, "subagent_session_id")
-	toolCallSelect = append(toolCallSelect, "otc.subagent_session_id")
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO tool_calls
-			(`+strings.Join(toolCallCols, ", ")+`)
-		SELECT
-			`+strings.Join(toolCallSelect, ", ")+`
-		FROM old_db.tool_calls otc
-		JOIN old_db.messages old_m
-			ON old_m.id = otc.message_id
-		JOIN main.messages new_m
-			ON new_m.session_id = old_m.session_id
-			AND new_m.ordinal = old_m.ordinal
-		WHERE otc.session_id IN (
-			SELECT id FROM _orphaned_ids
-		)`,
-	); err != nil {
-		return 0, fmt.Errorf(
-			"copying orphaned tool_calls: %w", err,
-		)
-	}
-
-	if oldDBHasTable(ctx, tx, "tool_result_events") {
-		if _, err := tx.ExecContext(ctx, `
-			INSERT INTO tool_result_events
-				(session_id, tool_call_message_ordinal,
-				 call_index, tool_use_id, agent_id,
-				 subagent_session_id, source, status,
-				 content, content_length, timestamp,
-				 event_index)
-			SELECT
-				session_id, tool_call_message_ordinal,
-				call_index, tool_use_id, agent_id,
-				subagent_session_id, source, status,
-				content, content_length, timestamp,
-				event_index
-			FROM old_db.tool_result_events
-			WHERE session_id IN (
-				SELECT id FROM _orphaned_ids
-			)`,
-		); err != nil {
-			return 0, fmt.Errorf(
-				"copying orphaned tool_result_events: %w", err,
-			)
-		}
+	if err := copySessionDataForIDs(ctx, tx, "_orphaned_ids"); err != nil {
+		return 0, fmt.Errorf("copying orphaned data: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -219,6 +110,85 @@ func (d *DB) CopyOrphanedDataFrom(
 		count, time.Since(t).Round(time.Millisecond),
 	)
 
+	return count, nil
+}
+
+// CopyTrashedDataFrom copies soft-deleted sessions and their
+// messages from the source database. ResyncAll calls this before
+// parsing into a fresh DB so UpsertSession can see trashed rows
+// and reject source-file writes that would otherwise overwrite
+// the user's trash.
+func (d *DB) CopyTrashedDataFrom(sourcePath string) (int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	ctx := context.Background()
+	conn, err := d.getWriter().Conn(ctx)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"acquiring connection: %w", err,
+		)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(
+		ctx, "ATTACH DATABASE ? AS old_db", sourcePath,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"attaching source db: %w", err,
+		)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(
+			ctx, "DETACH DATABASE old_db",
+		)
+	}()
+
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin trashed copy tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if !oldDBHasColumn(ctx, tx, "sessions", "deleted_at") {
+		return 0, nil
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TEMP TABLE _trashed_ids AS
+		SELECT id FROM old_db.sessions
+		WHERE deleted_at IS NOT NULL
+		  AND id NOT IN (SELECT id FROM main.excluded_sessions)`); err != nil {
+		return 0, fmt.Errorf(
+			"identifying trashed sessions: %w", err,
+		)
+	}
+	defer func() {
+		_, _ = tx.ExecContext(
+			ctx,
+			"DROP TABLE IF EXISTS _trashed_ids",
+		)
+	}()
+
+	var count int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT count(*) FROM _trashed_ids",
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf(
+			"counting trashed sessions: %w", err,
+		)
+	}
+	if count == 0 {
+		return 0, nil
+	}
+
+	if err := copySessionDataForIDs(ctx, tx, "_trashed_ids"); err != nil {
+		return 0, fmt.Errorf("copying trashed data: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("committing trashed copy: %w", err)
+	}
 	return count, nil
 }
 
@@ -442,6 +412,120 @@ func orphanSessionCols(ctx context.Context, tx *sql.Tx) string {
 		}
 	}
 	return strings.Join(cols, ", ")
+}
+
+func copySessionDataForIDs(
+	ctx context.Context,
+	tx *sql.Tx,
+	tempIDsTable string,
+) error {
+	// Copy session rows. Build column list dynamically so
+	// older source DBs missing display_name/deleted_at don't
+	// abort the migration.
+	orphanCols := orphanSessionCols(ctx, tx)
+
+	if _, err := tx.ExecContext(ctx,
+		"INSERT OR IGNORE INTO sessions ("+orphanCols+") "+
+			"SELECT "+orphanCols+" FROM old_db.sessions "+
+			"WHERE id IN (SELECT id FROM "+tempIDsTable+")",
+	); err != nil {
+		return fmt.Errorf("copying sessions: %w", err)
+	}
+
+	// Copy messages. Omit id to let auto-increment assign
+	// new IDs (old IDs may collide with freshly synced
+	// messages). Probe is_system so older source DBs that
+	// lack the column don't abort the migration.
+	var msgCols strings.Builder
+	msgCols.WriteString("session_id, ordinal, role, content, " +
+		"timestamp, has_thinking, has_tool_use, " +
+		"content_length")
+	if oldDBHasColumn(ctx, tx, "messages", "is_system") {
+		msgCols.WriteString(", is_system")
+	}
+	for _, c := range []string{
+		"model", "token_usage", "context_tokens",
+		"output_tokens", "has_context_tokens",
+		"has_output_tokens",
+		"claude_message_id", "claude_request_id",
+		"source_type", "source_subtype",
+		"source_uuid", "source_parent_uuid",
+		"is_sidechain", "is_compact_boundary",
+		"thinking_text",
+	} {
+		if oldDBHasColumn(ctx, tx, "messages", c) {
+			msgCols.WriteString(", " + c)
+		}
+	}
+	if _, err := tx.ExecContext(ctx,
+		"INSERT INTO messages ("+msgCols.String()+") "+
+			"SELECT "+msgCols.String()+" FROM old_db.messages "+
+			"WHERE session_id IN (SELECT id FROM "+tempIDsTable+")",
+	); err != nil {
+		return fmt.Errorf("copying messages: %w", err)
+	}
+
+	// Copy tool_calls. Map old message_id to new
+	// message_id via the (session_id, ordinal) natural key.
+	toolCallCols := []string{
+		"message_id", "session_id", "tool_name", "category",
+		"tool_use_id", "input_json", "skill_name",
+		"result_content_length",
+	}
+	toolCallSelect := []string{
+		"new_m.id", "otc.session_id", "otc.tool_name",
+		"otc.category", "otc.tool_use_id", "otc.input_json",
+		"otc.skill_name", "otc.result_content_length",
+	}
+	if oldDBHasColumn(ctx, tx, "tool_calls", "result_content") {
+		toolCallCols = append(toolCallCols, "result_content")
+		toolCallSelect = append(toolCallSelect, "otc.result_content")
+	}
+	toolCallCols = append(toolCallCols, "subagent_session_id")
+	toolCallSelect = append(toolCallSelect, "otc.subagent_session_id")
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO tool_calls
+			(`+strings.Join(toolCallCols, ", ")+`)
+		SELECT
+			`+strings.Join(toolCallSelect, ", ")+`
+		FROM old_db.tool_calls otc
+		JOIN old_db.messages old_m
+			ON old_m.id = otc.message_id
+		JOIN main.messages new_m
+			ON new_m.session_id = old_m.session_id
+			AND new_m.ordinal = old_m.ordinal
+		WHERE otc.session_id IN (
+			SELECT id FROM `+tempIDsTable+`
+		)`,
+	); err != nil {
+		return fmt.Errorf("copying tool_calls: %w", err)
+	}
+
+	if oldDBHasTable(ctx, tx, "tool_result_events") {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO tool_result_events
+				(session_id, tool_call_message_ordinal,
+				 call_index, tool_use_id, agent_id,
+				 subagent_session_id, source, status,
+				 content, content_length, timestamp,
+				 event_index)
+			SELECT
+				session_id, tool_call_message_ordinal,
+				call_index, tool_use_id, agent_id,
+				subagent_session_id, source, status,
+				content, content_length, timestamp,
+				event_index
+			FROM old_db.tool_result_events
+			WHERE session_id IN (
+				SELECT id FROM `+tempIDsTable+`
+			)`,
+		); err != nil {
+			return fmt.Errorf(
+				"copying tool_result_events: %w", err,
+			)
+		}
+	}
+	return nil
 }
 
 // oldDBHasColumn checks if a column exists in an old_db table

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -102,6 +102,7 @@ func (db *DB) WriteSessionBatch(
 // batch.
 func (db *DB) WriteSessionBatchAtomic(
 	writes []SessionBatchWrite,
+	beforeCommit ...func() error,
 ) (SessionBatchResult, error) {
 	var result SessionBatchResult
 	if len(writes) == 0 {
@@ -138,6 +139,14 @@ func (db *DB) WriteSessionBatchAtomic(
 		}
 		result.WrittenSessions++
 		result.WrittenMessages += messagesWritten
+	}
+
+	if len(beforeCommit) > 0 && beforeCommit[0] != nil {
+		if err := beforeCommit[0](); err != nil {
+			result.WrittenSessions = 0
+			result.WrittenMessages = 0
+			return result, err
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -97,6 +97,55 @@ func (db *DB) WriteSessionBatch(
 	return result, nil
 }
 
+// WriteSessionBatchAtomic writes all sessions in one
+// transaction. Any rejected or failed row rolls back the whole
+// batch.
+func (db *DB) WriteSessionBatchAtomic(
+	writes []SessionBatchWrite,
+) (SessionBatchResult, error) {
+	var result SessionBatchResult
+	if len(writes) == 0 {
+		return result, nil
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return result, fmt.Errorf("beginning batch tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, write := range writes {
+		messagesWritten, err := writeOneSessionBatchTx(tx, write)
+		if err != nil {
+			result.WrittenSessions = 0
+			result.WrittenMessages = 0
+			switch {
+			case errors.Is(err, ErrSessionExcluded),
+				errors.Is(err, ErrSessionTrashed):
+				result.ExcludedSessions++
+				result.ExcludedIDs = append(
+					result.ExcludedIDs,
+					write.Session.ID,
+				)
+			default:
+				result.FailedSessions++
+				result.Errors = append(result.Errors, err)
+			}
+			return result, err
+		}
+		result.WrittenSessions++
+		result.WrittenMessages += messagesWritten
+	}
+
+	if err := tx.Commit(); err != nil {
+		return result, fmt.Errorf("committing batch tx: %w", err)
+	}
+	return result, nil
+}
+
 func rollbackSavepoint(tx *sql.Tx, savepoint string) error {
 	if _, err := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint); err != nil {
 		return fmt.Errorf(

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -204,7 +204,12 @@ func writeOneSessionBatchTx(
 	}
 
 	msgs := write.Messages
+	var pins []savedPin
 	if write.ReplaceMessages {
+		pins, err = savePinsTx(tx, write.Session.ID)
+		if err != nil {
+			return 0, err
+		}
 		if err := deleteSessionMessagesTx(tx, write.Session.ID); err != nil {
 			return 0, err
 		}
@@ -227,6 +232,11 @@ func writeOneSessionBatchTx(
 		}
 		events := resolveToolResultEvents(msgs)
 		if err := insertToolResultEventsTx(tx, events); err != nil {
+			return 0, err
+		}
+	}
+	if write.ReplaceMessages {
+		if err := restorePinsTx(tx, write.Session.ID, pins); err != nil {
 			return 0, err
 		}
 	}

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -72,7 +72,8 @@ func (db *DB) WriteSessionBatch(
 			}
 			result.WrittenSessions++
 			result.WrittenMessages += messagesWritten
-		case errors.Is(err, ErrSessionExcluded):
+		case errors.Is(err, ErrSessionExcluded),
+			errors.Is(err, ErrSessionTrashed):
 			if rerr := rollbackSavepoint(tx, savepoint); rerr != nil {
 				return result, rerr
 			}
@@ -127,6 +128,20 @@ func writeOneSessionBatchTx(
 	}
 	if excluded == 1 {
 		return 0, ErrSessionExcluded
+	}
+	var trashed int
+	err = tx.QueryRow(
+		"SELECT 1 FROM sessions WHERE id = ? AND deleted_at IS NOT NULL",
+		write.Session.ID,
+	).Scan(&trashed)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf(
+			"checking trash for %s: %w",
+			write.Session.ID, err,
+		)
+	}
+	if trashed == 1 {
+		return 0, ErrSessionTrashed
 	}
 
 	if _, err := tx.Exec(

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -21,6 +21,11 @@ var ErrInvalidCursor = errors.New("invalid cursor")
 // skip any follow-up writes (messages, tool_calls) for this session.
 var ErrSessionExcluded = errors.New("session excluded")
 
+// ErrSessionTrashed is returned by UpsertSession when the
+// session currently exists in the trash. Upload/import callers
+// should surface a conflict instead of silently overwriting it.
+var ErrSessionTrashed = errors.New("session trashed")
+
 // sessionBaseCols is the column list for standard session queries
 // (list, get). Keep in sync with scanSessionRow.
 const sessionBaseCols = `id, project, machine, agent,
@@ -735,19 +740,26 @@ func upsertSessionArgs(s Session) []any {
 
 // UpsertSession inserts or updates a session.
 // Sessions that were permanently deleted (in excluded_sessions)
-// are silently skipped.
+// or currently in the trash are rejected.
 func (db *DB) UpsertSession(s Session) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	// Check exclusion under the write lock to avoid a race with
-	// concurrent DeleteSession/EmptyTrash.
+	// Check exclusion/trash state under the write lock to avoid a race with
+	// concurrent DeleteSession/EmptyTrash/RestoreSession.
 	var excluded int
 	_ = db.getWriter().QueryRow(
 		"SELECT 1 FROM excluded_sessions WHERE id = ?", s.ID,
 	).Scan(&excluded)
 	if excluded == 1 {
 		return ErrSessionExcluded
+	}
+	var trashed int
+	_ = db.getWriter().QueryRow(
+		"SELECT 1 FROM sessions WHERE id = ? AND deleted_at IS NOT NULL", s.ID,
+	).Scan(&trashed)
+	if trashed == 1 {
+		return ErrSessionTrashed
 	}
 
 	// data_version is intentionally NOT advanced here. The

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1054,7 +1054,8 @@ func (db *DB) GetSessionForIncremental(
 	var count int
 	err := db.getReader().QueryRow(
 		`SELECT COUNT(*) FROM sessions
-		 WHERE file_path = ?`, path,
+		 WHERE file_path = ?
+		   AND deleted_at IS NULL`, path,
 	).Scan(&count)
 	if err != nil || count != 1 {
 		return nil, false
@@ -1070,7 +1071,9 @@ func (db *DB) GetSessionForIncremental(
 			first_message,
 			total_output_tokens, peak_context_tokens,
 			has_total_output_tokens, has_peak_context_tokens
-		 FROM sessions WHERE file_path = ?`,
+		 FROM sessions
+		 WHERE file_path = ?
+		   AND deleted_at IS NULL`,
 		path,
 	).Scan(
 		&info.ID, &fs, &fm, &fi, &fd,

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -93,7 +93,10 @@ type Store interface {
 	// Upload (local-only; PG returns ErrReadOnly).
 	UpsertSession(s Session) error
 	ReplaceSessionMessages(sessionID string, msgs []Message) error
-	WriteSessionBatchAtomic(writes []SessionBatchWrite) (SessionBatchResult, error)
+	WriteSessionBatchAtomic(
+		writes []SessionBatchWrite,
+		beforeCommit ...func() error,
+	) (SessionBatchResult, error)
 
 	// ReadOnly returns true for remote/PG-backed stores.
 	ReadOnly() bool

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -93,6 +93,7 @@ type Store interface {
 	// Upload (local-only; PG returns ErrReadOnly).
 	UpsertSession(s Session) error
 	ReplaceSessionMessages(sessionID string, msgs []Message) error
+	WriteSessionBatchAtomic(writes []SessionBatchWrite) (SessionBatchResult, error)
 
 	// ReadOnly returns true for remote/PG-backed stores.
 	ReadOnly() bool

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -190,3 +190,10 @@ func (s *Store) ReplaceSessionMessages(
 ) error {
 	return db.ErrReadOnly
 }
+
+// WriteSessionBatchAtomic is not supported in read-only mode.
+func (s *Store) WriteSessionBatchAtomic(
+	_ []db.SessionBatchWrite,
+) (db.SessionBatchResult, error) {
+	return db.SessionBatchResult{}, db.ErrReadOnly
+}

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -194,6 +194,7 @@ func (s *Store) ReplaceSessionMessages(
 // WriteSessionBatchAtomic is not supported in read-only mode.
 func (s *Store) WriteSessionBatchAtomic(
 	_ []db.SessionBatchWrite,
+	_ ...func() error,
 ) (db.SessionBatchResult, error) {
 	return db.SessionBatchResult{}, db.ErrReadOnly
 }

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -894,6 +894,10 @@ func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
 		{"ReplaceSessionMessages", func() error {
 			return store.ReplaceSessionMessages("x", nil)
 		}},
+		{"WriteSessionBatchAtomic", func() error {
+			_, err := store.WriteSessionBatchAtomic(nil)
+			return err
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2466,6 +2466,50 @@ func TestUploadSession_Errors(t *testing.T) {
 	}
 }
 
+func TestUploadSession_ExcludedOrTrashedConflict(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, te *testEnv, id string)
+	}{
+		{
+			name: "excluded",
+			setup: func(t *testing.T, te *testEnv, id string) {
+				t.Helper()
+				require.NoError(t, te.db.UpsertSession(db.Session{
+					ID: id, Project: "myproj", Machine: "remote", Agent: "claude",
+				}), "seed session")
+				require.NoError(t, te.db.DeleteSession(id), "DeleteSession")
+			},
+		},
+		{
+			name: "trashed",
+			setup: func(t *testing.T, te *testEnv, id string) {
+				t.Helper()
+				require.NoError(t, te.db.UpsertSession(db.Session{
+					ID: id, Project: "myproj", Machine: "remote", Agent: "claude",
+				}), "seed session")
+				require.NoError(t, te.db.SoftDeleteSession(id), "SoftDeleteSession")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			te := setup(t)
+			const id = "upload-conflict"
+			tt.setup(t, te, id)
+
+			content := testjsonl.NewSessionBuilder().
+				AddClaudeUser(tsEarly, "Hello upload").
+				AddClaudeAssistant(tsEarlyS5, "Done.").
+				String()
+			w := te.upload(t, id+".jsonl", content, "project=myproj&machine=remote")
+			assertStatus(t, w, http.StatusConflict)
+			assertErrorResponse(t, w, "session upload rejected: session is excluded or trashed")
+		})
+	}
+}
+
 func TestUploadSession_EmptyFile(t *testing.T) {
 	te := setup(t)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"mime/multipart"
 	"net"
@@ -2506,6 +2507,12 @@ func TestUploadSession_ExcludedOrTrashedConflict(t *testing.T) {
 			w := te.upload(t, id+".jsonl", content, "project=myproj&machine=remote")
 			assertStatus(t, w, http.StatusConflict)
 			assertErrorResponse(t, w, "session upload rejected: session is excluded or trashed")
+			destPath := filepath.Join(
+				te.dataDir, "uploads", "myproj", id+".jsonl",
+			)
+			if _, err := os.Stat(destPath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("rejected upload file exists at %s: %v", destPath, err)
+			}
 		})
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2517,6 +2517,48 @@ func TestUploadSession_ExcludedOrTrashedConflict(t *testing.T) {
 	}
 }
 
+func TestUploadSession_MultiSessionConflictDoesNotPartiallyWrite(t *testing.T) {
+	te := setup(t)
+
+	const filename = "upload-multi-conflict.jsonl"
+	const mainID = "upload-multi-conflict"
+	const forkID = "upload-multi-conflict-i"
+
+	require.NoError(t, te.db.UpsertSession(db.Session{
+		ID: forkID, Project: "myproj", Machine: "remote", Agent: "claude",
+	}), "seed fork session")
+	require.NoError(t, te.db.DeleteSession(forkID), "DeleteSession")
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithUUID(tsEarly, "q1", "a", "").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:01Z", "a1", "b", "a").
+		AddClaudeUserWithUUID(tsEarlyS5, "q2", "c", "b").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:06Z", "a2", "d", "c").
+		AddClaudeUserWithUUID("2024-01-01T10:00:07Z", "q3", "e", "d").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:08Z", "a3", "f", "e").
+		AddClaudeUserWithUUID("2024-01-01T10:00:09Z", "q4", "g", "f").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:10Z", "a4", "h", "g").
+		AddClaudeUserWithUUID("2024-01-01T10:00:11Z", "q5", "k", "h").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:12Z", "a5", "l", "k").
+		AddClaudeUserWithUUID("2024-01-01T10:00:13Z", "fork q", "i", "b").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:14Z", "fork a", "j", "i").
+		String()
+
+	w := te.upload(t, filename, content, "project=myproj&machine=remote")
+	assertStatus(t, w, http.StatusConflict)
+	assertErrorResponse(t, w, "session upload rejected: session is excluded or trashed")
+
+	main, err := te.db.GetSessionFull(context.Background(), mainID)
+	require.NoError(t, err, "GetSessionFull main")
+	if main != nil {
+		t.Fatalf("main session was partially written: %+v", main)
+	}
+	destPath := filepath.Join(te.dataDir, "uploads", "myproj", filename)
+	if _, err := os.Stat(destPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("rejected upload file exists at %s: %v", destPath, err)
+	}
+}
+
 func TestUploadSession_EmptyFile(t *testing.T) {
 	te := setup(t)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2559,6 +2559,45 @@ func TestUploadSession_MultiSessionConflictDoesNotPartiallyWrite(t *testing.T) {
 	}
 }
 
+func TestUploadSession_ReuploadPreservesPins(t *testing.T) {
+	te := setup(t)
+
+	initial := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "original upload").
+		AddClaudeAssistant(tsEarlyS5, "original reply").
+		String()
+	w := te.upload(t, "upload-pinned.jsonl", initial,
+		"project=myproj&machine=remote")
+	assertStatus(t, w, http.StatusOK)
+
+	msgs, err := te.db.GetAllMessages(context.Background(), "upload-pinned")
+	require.NoError(t, err, "GetAllMessages")
+	require.Len(t, msgs, 2, "initial messages")
+	note := "keep this"
+	_, err = te.db.PinMessage("upload-pinned", msgs[0].ID, &note)
+	require.NoError(t, err, "PinMessage")
+
+	updated := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "updated upload").
+		AddClaudeAssistant(tsEarlyS5, "updated reply").
+		String()
+	w = te.upload(t, "upload-pinned.jsonl", updated,
+		"project=myproj&machine=remote")
+	assertStatus(t, w, http.StatusOK)
+
+	pins, err := te.db.ListPinnedMessages(
+		context.Background(), "upload-pinned", "",
+	)
+	require.NoError(t, err, "ListPinnedMessages")
+	require.Len(t, pins, 1, "pins after re-upload")
+	if pins[0].Ordinal != 0 {
+		t.Fatalf("pin ordinal = %d, want 0", pins[0].Ordinal)
+	}
+	if pins[0].Note == nil || *pins[0].Note != note {
+		t.Fatalf("pin note = %v, want %q", pins[0].Note, note)
+	}
+}
+
 func TestUploadSession_EmptyFile(t *testing.T) {
 	te := setup(t)
 

--- a/internal/server/sync_route.go
+++ b/internal/server/sync_route.go
@@ -34,7 +34,8 @@ func (s *Server) handleSyncSession(
 		if handleReadOnly(w, err) {
 			return
 		}
-		if errors.Is(err, db.ErrSessionExcluded) {
+		if errors.Is(err, db.ErrSessionExcluded) ||
+			errors.Is(err, db.ErrSessionTrashed) {
 			writeError(w, http.StatusConflict, err.Error())
 			return
 		}

--- a/internal/server/upload.go
+++ b/internal/server/upload.go
@@ -137,12 +137,12 @@ func commitUpload(upload stagedUpload) error {
 	return nil
 }
 
-// saveSessionToDB maps parsed session and messages to DB types
-// and persists them.
-func (s *Server) saveSessionToDB(
+// sessionBatchWriteFromParsed maps parsed session and messages
+// to DB types for an upload transaction.
+func sessionBatchWriteFromParsed(
 	sess parser.ParsedSession,
 	msgs []parser.ParsedMessage,
-) error {
+) db.SessionBatchWrite {
 	hasTotal, hasPeak := sess.TokenCoverage(msgs)
 	dbSess := db.Session{
 		ID:                   sess.ID,
@@ -172,10 +172,6 @@ func (s *Server) saveSessionToDB(
 		dbSess.EndedAt = timeutil.Ptr(sess.EndedAt)
 	}
 
-	if err := s.db.UpsertSession(dbSess); err != nil {
-		return fmt.Errorf("storing session: %w", err)
-	}
-
 	dbMsgs := make([]db.Message, len(msgs))
 	for i, m := range msgs {
 		hasCtx, hasOut := m.TokenPresence()
@@ -197,12 +193,11 @@ func (s *Server) saveSessionToDB(
 		}
 	}
 
-	if err := s.db.ReplaceSessionMessages(
-		sess.ID, dbMsgs,
-	); err != nil {
-		return fmt.Errorf("storing messages: %w", err)
+	return db.SessionBatchWrite{
+		Session:         dbSess,
+		Messages:        dbMsgs,
+		ReplaceMessages: true,
 	}
-	return nil
 }
 
 func (s *Server) handleUploadSession(
@@ -260,21 +255,26 @@ func (s *Server) handleUploadSession(
 		results[i].Session.File.Path = upload.finalPath
 	}
 
-	for _, pr := range results {
-		if err := s.saveSessionToDB(pr.Session, pr.Messages); err != nil {
-			if handleReadOnly(w, err) {
-				return
-			}
-			if errors.Is(err, db.ErrSessionExcluded) || errors.Is(err, db.ErrSessionTrashed) {
-				writeError(w, http.StatusConflict,
-					"session upload rejected: session is excluded or trashed")
-				return
-			}
-			log.Printf("Error saving session to DB: %v", err)
-			writeError(w, http.StatusInternalServerError,
-				"failed to save session to database")
+	writes := make([]db.SessionBatchWrite, len(results))
+	for i, pr := range results {
+		writes[i] = sessionBatchWriteFromParsed(
+			pr.Session, pr.Messages,
+		)
+	}
+	if _, err := s.db.WriteSessionBatchAtomic(writes); err != nil {
+		if handleReadOnly(w, err) {
 			return
 		}
+		if errors.Is(err, db.ErrSessionExcluded) ||
+			errors.Is(err, db.ErrSessionTrashed) {
+			writeError(w, http.StatusConflict,
+				"session upload rejected: session is excluded or trashed")
+			return
+		}
+		log.Printf("Error saving session to DB: %v", err)
+		writeError(w, http.StatusInternalServerError,
+			"failed to save session to database")
+		return
 	}
 
 	if err := commitUpload(upload); err != nil {

--- a/internal/server/upload.go
+++ b/internal/server/upload.go
@@ -261,8 +261,19 @@ func (s *Server) handleUploadSession(
 			pr.Session, pr.Messages,
 		)
 	}
-	if _, err := s.db.WriteSessionBatchAtomic(writes); err != nil {
+	var commitErr error
+	_, err = s.db.WriteSessionBatchAtomic(writes, func() error {
+		commitErr = commitUpload(upload)
+		return commitErr
+	})
+	if err != nil {
 		if handleReadOnly(w, err) {
+			return
+		}
+		if commitErr != nil {
+			log.Printf("Error committing upload: %v", commitErr)
+			writeError(w, http.StatusInternalServerError,
+				"failed to save upload")
 			return
 		}
 		if errors.Is(err, db.ErrSessionExcluded) ||
@@ -274,13 +285,6 @@ func (s *Server) handleUploadSession(
 		log.Printf("Error saving session to DB: %v", err)
 		writeError(w, http.StatusInternalServerError,
 			"failed to save session to database")
-		return
-	}
-
-	if err := commitUpload(upload); err != nil {
-		log.Printf("Error committing upload: %v", err)
-		writeError(w, http.StatusInternalServerError,
-			"failed to save upload")
 		return
 	}
 	committed = true

--- a/internal/server/upload.go
+++ b/internal/server/upload.go
@@ -29,6 +29,13 @@ type stagedUpload struct {
 	finalPath string
 }
 
+type committedUpload struct {
+	finalPath   string
+	backupPath  string
+	hadPrevious bool
+	movedFinal  bool
+}
+
 // parseUploadRequest extracts and validates query params and
 // the multipart file from an upload request. The caller must
 // close req.file when done.
@@ -129,12 +136,91 @@ func (s *Server) stageUpload(
 	}, nil
 }
 
-func commitUpload(upload stagedUpload) error {
-	if err := os.Rename(upload.tempPath, upload.finalPath); err != nil {
-		return fmt.Errorf("committing upload: %w", err)
+func commitUpload(upload stagedUpload) (committedUpload, error) {
+	state := committedUpload{finalPath: upload.finalPath}
+
+	info, err := os.Lstat(upload.finalPath)
+	switch {
+	case err == nil:
+		if !info.Mode().IsRegular() {
+			return state, fmt.Errorf(
+				"committing upload: destination is not a regular file",
+			)
+		}
+		backupPath, err := createUploadBackupPath(upload.finalPath)
+		if err != nil {
+			return state, err
+		}
+		state.backupPath = backupPath
+		state.hadPrevious = true
+		if err := os.Rename(upload.finalPath, backupPath); err != nil {
+			return state, fmt.Errorf(
+				"backing up existing upload: %w", err,
+			)
+		}
+	case errors.Is(err, os.ErrNotExist):
+	default:
+		return state, fmt.Errorf(
+			"checking upload destination: %w", err,
+		)
 	}
-	_ = os.RemoveAll(upload.tempDir)
+
+	if err := os.Rename(upload.tempPath, upload.finalPath); err != nil {
+		if state.hadPrevious {
+			if rbErr := os.Rename(state.backupPath, upload.finalPath); rbErr != nil {
+				return state, fmt.Errorf(
+					"committing upload: %w (restore previous upload failed: %v)",
+					err, rbErr,
+				)
+			}
+			state.hadPrevious = false
+			state.backupPath = ""
+		}
+		return state, fmt.Errorf("committing upload: %w", err)
+	}
+	state.movedFinal = true
+	return state, nil
+}
+
+func createUploadBackupPath(finalPath string) (string, error) {
+	f, err := os.CreateTemp(
+		filepath.Dir(finalPath),
+		"."+filepath.Base(finalPath)+".*.bak",
+	)
+	if err != nil {
+		return "", fmt.Errorf("creating upload backup: %w", err)
+	}
+	path := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("closing upload backup: %w", err)
+	}
+	if err := os.Remove(path); err != nil {
+		return "", fmt.Errorf("preparing upload backup: %w", err)
+	}
+	return path, nil
+}
+
+func rollbackCommittedUpload(upload committedUpload) error {
+	if !upload.movedFinal {
+		return nil
+	}
+	if err := os.Remove(upload.finalPath); err != nil &&
+		!errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing committed upload: %w", err)
+	}
+	if upload.hadPrevious {
+		if err := os.Rename(upload.backupPath, upload.finalPath); err != nil {
+			return fmt.Errorf("restoring previous upload: %w", err)
+		}
+	}
 	return nil
+}
+
+func cleanupCommittedUpload(upload committedUpload) {
+	if upload.hadPrevious && upload.backupPath != "" {
+		_ = os.Remove(upload.backupPath)
+	}
 }
 
 // sessionBatchWriteFromParsed maps parsed session and messages
@@ -229,11 +315,8 @@ func (s *Server) handleUploadSession(
 			"failed to save upload")
 		return
 	}
-	committed := false
 	defer func() {
-		if !committed {
-			_ = os.RemoveAll(upload.tempDir)
-		}
+		_ = os.RemoveAll(upload.tempDir)
 	}()
 
 	results, err := parser.ParseClaudeSession(
@@ -262,18 +345,31 @@ func (s *Server) handleUploadSession(
 		)
 	}
 	var commitErr error
+	var uploadCommit committedUpload
 	_, err = s.db.WriteSessionBatchAtomic(writes, func() error {
-		commitErr = commitUpload(upload)
+		uploadCommit, commitErr = commitUpload(upload)
 		return commitErr
 	})
 	if err != nil {
-		if handleReadOnly(w, err) {
-			return
-		}
 		if commitErr != nil {
 			log.Printf("Error committing upload: %v", commitErr)
 			writeError(w, http.StatusInternalServerError,
 				"failed to save upload")
+			return
+		}
+		if uploadCommit.movedFinal {
+			if rbErr := rollbackCommittedUpload(uploadCommit); rbErr != nil {
+				log.Printf(
+					"Error rolling back upload after DB failure: %v",
+					rbErr,
+				)
+				writeError(w, http.StatusInternalServerError,
+					"failed to save upload")
+				return
+			}
+			cleanupCommittedUpload(uploadCommit)
+		}
+		if handleReadOnly(w, err) {
 			return
 		}
 		if errors.Is(err, db.ErrSessionExcluded) ||
@@ -287,7 +383,7 @@ func (s *Server) handleUploadSession(
 			"failed to save session to database")
 		return
 	}
-	committed = true
+	cleanupCommittedUpload(uploadCommit)
 
 	main := results[0]
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/internal/server/upload.go
+++ b/internal/server/upload.go
@@ -138,9 +138,6 @@ func (s *Server) saveSessionToDB(
 	}
 
 	if err := s.db.UpsertSession(dbSess); err != nil {
-		if errors.Is(err, db.ErrSessionExcluded) {
-			return nil // silently skip excluded sessions
-		}
 		return fmt.Errorf("storing session: %w", err)
 	}
 
@@ -222,6 +219,11 @@ func (s *Server) handleUploadSession(
 	for _, pr := range results {
 		if err := s.saveSessionToDB(pr.Session, pr.Messages); err != nil {
 			if handleReadOnly(w, err) {
+				return
+			}
+			if errors.Is(err, db.ErrSessionExcluded) || errors.Is(err, db.ErrSessionTrashed) {
+				writeError(w, http.StatusConflict,
+					"session upload rejected: session is excluded or trashed")
 				return
 			}
 			log.Printf("Error saving session to DB: %v", err)

--- a/internal/server/upload.go
+++ b/internal/server/upload.go
@@ -23,6 +23,12 @@ type uploadRequest struct {
 	filename string
 }
 
+type stagedUpload struct {
+	tempPath  string
+	tempDir   string
+	finalPath string
+}
+
 // parseUploadRequest extracts and validates query params and
 // the multipart file from an upload request. The caller must
 // close req.file when done.
@@ -70,36 +76,65 @@ func parseUploadRequest(
 	}, ""
 }
 
-// saveUpload writes the uploaded file to disk under
-// <dataDir>/uploads/<project>/<filename> and returns the
-// destination path.
-func (s *Server) saveUpload(
+// stageUpload writes the uploaded file to a temporary path in
+// <dataDir>/uploads/<project>. The caller must either commit
+// or remove the staged file.
+func (s *Server) stageUpload(
 	project string, filename string, src io.Reader,
-) (string, error) {
+) (stagedUpload, error) {
 	uploadDir := filepath.Join(
 		s.cfg.DataDir, "uploads", project,
 	)
 	if err := os.MkdirAll(uploadDir, 0o755); err != nil {
-		return "", fmt.Errorf(
+		return stagedUpload{}, fmt.Errorf(
 			"creating upload directory: %w", err,
 		)
 	}
 
-	destPath := filepath.Join(uploadDir, filename)
-	dest, err := os.Create(destPath)
+	tempDir, err := os.MkdirTemp(
+		uploadDir, "."+strings.TrimSuffix(filename, ".jsonl")+".*.tmp",
+	)
 	if err != nil {
-		return "", fmt.Errorf(
+		return stagedUpload{}, fmt.Errorf(
 			"saving uploaded file: %w", err,
 		)
 	}
-	defer dest.Close()
+	finalPath := filepath.Join(uploadDir, filename)
+	tempPath := filepath.Join(tempDir, filename)
+	dest, err := os.Create(tempPath)
+	if err != nil {
+		_ = os.RemoveAll(tempDir)
+		return stagedUpload{}, fmt.Errorf(
+			"saving uploaded file: %w", err,
+		)
+	}
 
 	if _, err := io.Copy(dest, src); err != nil {
-		return "", fmt.Errorf(
+		_ = dest.Close()
+		_ = os.RemoveAll(tempDir)
+		return stagedUpload{}, fmt.Errorf(
 			"writing uploaded file: %w", err,
 		)
 	}
-	return destPath, nil
+	if err := dest.Close(); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return stagedUpload{}, fmt.Errorf(
+			"closing uploaded file: %w", err,
+		)
+	}
+	return stagedUpload{
+		tempPath:  tempPath,
+		tempDir:   tempDir,
+		finalPath: finalPath,
+	}, nil
+}
+
+func commitUpload(upload stagedUpload) error {
+	if err := os.Rename(upload.tempPath, upload.finalPath); err != nil {
+		return fmt.Errorf("committing upload: %w", err)
+	}
+	_ = os.RemoveAll(upload.tempDir)
+	return nil
 }
 
 // saveSessionToDB maps parsed session and messages to DB types
@@ -190,7 +225,7 @@ func (s *Server) handleUploadSession(
 	}
 	defer req.file.Close()
 
-	destPath, err := s.saveUpload(
+	upload, err := s.stageUpload(
 		req.project, req.filename, req.file,
 	)
 	if err != nil {
@@ -199,9 +234,15 @@ func (s *Server) handleUploadSession(
 			"failed to save upload")
 		return
 	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(upload.tempDir)
+		}
+	}()
 
 	results, err := parser.ParseClaudeSession(
-		destPath, req.project, req.machine,
+		upload.tempPath, req.project, req.machine,
 	)
 	if err != nil {
 		writeError(w, http.StatusBadRequest,
@@ -215,6 +256,9 @@ func (s *Server) handleUploadSession(
 	}
 
 	parser.InferRelationshipTypes(results)
+	for i := range results {
+		results[i].Session.File.Path = upload.finalPath
+	}
 
 	for _, pr := range results {
 		if err := s.saveSessionToDB(pr.Session, pr.Messages); err != nil {
@@ -232,6 +276,14 @@ func (s *Server) handleUploadSession(
 			return
 		}
 	}
+
+	if err := commitUpload(upload); err != nil {
+		log.Printf("Error committing upload: %v", err)
+		writeError(w, http.StatusInternalServerError,
+			"failed to save upload")
+		return
+	}
+	committed = true
 
 	main := results[0]
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/internal/server/upload_failure_test.go
+++ b/internal/server/upload_failure_test.go
@@ -1,10 +1,13 @@
 package server_test
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/wesm/agentsview/internal/testjsonl"
 )
 
 func TestUploadSession_SaveFailure(t *testing.T) {
@@ -36,4 +39,35 @@ func TestUploadSession_DBFailure(t *testing.T) {
 	w := te.upload(t, "test.jsonl", content, "project=myproj")
 	assertStatus(t, w, http.StatusInternalServerError)
 	assertErrorResponse(t, w, "failed to save session to database")
+}
+
+func TestUploadSession_CommitFailureDoesNotWriteDB(t *testing.T) {
+	te := setup(t)
+
+	project := "myproj"
+	filename := "rename-fail.jsonl"
+	finalPath := filepath.Join(
+		te.dataDir, "uploads", project, filename,
+	)
+	if err := os.MkdirAll(finalPath, 0o755); err != nil {
+		t.Fatalf("creating final path directory: %v", err)
+	}
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T10:00:00Z", "hello").
+		AddClaudeAssistant("2024-01-01T10:00:05Z", "hi").
+		String()
+	w := te.upload(t, filename, content, "project="+project)
+	assertStatus(t, w, http.StatusInternalServerError)
+	assertErrorResponse(t, w, "failed to save upload")
+
+	sess, err := te.db.GetSessionFull(
+		context.Background(), "rename-fail",
+	)
+	if err != nil {
+		t.Fatalf("GetSessionFull: %v", err)
+	}
+	if sess != nil {
+		t.Fatalf("session persisted despite upload commit failure: %+v", sess)
+	}
 }

--- a/internal/server/upload_failure_test.go
+++ b/internal/server/upload_failure_test.go
@@ -1,14 +1,41 @@
 package server_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"mime/multipart"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/wesm/agentsview/internal/config"
+	"github.com/wesm/agentsview/internal/db"
+	"github.com/wesm/agentsview/internal/server"
 	"github.com/wesm/agentsview/internal/testjsonl"
 )
+
+type uploadCommitFailStore struct {
+	db.Store
+	err error
+}
+
+func (s uploadCommitFailStore) ReadOnly() bool { return false }
+
+func (s uploadCommitFailStore) WriteSessionBatchAtomic(
+	_ []db.SessionBatchWrite,
+	beforeCommit ...func() error,
+) (db.SessionBatchResult, error) {
+	if len(beforeCommit) > 0 && beforeCommit[0] != nil {
+		if err := beforeCommit[0](); err != nil {
+			return db.SessionBatchResult{}, err
+		}
+	}
+	return db.SessionBatchResult{}, s.err
+}
 
 func TestUploadSession_SaveFailure(t *testing.T) {
 	te := setup(t)
@@ -69,5 +96,118 @@ func TestUploadSession_CommitFailureDoesNotWriteDB(t *testing.T) {
 	}
 	if sess != nil {
 		t.Fatalf("session persisted despite upload commit failure: %+v", sess)
+	}
+}
+
+func TestUploadSession_DBCommitFailureAfterFileCommitRollsBackUpload(
+	t *testing.T,
+) {
+	dir := t.TempDir()
+	const (
+		project  = "myproj"
+		filename = "commit-fails-after-rename.jsonl"
+	)
+	finalPath := filepath.Join(dir, "uploads", project, filename)
+
+	srv := server.New(config.Config{
+		Host:         "127.0.0.1",
+		Port:         0,
+		DataDir:      dir,
+		WriteTimeout: 30 * time.Second,
+	}, uploadCommitFailStore{err: errors.New("commit failed")}, nil)
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T10:00:00Z", "hello").
+		AddClaudeAssistant("2024-01-01T10:00:05Z", "hi").
+		String()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatalf("creating form file: %v", err)
+	}
+	if _, err := fw.Write([]byte(content)); err != nil {
+		t.Fatalf("writing form file: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("closing multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sessions/upload?project="+project+"&machine=remote", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Origin", "http://127.0.0.1:0")
+	req.Host = "127.0.0.1:0"
+	req.RemoteAddr = "127.0.0.1:1234"
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	assertErrorResponse(t, w, "failed to save session to database")
+	if _, err := os.Stat(finalPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("upload file exists after DB commit failure: %v", err)
+	}
+}
+
+func TestUploadSession_DBCommitFailureAfterReplacingFileRestoresPrevious(
+	t *testing.T,
+) {
+	dir := t.TempDir()
+	const (
+		project  = "myproj"
+		filename = "replace-then-commit-fails.jsonl"
+	)
+	finalPath := filepath.Join(dir, "uploads", project, filename)
+	if err := os.MkdirAll(filepath.Dir(finalPath), 0o755); err != nil {
+		t.Fatalf("creating upload dir: %v", err)
+	}
+	previous := []byte("previous file contents")
+	if err := os.WriteFile(finalPath, previous, 0o644); err != nil {
+		t.Fatalf("writing previous upload: %v", err)
+	}
+
+	srv := server.New(config.Config{
+		Host:         "127.0.0.1",
+		Port:         0,
+		DataDir:      dir,
+		WriteTimeout: 30 * time.Second,
+	}, uploadCommitFailStore{err: errors.New("commit failed")}, nil)
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T10:00:00Z", "hello").
+		AddClaudeAssistant("2024-01-01T10:00:05Z", "hi").
+		String()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatalf("creating form file: %v", err)
+	}
+	if _, err := fw.Write([]byte(content)); err != nil {
+		t.Fatalf("writing form file: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("closing multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sessions/upload?project="+project+"&machine=remote", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Origin", "http://127.0.0.1:0")
+	req.Host = "127.0.0.1:0"
+	req.RemoteAddr = "127.0.0.1:1234"
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	assertErrorResponse(t, w, "failed to save session to database")
+	got, err := os.ReadFile(finalPath)
+	if err != nil {
+		t.Fatalf("reading restored upload: %v", err)
+	}
+	if !bytes.Equal(got, previous) {
+		t.Fatalf("restored file = %q, want %q", got, previous)
 	}
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1017,11 +1017,13 @@ func (e *Engine) ResyncAll(
 		log.Printf("resync: pre-sync copy excluded sessions: %v", err)
 		// Non-fatal: worst case, deleted sessions reappear.
 	}
+	trashedCopied := 0
 	if n, err := newDB.CopyTrashedDataFrom(origPath); err != nil {
 		log.Printf("resync: pre-sync copy trashed sessions: %v", err)
 		// Non-fatal: worst case, trashed sessions are reparsed
 		// and then re-marked as trashed by metadata copy.
 	} else if n > 0 {
+		trashedCopied = n
 		log.Printf("resync: pre-sync copied %d trashed sessions", n)
 	}
 
@@ -1080,15 +1082,15 @@ func (e *Engine) ResyncAll(
 	emptyDiscovery := stats.filesDiscovered == 0 &&
 		stats.filesOK == 0 &&
 		oldFileSessions > 0
-	openCodeArchiveOnly := stats.Synced == 0 &&
+	preservedOnly := stats.Synced == 0 &&
 		stats.TotalSessions > 0 &&
 		stats.Failed == 0 &&
-		oldFileSessions == 0
+		(oldFileSessions == 0 || trashedCopied > 0)
 	abortSwap := stats.Aborted ||
 		emptyDiscovery ||
 		(stats.Synced == 0 &&
 			stats.TotalSessions > 0 &&
-			!openCodeArchiveOnly) ||
+			!preservedOnly) ||
 		(stats.Failed > 0 && stats.Failed > stats.filesOK)
 	if abortSwap {
 		log.Printf(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -34,6 +34,11 @@ const (
 
 var errSessionPreserved = errors.New("session preserved")
 
+func isIntentionalSessionSkip(err error) bool {
+	return errors.Is(err, db.ErrSessionExcluded) ||
+		errors.Is(err, db.ErrSessionTrashed)
+}
+
 // Emitter is notified after a sync pass writes data. Implementations
 // must be thread-safe; Emit is called from whatever goroutine runs
 // the sync pass (e.g., the file watcher, a periodic timer, or a
@@ -1479,7 +1484,7 @@ func (e *Engine) syncAllLocked(
 				switch err := e.writeSessionFull(pw); {
 				case err == nil:
 					ocWritten++
-				case errors.Is(err, db.ErrSessionExcluded),
+				case isIntentionalSessionSkip(err),
 					errors.Is(err, errSessionPreserved):
 					// Intentional skip, not a failure.
 				default:
@@ -1531,7 +1536,7 @@ func (e *Engine) syncAllLocked(
 				switch err := e.writeSessionFull(pw); {
 				case err == nil:
 					warpWritten++
-				case errors.Is(err, db.ErrSessionExcluded),
+				case isIntentionalSessionSkip(err),
 					errors.Is(err, errSessionPreserved):
 					// Intentional skip, not a failure.
 				default:
@@ -3248,7 +3253,7 @@ func (e *Engine) writeBatch(
 		// are written first since the session already
 		// exists.
 		if err := e.db.UpsertSession(s); err != nil {
-			if errors.Is(err, db.ErrSessionExcluded) {
+			if isIntentionalSessionSkip(err) {
 				if pw.sess.File.Path != "" {
 					e.cacheSkip(
 						pw.sess.File.Path,
@@ -3490,9 +3495,9 @@ func (e *Engine) writeMessages(
 // delete+reinsert of its messages. Used by explicit
 // single-session re-syncs where existing content may have
 // changed (not just appended).
-// writeSessionFull returns nil on success,
-// db.ErrSessionExcluded for intentional skips, or
-// another error for real failures.
+// writeSessionFull returns nil on success, a session skip
+// sentinel for intentional skips, or another error for real
+// failures.
 func (e *Engine) writeSessionFull(pw pendingWrite) error {
 	msgs := toDBMessages(pw, e.blockedResultCategories)
 	s := toDBSession(pw)
@@ -3507,11 +3512,11 @@ func (e *Engine) writeSessionFull(pw pendingWrite) error {
 		return errSessionPreserved
 	}
 	if err := e.db.UpsertSession(s); err != nil {
-		if errors.Is(err, db.ErrSessionExcluded) {
+		if isIntentionalSessionSkip(err) {
 			if pw.sess.File.Path != "" {
 				e.cacheSkip(pw.sess.File.Path, pw.sess.File.Mtime)
 			}
-			return db.ErrSessionExcluded
+			return err
 		}
 		log.Printf("upsert session %s: %v", s.ID, err)
 		return err
@@ -4058,7 +4063,7 @@ func (e *Engine) SyncSingleSession(sessionID string) (err error) {
 		if err := e.writeSessionFull(
 			pendingWrite{sess: pr.Session, msgs: pr.Messages},
 		); err != nil &&
-			!errors.Is(err, db.ErrSessionExcluded) &&
+			!isIntentionalSessionSkip(err) &&
 			!errors.Is(err, errSessionPreserved) {
 			return fmt.Errorf("write session %s: %w",
 				pr.Session.ID, err)
@@ -4106,7 +4111,7 @@ func (e *Engine) syncSingleOpenCode(
 		if err := e.writeSessionFull(
 			pendingWrite{sess: *sess, msgs: msgs},
 		); err != nil &&
-			!errors.Is(err, db.ErrSessionExcluded) &&
+			!isIntentionalSessionSkip(err) &&
 			!errors.Is(err, errSessionPreserved) {
 			return fmt.Errorf("write session %s: %w",
 				sess.ID, err)
@@ -4271,7 +4276,7 @@ func (e *Engine) syncSingleWarp(
 		}
 		if err := e.writeSessionFull(
 			pendingWrite{sess: *sess, msgs: msgs},
-		); err != nil && !errors.Is(err, db.ErrSessionExcluded) {
+		); err != nil && !isIntentionalSessionSkip(err) {
 			return fmt.Errorf("write session %s: %w",
 				sess.ID, err)
 		}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1017,6 +1017,13 @@ func (e *Engine) ResyncAll(
 		log.Printf("resync: pre-sync copy excluded sessions: %v", err)
 		// Non-fatal: worst case, deleted sessions reappear.
 	}
+	if n, err := newDB.CopyTrashedDataFrom(origPath); err != nil {
+		log.Printf("resync: pre-sync copy trashed sessions: %v", err)
+		// Non-fatal: worst case, trashed sessions are reparsed
+		// and then re-marked as trashed by metadata copy.
+	} else if n > 0 {
+		log.Printf("resync: pre-sync copied %d trashed sessions", n)
+	}
 
 	// The temp DB is not swapped into production until the end,
 	// so avoid per-row FTS trigger work during the bulk load and

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -4016,6 +4016,19 @@ func TestResyncAllPreservesTrashedSessionData(t *testing.T) {
 	runSyncAndAssert(t, env.engine, sync.SyncStats{
 		TotalSessions: 1, Synced: 1,
 	})
+	orphanContent := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "orphan prompt").
+		AddClaudeAssistant(tsZeroS5, "orphan reply").
+		String()
+	orphanPath := env.writeClaudeSession(
+		t, "test-proj", "active-orphan.jsonl", orphanContent,
+	)
+	env.engine.SyncPaths([]string{orphanPath})
+	assertSessionMessageCount(t, env.db, "active-orphan", 2)
+	if err := os.Remove(orphanPath); err != nil {
+		t.Fatalf("remove orphan source: %v", err)
+	}
+
 	if err := env.db.SoftDeleteSession("resync-trash"); err != nil {
 		t.Fatalf("SoftDeleteSession: %v", err)
 	}
@@ -4030,6 +4043,7 @@ func TestResyncAllPreservesTrashedSessionData(t *testing.T) {
 	if stats.Aborted {
 		t.Fatalf("ResyncAll aborted: %+v", stats)
 	}
+	assertSessionMessageCount(t, env.db, "active-orphan", 2)
 
 	full, err := env.db.GetSessionFull(
 		context.Background(), "resync-trash",

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -4002,6 +4002,56 @@ func TestResyncAllReplacesMessageContent(t *testing.T) {
 	}
 }
 
+func TestResyncAllPreservesTrashedSessionData(t *testing.T) {
+	env := setupTestEnv(t)
+
+	original := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "original trashed prompt").
+		AddClaudeAssistant(tsZeroS5, "original trashed reply").
+		String()
+	path := env.writeClaudeSession(
+		t, "test-proj", "resync-trash.jsonl", original,
+	)
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+	if err := env.db.SoftDeleteSession("resync-trash"); err != nil {
+		t.Fatalf("SoftDeleteSession: %v", err)
+	}
+
+	replacement := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "replacement prompt").
+		AddClaudeAssistant(tsZeroS5, "replacement reply").
+		String()
+	dbtest.WriteTestFile(t, path, []byte(replacement))
+
+	stats := env.engine.ResyncAll(context.Background(), nil)
+	if stats.Aborted {
+		t.Fatalf("ResyncAll aborted: %+v", stats)
+	}
+
+	full, err := env.db.GetSessionFull(
+		context.Background(), "resync-trash",
+	)
+	if err != nil {
+		t.Fatalf("GetSessionFull: %v", err)
+	}
+	if full == nil || full.DeletedAt == nil {
+		t.Fatal("trashed session was not preserved as trashed")
+	}
+	msgs := fetchMessages(t, env.db, "resync-trash")
+	if len(msgs) != 2 {
+		t.Fatalf("messages = %d, want 2", len(msgs))
+	}
+	if msgs[0].Content != "original trashed prompt" {
+		t.Fatalf(
+			"trashed content = %q, want original content",
+			msgs[0].Content,
+		)
+	}
+}
+
 // TestResyncAllSurfacesQueuedCommands locks in that bumping
 // dataVersion (which forces a full resync) recovers Claude
 // queued_command attachments dropped by older parser versions.
@@ -5952,6 +6002,59 @@ func TestSyncAllTrashedSessionIsSkippedAndCached(t *testing.T) {
 	}
 	if got := env.engine.SnapshotSkipCache()[path]; got == 0 {
 		t.Fatalf("skip cache missing trashed session path %s", path)
+	}
+}
+
+func TestSyncAllTrashedSessionAppendUsesSkipPath(t *testing.T) {
+	env := setupTestEnv(t)
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "hello").
+		AddClaudeAssistant(tsZeroS5, "hi").
+		String()
+
+	path := env.writeClaudeSession(
+		t, "test-proj", "trashed-append.jsonl", content,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+	assertSessionMessageCount(t, env.db, "trashed-append", 2)
+
+	if err := env.db.SoftDeleteSession("trashed-append"); err != nil {
+		t.Fatalf("SoftDeleteSession: %v", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open append: %v", err)
+	}
+	_, err = f.WriteString(
+		testjsonl.NewSessionBuilder().
+			AddClaudeUser(tsEarly, "new prompt").
+			AddClaudeAssistant(tsEarlyS5, "new reply").
+			String(),
+	)
+	if closeErr := f.Close(); closeErr != nil {
+		t.Fatalf("close append: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	if stats.Failed != 0 {
+		t.Fatalf("Failed = %d, want 0 for trashed append", stats.Failed)
+	}
+	if stats.Synced != 0 {
+		t.Fatalf("Synced = %d, want 0 for trashed append", stats.Synced)
+	}
+	full, err := env.db.GetSessionFull(
+		context.Background(), "trashed-append",
+	)
+	if err != nil {
+		t.Fatalf("GetSessionFull: %v", err)
+	}
+	if full == nil || full.MessageCount != 2 {
+		t.Fatalf("MessageCount = %v, want preserved count 2", full)
 	}
 }
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5909,6 +5909,78 @@ func TestSyncSingleSessionExcludedIsNoOp(t *testing.T) {
 	}
 }
 
+func TestSyncAllTrashedSessionIsSkippedAndCached(t *testing.T) {
+	env := setupTestEnv(t)
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "hello").
+		AddClaudeAssistant(tsZeroS5, "hi").
+		String()
+
+	path := env.writeClaudeSession(
+		t, "test-proj", "trashed-sync.jsonl", content,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+	assertSessionMessageCount(t, env.db, "trashed-sync", 2)
+
+	if err := env.db.SoftDeleteSession("trashed-sync"); err != nil {
+		t.Fatalf("SoftDeleteSession: %v", err)
+	}
+	if err := env.db.ResetAllMtimes(); err != nil {
+		t.Fatalf("ResetAllMtimes: %v", err)
+	}
+
+	updated := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "hello again with a longer prompt").
+		AddClaudeAssistant(tsZeroS5, "still here with a longer reply").
+		String()
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	dbtest.WriteTestFile(t, path, []byte(updated))
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	if stats.Failed != 0 {
+		t.Fatalf("Failed = %d, want 0 for trashed session", stats.Failed)
+	}
+	if stats.Synced != 0 {
+		t.Fatalf("Synced = %d, want 0 for trashed session", stats.Synced)
+	}
+	if got := env.engine.SnapshotSkipCache()[path]; got == 0 {
+		t.Fatalf("skip cache missing trashed session path %s", path)
+	}
+}
+
+func TestSyncSingleSessionTrashedIsNoOp(t *testing.T) {
+	env := setupTestEnv(t)
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "hello").
+		AddClaudeAssistant(tsZeroS5, "hi").
+		String()
+
+	env.writeClaudeSession(
+		t, "test-proj", "trashed-single.jsonl", content,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+	assertSessionMessageCount(t, env.db, "trashed-single", 2)
+
+	if err := env.db.SoftDeleteSession("trashed-single"); err != nil {
+		t.Fatalf("SoftDeleteSession: %v", err)
+	}
+
+	if err := env.engine.SyncSingleSession("trashed-single"); err != nil {
+		t.Fatalf(
+			"SyncSingleSession on trashed session "+
+				"returned error: %v", err,
+		)
+	}
+}
+
 // TestSyncSingleSessionOpenCodeExcludedIsNoOp verifies that
 // calling SyncSingleSession on an excluded OpenCode session
 // returns nil.


### PR DESCRIPTION
## Summary
- return HTTP 409 when an uploaded session ID was permanently excluded or is currently in the trash
- reject DB upserts for trashed sessions with a dedicated `ErrSessionTrashed` sentinel, matching the existing excluded-session guard
- add regression coverage for both server conflicts and DB behavior

## Test plan
- go test ./internal/server ./internal/db -run 'TestUploadSession_ExcludedOrTrashedConflict|TestUploadSession_EmptyFile|TestDeleteSessionExcludes|TestUpsertSessionTrashedReturnsErrSessionTrashed|TestEmptyTrashExcludes' -count=1

Fixes #128
