### PR TITLE
fix(parser): extract OpenClaw per-message token usage and model

### DIFF
--- a/internal/parser/openclaw.go
+++ b/internal/parser/openclaw.go
@@ -140,16 +140,17 @@ func ParseOpenClawSession(
 			}
 
 			pm := ParsedMessage{
-				Ordinal:       ordinal,
-				Role:          RoleAssistant,
-				Content:       text,
-				Timestamp:     ts,
-				HasThinking:   hasThinking,
-				ThinkingText:  thinkingText,
-				HasToolUse:    hasToolUse,
-				ContentLength: len(text),
-				ToolCalls:     tcs,
-				ToolResults:   trs,
+				Ordinal:            ordinal,
+				Role:               RoleAssistant,
+				Content:            text,
+				Timestamp:          ts,
+				HasThinking:        hasThinking,
+				ThinkingText:       thinkingText,
+				HasToolUse:         hasToolUse,
+				ContentLength:      len(text),
+				ToolCalls:          tcs,
+				ToolResults:        trs,
+				tokenPresenceKnown: true,
 			}
 			applyOpenClawAssistantUsage(&pm, msg)
 			messages = append(messages, pm)

--- a/internal/parser/openclaw.go
+++ b/internal/parser/openclaw.go
@@ -3,6 +3,7 @@
 package parser
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -138,7 +139,7 @@ func ParseOpenClawSession(
 				continue
 			}
 
-			messages = append(messages, ParsedMessage{
+			pm := ParsedMessage{
 				Ordinal:       ordinal,
 				Role:          RoleAssistant,
 				Content:       text,
@@ -149,7 +150,9 @@ func ParseOpenClawSession(
 				ContentLength: len(text),
 				ToolCalls:     tcs,
 				ToolResults:   trs,
-			})
+			}
+			applyOpenClawAssistantUsage(&pm, msg)
+			messages = append(messages, pm)
 			ordinal++
 
 		case "toolResult":
@@ -224,7 +227,88 @@ func ParseOpenClawSession(
 		},
 	}
 
+	accumulateMessageTokenUsage(sess, messages)
+
 	return sess, messages, nil
+}
+
+// applyOpenClawAssistantUsage copies the assistant turn's model id
+// and per-message token counts into pm so the usage dashboard can
+// attribute cost. OpenClaw uses its own usage shape — short field
+// names (input, output, cacheRead, cacheWrite) under message.usage,
+// with provider/model on message itself. We map the token fields
+// onto the agentsview-native input_tokens/output_tokens/
+// cache_creation_input_tokens/cache_read_input_tokens keys that
+// internal/db/usage.go reads.
+//
+// Cost (message.usage.cost.total) is intentionally not propagated:
+// agentsview re-prices via the model_pricing table (loaded from
+// LiteLLM), so trusting the gateway's at-request cost would skew
+// totals against the canonical pricing source. The model name is
+// the load-bearing field for accurate pricing lookup.
+//
+// Defensive about missing fields — older sessions may carry a model
+// without a usage block, or a usage block without cost; either is
+// fine.
+func applyOpenClawAssistantUsage(
+	pm *ParsedMessage, msg gjson.Result,
+) {
+	if model := msg.Get("model").Str; model != "" {
+		pm.Model = model
+	}
+
+	usage := msg.Get("usage")
+	if !usage.Exists() {
+		return
+	}
+
+	var (
+		input      int
+		output     int
+		cacheRead  int
+		cacheWrite int
+
+		hasInput      bool
+		hasOutput     bool
+		hasCacheRead  bool
+		hasCacheWrite bool
+	)
+	if f := usage.Get("input"); f.Exists() {
+		input = int(f.Int())
+		hasInput = true
+	}
+	if f := usage.Get("output"); f.Exists() {
+		output = int(f.Int())
+		hasOutput = true
+	}
+	if f := usage.Get("cacheRead"); f.Exists() {
+		cacheRead = int(f.Int())
+		hasCacheRead = true
+	}
+	if f := usage.Get("cacheWrite"); f.Exists() {
+		cacheWrite = int(f.Int())
+		hasCacheWrite = true
+	}
+
+	if !hasInput && !hasOutput && !hasCacheRead && !hasCacheWrite {
+		return
+	}
+
+	normalized := map[string]int{
+		"input_tokens":                input,
+		"output_tokens":               output,
+		"cache_read_input_tokens":     cacheRead,
+		"cache_creation_input_tokens": cacheWrite,
+	}
+	j, err := json.Marshal(normalized)
+	if err != nil {
+		return
+	}
+	pm.TokenUsage = j
+	pm.OutputTokens = output
+	pm.HasOutputTokens = hasOutput
+	pm.ContextTokens = input + cacheRead + cacheWrite
+	pm.HasContextTokens = hasInput || hasCacheRead || hasCacheWrite
 }
 
 // extractToolResultText extracts plain text from an OpenClaw

--- a/internal/parser/openclaw_test.go
+++ b/internal/parser/openclaw_test.go
@@ -305,6 +305,68 @@ func TestParseOpenClawSession_AssistantUsageWithoutCost(t *testing.T) {
 	}
 }
 
+func TestParseOpenClawSession_PartialUsage(t *testing.T) {
+	// Partial usage block: only output is present in the source.
+	// applyOpenClawAssistantUsage normalizes to a 4-key JSON, but
+	// HasContextTokens must still be false. TokenPresence() must
+	// trust the parser's explicit flags rather than inferring from
+	// the always-populated normalized keys.
+	path, _ := writeOpenClawTestFile(t, "main",
+		`{"type":"session","version":3,"id":"partial","timestamp":"2026-04-30T12:00:00Z","cwd":"/tmp"}`,
+		`{"type":"message","id":"u1","timestamp":"2026-04-30T12:00:01Z","message":{"role":"user","content":[{"type":"text","text":"hi"}],"timestamp":"2026-04-30T12:00:01Z"}}`,
+		`{"type":"message","id":"a1","timestamp":"2026-04-30T12:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"reply"}],"timestamp":"2026-04-30T12:00:02Z","provider":"anthropic","model":"claude-haiku-4-5","usage":{"output":17}}}`,
+	)
+
+	_, msgs, err := ParseOpenClawSession(path, "", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+
+	a := msgs[1]
+	if a.HasContextTokens {
+		t.Error("HasContextTokens = true, want false")
+	}
+	if !a.HasOutputTokens {
+		t.Error("HasOutputTokens = false, want true")
+	}
+
+	hasCtx, hasOut := a.TokenPresence()
+	if hasCtx {
+		t.Error("TokenPresence ctx = true, want false " +
+			"(parser flags must take precedence over JSON keys)")
+	}
+	if !hasOut {
+		t.Error("TokenPresence out = false, want true")
+	}
+}
+
+func TestParseOpenClawSession_NoUsage(t *testing.T) {
+	// Assistant turn without any usage block: the parser is still
+	// authoritative — both presence flags must be false and stick.
+	path, _ := writeOpenClawTestFile(t, "main",
+		`{"type":"session","version":3,"id":"nousage","timestamp":"2026-04-30T12:00:00Z","cwd":"/tmp"}`,
+		`{"type":"message","id":"u1","timestamp":"2026-04-30T12:00:01Z","message":{"role":"user","content":[{"type":"text","text":"hi"}],"timestamp":"2026-04-30T12:00:01Z"}}`,
+		`{"type":"message","id":"a1","timestamp":"2026-04-30T12:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"reply"}],"timestamp":"2026-04-30T12:00:02Z"}}`,
+	)
+
+	_, msgs, err := ParseOpenClawSession(path, "", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+
+	hasCtx, hasOut := msgs[1].TokenPresence()
+	if hasCtx || hasOut {
+		t.Errorf("TokenPresence = (%v, %v), want (false, false)",
+			hasCtx, hasOut)
+	}
+}
+
 func TestParseOpenClawSession_Compaction(t *testing.T) {
 	path, _ := writeOpenClawTestFile(t, "main",
 		`{"type":"session","version":3,"id":"compact","timestamp":"2026-02-25T10:00:00Z","cwd":"/tmp"}`,

--- a/internal/parser/openclaw_test.go
+++ b/internal/parser/openclaw_test.go
@@ -194,6 +194,117 @@ func TestParseOpenClawSession_EmptyFile(t *testing.T) {
 	}
 }
 
+func TestParseOpenClawSession_AssistantUsage(t *testing.T) {
+	// Synthetic fixture covering the OpenClaw assistant-turn usage
+	// shape: per-message provider/model and a usage block with
+	// short-name token counts plus a nested cost object.
+	path, _ := writeOpenClawTestFile(t, "main",
+		`{"type":"session","version":3,"id":"usage-1","timestamp":"2026-04-30T12:00:00Z","cwd":"/home/user/proj"}`,
+		`{"type":"model_change","id":"mc1","timestamp":"2026-04-30T12:00:00Z","provider":"anthropic","modelId":"claude-sonnet-4-6"}`,
+		`{"type":"message","id":"u1","timestamp":"2026-04-30T12:00:01Z","message":{"role":"user","content":[{"type":"text","text":"do a thing"}],"timestamp":"2026-04-30T12:00:01Z"}}`,
+		`{"type":"message","id":"a1","timestamp":"2026-04-30T12:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"timestamp":"2026-04-30T12:00:02Z","provider":"anthropic","model":"claude-sonnet-4-6","usage":{"input":3,"output":91,"cacheRead":0,"cacheWrite":9612,"totalTokens":9706,"cost":{"input":0.000009,"output":0.001365,"cacheRead":0,"cacheWrite":0.036045,"total":0.037419}}}}`,
+	)
+
+	sess, msgs, err := ParseOpenClawSession(path, "", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+
+	a := msgs[1]
+	if a.Role != RoleAssistant {
+		t.Fatalf("expected assistant role, got %s", a.Role)
+	}
+	if a.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want claude-sonnet-4-6", a.Model)
+	}
+	if a.OutputTokens != 91 {
+		t.Errorf("OutputTokens = %d, want 91", a.OutputTokens)
+	}
+	if !a.HasOutputTokens {
+		t.Error("HasOutputTokens = false, want true")
+	}
+	// ContextTokens = input + cacheRead + cacheWrite.
+	if a.ContextTokens != 9615 {
+		t.Errorf("ContextTokens = %d, want 9615", a.ContextTokens)
+	}
+	if !a.HasContextTokens {
+		t.Error("HasContextTokens = false, want true")
+	}
+	// TokenUsage must be normalized to Anthropic-style keys so
+	// downstream usage aggregation (internal/db/usage.go) can
+	// read input_tokens/output_tokens/cache_*_input_tokens.
+	if len(a.TokenUsage) == 0 {
+		t.Fatal("TokenUsage empty, want normalized JSON")
+	}
+	tu := string(a.TokenUsage)
+	for _, want := range []string{
+		`"input_tokens":3`,
+		`"output_tokens":91`,
+		`"cache_read_input_tokens":0`,
+		`"cache_creation_input_tokens":9612`,
+	} {
+		if !strings.Contains(tu, want) {
+			t.Errorf("TokenUsage %q missing %q", tu, want)
+		}
+	}
+
+	// Session-level rollup must reflect the per-message totals.
+	if !sess.HasTotalOutputTokens {
+		t.Error("sess.HasTotalOutputTokens = false, want true")
+	}
+	if sess.TotalOutputTokens != 91 {
+		t.Errorf("TotalOutputTokens = %d, want 91",
+			sess.TotalOutputTokens)
+	}
+	if !sess.HasPeakContextTokens {
+		t.Error("sess.HasPeakContextTokens = false, want true")
+	}
+	if sess.PeakContextTokens != 9615 {
+		t.Errorf("PeakContextTokens = %d, want 9615",
+			sess.PeakContextTokens)
+	}
+}
+
+func TestParseOpenClawSession_AssistantUsageWithoutCost(t *testing.T) {
+	// Older sessions may carry a usage block without the nested
+	// cost object. Token extraction must still succeed and not
+	// crash on the missing field.
+	path, _ := writeOpenClawTestFile(t, "main",
+		`{"type":"session","version":3,"id":"usage-2","timestamp":"2026-04-30T12:00:00Z","cwd":"/tmp"}`,
+		`{"type":"message","id":"u1","timestamp":"2026-04-30T12:00:01Z","message":{"role":"user","content":[{"type":"text","text":"hi"}],"timestamp":"2026-04-30T12:00:01Z"}}`,
+		`{"type":"message","id":"a1","timestamp":"2026-04-30T12:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"hi back"}],"timestamp":"2026-04-30T12:00:02Z","provider":"anthropic","model":"claude-haiku-4-5","usage":{"input":42,"output":17,"cacheRead":0,"cacheWrite":0,"totalTokens":59}}}`,
+	)
+
+	sess, msgs, err := ParseOpenClawSession(path, "", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+
+	a := msgs[1]
+	if a.Model != "claude-haiku-4-5" {
+		t.Errorf("Model = %q, want claude-haiku-4-5", a.Model)
+	}
+	if a.OutputTokens != 17 {
+		t.Errorf("OutputTokens = %d, want 17", a.OutputTokens)
+	}
+	if a.ContextTokens != 42 {
+		t.Errorf("ContextTokens = %d, want 42", a.ContextTokens)
+	}
+	if len(a.TokenUsage) == 0 {
+		t.Error("TokenUsage empty, want normalized JSON")
+	}
+	if sess.TotalOutputTokens != 17 {
+		t.Errorf("TotalOutputTokens = %d, want 17",
+			sess.TotalOutputTokens)
+	}
+}
+
 func TestParseOpenClawSession_Compaction(t *testing.T) {
 	path, _ := writeOpenClawTestFile(t, "main",
 		`{"type":"session","version":3,"id":"compact","timestamp":"2026-02-25T10:00:00Z","cwd":"/tmp"}`,


### PR DESCRIPTION
## The gap

OpenClaw sessions are already discovered and registered (`agentsview session list --agent openclaw` returns them), but the parser never read the assistant turn's `model` or `usage` block. The downstream usage aggregator (`internal/db/usage.go`) requires both fields:

```sql
m.token_usage != '' AND m.model != ''
```

so every OpenClaw row was filtered out and `usage daily --agent openclaw` totalled $0.00 even when the underlying API spend was non-zero.

## Schema

OpenClaw writes one JSON object per line. Assistant `type:"message"` records carry per-turn provider, model, and usage:

```json
{
  "type": "message",
  "message": {
    "role": "assistant",
    "content": [...],
    "provider": "anthropic",
    "model": "claude-sonnet-4-6",
    "usage": {
      "input": 3,
      "output": 91,
      "cacheRead": 0,
      "cacheWrite": 9612,
      "totalTokens": 9706,
      "cost": { "input": ..., "output": ..., "total": 0.037419 }
    }
  }
}
```

Field names are short (`input`, `output`, `cacheRead`, `cacheWrite`) — they don't match the Anthropic-style names the rest of agentsview reads.

## The fix

Mirror the OpenCode parser (`applyOpenCodeTokenUsage`):

- For each `type:"message"` record with `role:"assistant"`, read `message.model` and translate `message.usage.{input,output,cacheRead,cacheWrite}` onto the canonical `input_tokens` / `output_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens` keys before storing as `TokenUsage`.
- Set `Model` per assistant message rather than relying on the standalone `model_change` event, so mid-session model swaps are attributed correctly.
- Call `accumulateMessageTokenUsage` so session-level `TotalOutputTokens` and `PeakContextTokens` roll up.
- Defensive about missing fields: a usage block without the nested `cost` object (older sessions) still extracts tokens cleanly.

## On `cost.total`

The OpenClaw `usage.cost.total` is **not** propagated into `ParsedMessage`. agentsview re-prices every message via the `model_pricing` table (loaded from LiteLLM) in `GetDailyUsage`, so trusting the gateway's at-request cost would skew totals against the canonical pricing source. Setting `Model` correctly is the load-bearing field — the existing pricing pipeline computes cost from the normalized token counts.

## Tests

Added two test cases to `internal/parser/openclaw_test.go` using **synthetic** JSONL fixtures (no real session content):

- `TestParseOpenClawSession_AssistantUsage` — full `usage` + `cost` block; asserts model, output tokens (91), context tokens (input + cacheRead + cacheWrite = 9615), normalized JSON shape, and session-level rollup.
- `TestParseOpenClawSession_AssistantUsageWithoutCost` — `usage` block missing the `cost` field; asserts no crash and tokens still extracted.

## Verification

```
go test ./internal/parser/...   # PASS
go build ./...                   # clean
```

The pre-existing `TestReplaceSessionMessages_LargeSession` failure in `internal/db` reproduces on stock `main` — unrelated to this change.