### PR TITLE
test: cover Codex assistant blockquotes

### DIFF
--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -52,6 +52,14 @@ describe("parseContent", () => {
     ]);
   });
 
+  it("keeps blockquote markers in prose as one text segment", () => {
+    const content =
+      "blabla1\n\n> blabla2\n\nblabla3\n\n> blabla4\n\nblabla5";
+    expect(parseContent(content)).toEqual([
+      { type: "text", content },
+    ]);
+  });
+
   it("preserves leading whitespace before blocks", () => {
     const segments =
       parseContent("  Indented text\n[Thinking]\n...");

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -156,6 +156,20 @@ describe("renderMarkdown", () => {
       expect(bq!.textContent!.trim()).toBe("quoted text");
     });
 
+    it("preserves prose around separated blockquotes", () => {
+      const dom = parseHTML(
+        renderMarkdown(
+          "blabla1\n\n> blabla2\n\nblabla3\n\n> blabla4\n\nblabla5",
+        ),
+      );
+      expect(dom.textContent).toContain("blabla1");
+      expect(dom.textContent).toContain("blabla2");
+      expect(dom.textContent).toContain("blabla3");
+      expect(dom.textContent).toContain("blabla4");
+      expect(dom.textContent).toContain("blabla5");
+      expect(dom.querySelectorAll("blockquote")).toHaveLength(2);
+    });
+
     it("renders tables", () => {
       const md = "| A | B |\n| --- | --- |\n| 1 | 2 |";
       const dom = parseHTML(renderMarkdown(md));

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -47,6 +47,22 @@ func TestParseCodexSession_Basic(t *testing.T) {
 	assertSessionMeta(t, sess, "codex:abc-123", "my_api", AgentCodex)
 }
 
+func TestParseCodexSession_PreservesAssistantBlockquotes(t *testing.T) {
+	content := loadFixture(t, "codex/blockquotes_session.jsonl")
+	sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+	require.NotNil(t, sess)
+	assert.Equal(t, "codex:quote-123", sess.ID)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "blablabla?", msgs[0].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t,
+		"blabla1\n\n> blabla2\n\nblabla3\n\n> blabla4\n\nblabla5",
+		msgs[1].Content,
+	)
+}
+
 func TestParseCodexSession_ExecOriginator(t *testing.T) {
 	execContent := testjsonl.JoinJSONL(
 		testjsonl.CodexSessionMetaJSON("abc", "/tmp", "codex_exec", tsEarly),

--- a/internal/parser/testdata/codex/blockquotes_session.jsonl
+++ b/internal/parser/testdata/codex/blockquotes_session.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-05-02T12:33:24.669Z","type":"session_meta","payload":{"id":"quote-123","timestamp":"2026-05-02T12:33:22.511Z","cwd":"/tmp/agentsview-quote","originator":"codex_exec","cli_version":"0.128.0","source":"exec","model_provider":"openai"}}
+{"timestamp":"2026-05-02T12:33:24.753Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"blablabla?"}]}}
+{"timestamp":"2026-05-02T12:33:26.485Z","type":"event_msg","payload":{"type":"agent_message","message":"blabla1\n\n> blabla2\n\nblabla3\n\n> blabla4\n\nblabla5","phase":"final_answer","memory_citation":null}}
+{"timestamp":"2026-05-02T12:33:26.485Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"blabla1\n\n> blabla2\n\nblabla3\n\n> blabla4\n\nblabla5"}],"phase":"final_answer"}}


### PR DESCRIPTION
## Summary

Refs #436.

- add a sanitized Codex JSONL fixture with assistant output containing separated Markdown blockquotes
- verify the Codex parser preserves the full assistant message around `>` lines
- verify frontend content parsing and Markdown rendering keep all prose and render two blockquotes

## Reproducer attempt

I attempted to synthesize a reproducer by running `codex exec` with the exact conversation shape from the issue, then captured the generated JSONL from `~/.codex/sessions` and reduced it into the fixture in this PR. That generated transcript preserved all content in one assistant `response_item`, so this PR locks that behavior down with regression coverage.

## Validation

- `go test ./internal/parser`
- `cd frontend && npm test -- --run src/lib/utils/content-parser.test.ts src/lib/utils/markdown.test.ts`
