### PR TITLE
fix: link Codex app subagents

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,10 +27,15 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 24: Codex parser now annotates spawn_agent tool calls
+// Bumped to 25: Codex parser now also links codex_app subagents
+// via collab_agent_spawn_end event_msgs, wait_agent function
+// calls, and agent_path subagent notifications. Existing rows
+// need re-parsing so codex_app subagent linkage works.
+//
+// (24: Codex parser now annotates spawn_agent tool calls
 // with subagent_session_id once the spawned agent id is known.
 // Existing rows need re-parsing so inline subagent expansion can
-// resolve child sessions from persisted tool call metadata.
+// resolve child sessions from persisted tool call metadata.)
 //
 // (23: split termination_status into awaiting_user vs
 // clean (Claude end_turn / Codex task_complete vs other clean
@@ -63,7 +68,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 24
+const dataVersion = 25
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -180,16 +180,20 @@ func (b *codexSessionBuilder) handleResponseItem(
 	b.ordinal++
 }
 
-func (b *codexSessionBuilder) handleEventMsg(
-	payload gjson.Result,
-) {
+func (b *codexSessionBuilder) handleEventMsg(payload gjson.Result) {
 	switch payload.Get("type").Str {
 	case "task_started", "task_complete", "turn_aborted":
 		b.lastTaskEvent = payload.Get("type").Str
+	case "token_count":
+		b.handleTokenCountEvent(payload)
+	case "collab_agent_spawn_end":
+		b.handleCollabAgentSpawnEnd(payload)
 	}
-	if payload.Get("type").Str != "token_count" {
-		return
-	}
+}
+
+func (b *codexSessionBuilder) handleTokenCountEvent(
+	payload gjson.Result,
+) {
 	raw := payload.Get("info.last_token_usage").Raw
 	if raw == "" || raw == b.lastTokenUsageRaw {
 		return
@@ -209,6 +213,18 @@ func (b *codexSessionBuilder) handleEventMsg(
 			return
 		}
 	}
+}
+
+func (b *codexSessionBuilder) handleCollabAgentSpawnEnd(
+	payload gjson.Result,
+) {
+	callID := payload.Get("call_id").Str
+	agentID := strings.TrimSpace(payload.Get("new_thread_id").Str)
+	if callID == "" || agentID == "" {
+		return
+	}
+	b.agentSpawnCalls[agentID] = callID
+	b.setCallSubagentSessionID(callID, codexSubagentSessionID(agentID))
 }
 
 // applyCodexTokenUsage normalizes Codex token usage fields
@@ -264,7 +280,7 @@ func (b *codexSessionBuilder) handleFunctionCall(
 	content := formatCodexFunctionCall(name, payload)
 	inputJSON := extractCodexInputJSON(payload)
 	waitAgentIDs := []string(nil)
-	if name == "wait" && callID != "" {
+	if isCodexWaitAgentCall(name) && callID != "" {
 		args, _ := parseCodexFunctionArgs(payload)
 		waitAgentIDs = codexWaitAgentIDs(args)
 	}
@@ -292,7 +308,7 @@ func (b *codexSessionBuilder) handleFunctionCall(
 	}
 	b.ordinal++
 
-	if name == "wait" && callID != "" {
+	if isCodexWaitAgentCall(name) && callID != "" {
 		for _, agentID := range waitAgentIDs {
 			b.agentWaitCalls[agentID] = callID
 			b.claimPendingAgentEvents(callID, agentID)
@@ -321,7 +337,7 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 		}
 		b.agentSpawnCalls[agentID] = callID
 		b.setCallSubagentSessionID(callID, codexSubagentSessionID(agentID))
-	case "wait":
+	case "wait", "wait_agent":
 		status := output.Get("status")
 		if !status.Exists() || !status.IsObject() {
 			return
@@ -346,6 +362,13 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 	}
 }
 
+// setCallSubagentSessionID links a tool call to the session of
+// the subagent it spawned. Callers must invoke this only after
+// the originating function_call has been processed (which
+// populates b.callRefs[callID]); otherwise the link is silently
+// dropped. In real codex session files the spawn function_call
+// always precedes both its function_call_output and the
+// collab_agent_spawn_end event_msg.
 func (b *codexSessionBuilder) setCallSubagentSessionID(
 	callID, sessionID string,
 ) {
@@ -495,6 +518,9 @@ func codexSubagentSessionID(agentID string) string {
 	agentID = strings.TrimSpace(agentID)
 	if agentID == "" {
 		return ""
+	}
+	if strings.HasPrefix(agentID, "codex:") {
+		return agentID
 	}
 	return "codex:" + agentID
 }
@@ -952,6 +978,9 @@ func codexWaitAgentIDs(args gjson.Result) []string {
 		return nil
 	}
 	ids := args.Get("ids")
+	if !ids.Exists() {
+		ids = args.Get("targets")
+	}
 	if !ids.Exists() || !ids.IsArray() {
 		return nil
 	}
@@ -965,6 +994,10 @@ func codexWaitAgentIDs(args gjson.Result) []string {
 		out = append(out, id)
 	}
 	return out
+}
+
+func isCodexWaitAgentCall(name string) bool {
+	return name == "wait" || name == "wait_agent"
 }
 
 func parseCodexSubagentNotification(
@@ -981,7 +1014,10 @@ func parseCodexSubagentNotification(
 		return "", "", ""
 	}
 	parsed := gjson.Parse(body)
-	agentID = strings.TrimSpace(parsed.Get("agent_id").Str)
+	agentID = firstNonEmpty(
+		parsed.Get("agent_id").Str,
+		parsed.Get("agent_path").Str,
+	)
 	status := parsed.Get("status")
 	statusName, text = codexTerminalSubagentEvent(status)
 	return agentID, statusName, text
@@ -1302,14 +1338,19 @@ func isCodexSubagentNotification(content string) bool {
 }
 
 func codexIncrementalNeedsFullParse(line string) bool {
-	if gjson.Get(line, "type").Str != codexTypeResponseItem {
+	switch gjson.Get(line, "type").Str {
+	case codexTypeEventMsg:
+		return gjson.Get(line, "payload.type").Str ==
+			"collab_agent_spawn_end"
+	case codexTypeResponseItem:
+	default:
 		return false
 	}
 
 	payload := gjson.Get(line, "payload")
 	switch payload.Get("type").Str {
 	case "function_call":
-		return payload.Get("name").Str == "wait"
+		return isCodexWaitAgentCall(payload.Get("name").Str)
 	case "function_call_output":
 		output, _ := parseCodexFunctionOutput(payload)
 		return isCodexSubagentFunctionOutput(output)

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -309,6 +309,101 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		assert.Equal(t, "continuing", msgs[2].Content)
 	})
 
+	t.Run("codex app wait_agent and agent_path notifications link child session", func(t *testing.T) {
+		childID := "019df406-3bd3-7343-b3d8-f8d5996c428b"
+		summary := "Inspected only. I did not modify files."
+		notification := "<subagent_notification>\n" +
+			"{\"agent_path\":\"" + childID + "\",\"status\":{\"completed\":\"" + summary + "\"}}\n" +
+			"</subagent_notification>"
+		spawnEnd := "{\"timestamp\":\"2024-01-01T10:01:05Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"collab_agent_spawn_end\",\"call_id\":\"call_spawn\",\"sender_thread_id\":\"parent-thread\",\"new_thread_id\":\"" + childID + "\",\"new_agent_nickname\":\"Einstein\",\"new_agent_role\":\"explorer\",\"status\":\"pending_init\"}}"
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("fc-codex-app-subagent", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "run a child agent", tsEarlyS1),
+			testjsonl.CodexFunctionCallWithCallIDJSON("spawn_agent", "call_spawn", map[string]any{
+				"agent_type": "explorer",
+				"message":    "Inspect the code",
+			}, tsEarlyS5),
+			spawnEnd,
+			testjsonl.CodexFunctionCallOutputJSON("call_spawn", `{"agent_id":"`+childID+`","nickname":"Einstein"}`, tsLate),
+			testjsonl.CodexFunctionCallWithCallIDJSON("wait_agent", "call_wait", map[string]any{
+				"targets":    []string{childID},
+				"timeout_ms": 10000,
+			}, tsLateS5),
+			testjsonl.CodexMsgJSON("user", notification, "2024-01-01T10:01:07Z"),
+		)
+		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+		require.NotNil(t, sess)
+		assert.Equal(t, 3, len(msgs))
+		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
+			ToolUseID:         "call_spawn",
+			ToolName:          "spawn_agent",
+			Category:          "Task",
+			SubagentSessionID: "codex:" + childID,
+		}})
+		assertToolCalls(t, msgs[2].ToolCalls, []ParsedToolCall{{
+			ToolUseID: "call_wait",
+			ToolName:  "wait_agent",
+			Category:  "Other",
+		}})
+		assertToolResultEvents(t, msgs[2].ToolCalls[0].ResultEvents, []ParsedToolResultEvent{{
+			ToolUseID:         "call_wait",
+			AgentID:           childID,
+			SubagentSessionID: "codex:" + childID,
+			Source:            "subagent_notification",
+			Status:            "completed",
+			Content:           summary,
+		}})
+	})
+
+	t.Run("codex app pending notification waits for later wait_agent binding", func(t *testing.T) {
+		childID := "019df406-3bd3-7343-b3d8-f8d5996c428b"
+		summary := "Inspected before wait_agent existed."
+		notification := "<subagent_notification>\n" +
+			"{\"agent_path\":\"" + childID + "\",\"status\":{\"completed\":\"" + summary + "\"}}\n" +
+			"</subagent_notification>"
+		spawnEnd := "{\"timestamp\":\"2024-01-01T10:01:05Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"collab_agent_spawn_end\",\"call_id\":\"call_spawn\",\"sender_thread_id\":\"parent-thread\",\"new_thread_id\":\"" + childID + "\",\"new_agent_nickname\":\"Einstein\",\"new_agent_role\":\"explorer\",\"status\":\"pending_init\"}}"
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("fc-codex-app-subagent-pending", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "run a child agent", tsEarlyS1),
+			testjsonl.CodexFunctionCallWithCallIDJSON("spawn_agent", "call_spawn", map[string]any{
+				"agent_type": "explorer",
+				"message":    "Inspect the code",
+			}, tsEarlyS5),
+			spawnEnd,
+			testjsonl.CodexFunctionCallOutputJSON("call_spawn", `{"agent_id":"`+childID+`","nickname":"Einstein"}`, tsLate),
+			testjsonl.CodexMsgJSON("user", notification, "2024-01-01T10:01:07Z"),
+			testjsonl.CodexFunctionCallWithCallIDJSON("wait_agent", "call_wait", map[string]any{
+				"targets":    []string{childID},
+				"timeout_ms": 10000,
+			}, "2024-01-01T10:01:08Z"),
+		)
+		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+		require.NotNil(t, sess)
+		assert.Equal(t, 3, len(msgs))
+		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
+			ToolUseID:         "call_spawn",
+			ToolName:          "spawn_agent",
+			Category:          "Task",
+			SubagentSessionID: "codex:" + childID,
+		}})
+		assert.Empty(t, msgs[1].ToolCalls[0].ResultEvents)
+		assertToolCalls(t, msgs[2].ToolCalls, []ParsedToolCall{{
+			ToolUseID: "call_wait",
+			ToolName:  "wait_agent",
+			Category:  "Other",
+		}})
+		assertToolResultEvents(t, msgs[2].ToolCalls[0].ResultEvents, []ParsedToolResultEvent{{
+			ToolUseID:         "call_wait",
+			AgentID:           childID,
+			SubagentSessionID: "codex:" + childID,
+			Source:            "subagent_notification",
+			Status:            "completed",
+			Content:           summary,
+		}})
+	})
+
 	t.Run("duplicate pending notification preserves earliest chronology", func(t *testing.T) {
 		childID := "019c9c96-6ee7-77c0-ba4c-380f844289d5"
 		summary := "Exit code: `1`\n\nFull output:\n```text\nTraceback...\n```"
@@ -1308,6 +1403,37 @@ func TestParseCodexSessionFrom_SubagentOutputRequiresFullParse(t *testing.T) {
 	assert.Contains(t, err.Error(), "full parse")
 }
 
+func TestParseCodexSessionFrom_CollabAgentSpawnEndRequiresFullParse(t *testing.T) {
+	t.Parallel()
+
+	childID := "019c9c96-6ee7-77c0-ba4c-380f844289d5"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON("inc-sub-event", "/tmp", "codex_cli_rs", tsEarly),
+		testjsonl.CodexMsgJSON("user", "run child", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON("spawn_agent", "call_spawn", map[string]any{
+			"agent_type": "awaiter",
+			"message":    "run it",
+		}, tsEarlyS5),
+	)
+	path := createTestFile(t, "codex-subagent-event-inc.jsonl", initial)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(testjsonl.JoinJSONL(
+		"{\"timestamp\":\"2024-01-01T10:01:05Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"collab_agent_spawn_end\",\"call_id\":\"call_spawn\",\"new_thread_id\":\"" + childID + "\",\"status\":\"pending_init\"}}",
+	))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 2, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "full parse")
+}
+
 func TestParseCodexSessionFrom_WaitCallRequiresFullParse(t *testing.T) {
 	t.Parallel()
 
@@ -1336,6 +1462,44 @@ func TestParseCodexSessionFrom_WaitCallRequiresFullParse(t *testing.T) {
 	_, err = f.WriteString(testjsonl.JoinJSONL(
 		testjsonl.CodexFunctionCallWithCallIDJSON("wait", "call_wait", map[string]any{
 			"ids": []string{childID},
+		}, "2024-01-01T10:01:06Z"),
+	))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 4, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "full parse")
+}
+
+func TestParseCodexSessionFrom_WaitAgentCallRequiresFullParse(t *testing.T) {
+	t.Parallel()
+
+	childID := "019c9c96-6ee7-77c0-ba4c-380f844289d5"
+	notification := "<subagent_notification>\n" +
+		"{\"agent_path\":\"" + childID + "\",\"status\":{\"completed\":\"Finished successfully\"}}\n" +
+		"</subagent_notification>"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON("inc-wait-agent", "/tmp", "codex_cli_rs", tsEarly),
+		testjsonl.CodexMsgJSON("user", "run child", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON("spawn_agent", "call_spawn", map[string]any{
+			"agent_type": "awaiter",
+			"message":    "run it",
+		}, tsEarlyS5),
+		testjsonl.CodexFunctionCallOutputJSON("call_spawn", `{"agent_id":"`+childID+`","nickname":"Fennel"}`, tsLate),
+		testjsonl.CodexMsgJSON("user", notification, tsLateS5),
+	)
+	path := createTestFile(t, "codex-wait-agent-inc.jsonl", initial)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(testjsonl.JoinJSONL(
+		testjsonl.CodexFunctionCallWithCallIDJSON("wait_agent", "call_wait", map[string]any{
+			"targets": []string{childID},
 		}, "2024-01-01T10:01:06Z"),
 	))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Link Codex app subagent spawn events to `ParsedToolCall.SubagentSessionID` by consuming both `spawn_agent` outputs and `collab_agent_spawn_end.new_thread_id` events.
- Recognize `wait_agent` calls with `targets` and subagent notifications that identify children via `agent_path`.
- Keep upstream Codex task lifecycle handling intact while adding the subagent event path.

## Supporting evidence
- OpenAI's Codex subagents docs describe Codex spawning specialized agents, waiting for results, and surfacing subagent activity in the app and CLI: https://developers.openai.com/codex/subagents
- I cloned `openai/codex` locally at `905987c08f40bc8fb8f36d69e8137865e1a67393`; that source defines `spawn_agent`, canonical child task names, and `wait_agent.targets`: https://github.com/openai/codex/blob/905987c08f40bc8fb8f36d69e8137865e1a67393/codex-rs/tools/src/agent_tool.rs#L667-L672 and https://github.com/openai/codex/blob/905987c08f40bc8fb8f36d69e8137865e1a67393/codex-rs/tools/src/agent_tool.rs#L721-L745
- The Codex protocol exposes `CollabAgentSpawnEndEvent.new_thread_id`, and the app-server thread history handler consumes that event to populate receiver thread IDs: https://github.com/openai/codex/blob/905987c08f40bc8fb8f36d69e8137865e1a67393/codex-rs/protocol/src/protocol.rs#L3788-L3795 and https://github.com/openai/codex/blob/905987c08f40bc8fb8f36d69e8137865e1a67393/codex-rs/app-server-protocol/src/protocol/thread_history.rs#L623-L645
- Codex subagent notifications are emitted with `agent_path`, which this parser now accepts in addition to legacy `agent_id`: https://github.com/openai/codex/blob/905987c08f40bc8fb8f36d69e8137865e1a67393/codex-rs/core/src/context/subagent_notification.rs#L20-L31

## Validation
- `go test ./internal/parser ./internal/sync -count=1`
- `git diff --check`
