### PR TITLE
Link Codex spawn calls to subagent sessions

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,11 +27,16 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 23: split termination_status into awaiting_user vs
+// Bumped to 24: Codex parser now annotates spawn_agent tool calls
+// with subagent_session_id once the spawned agent id is known.
+// Existing rows need re-parsing so inline subagent expansion can
+// resolve child sessions from persisted tool call metadata.
+//
+// (23: split termination_status into awaiting_user vs
 // clean (Claude end_turn / Codex task_complete vs other clean
 // stops); Codex parser now classifies based on task lifecycle
 // events. Existing rows need re-parsing so the new awaiting_user
-// value populates correctly.
+// value populates correctly.)
 //
 // (22: added termination_status column to sessions; existing
 // rows need re-parsing so the Claude classifier can populate
@@ -58,7 +63,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 23
+const dataVersion = 24
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -320,6 +320,7 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 			return
 		}
 		b.agentSpawnCalls[agentID] = callID
+		b.setCallSubagentSessionID(callID, codexSubagentSessionID(agentID))
 	case "wait":
 		status := output.Get("status")
 		if !status.Exists() || !status.IsObject() {
@@ -343,6 +344,22 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 			return true
 		})
 	}
+}
+
+func (b *codexSessionBuilder) setCallSubagentSessionID(
+	callID, sessionID string,
+) {
+	if callID == "" || sessionID == "" {
+		return
+	}
+	ref, ok := b.callRefs[callID]
+	if !ok || ref.messageIndex < 0 || ref.messageIndex >= len(b.messages) {
+		return
+	}
+	if ref.callIndex < 0 || ref.callIndex >= len(b.messages[ref.messageIndex].ToolCalls) {
+		return
+	}
+	b.messages[ref.messageIndex].ToolCalls[ref.callIndex].SubagentSessionID = sessionID
 }
 
 func (b *codexSessionBuilder) handleSubagentNotification(

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -217,9 +217,10 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		assert.Equal(t, 4, len(msgs))
 		assert.Equal(t, RoleAssistant, msgs[1].Role)
 		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
-			ToolUseID: "call_spawn",
-			ToolName:  "spawn_agent",
-			Category:  "Task",
+			ToolUseID:         "call_spawn",
+			ToolName:          "spawn_agent",
+			Category:          "Task",
+			SubagentSessionID: "codex:" + childID,
 		}})
 		assert.Equal(t, RoleAssistant, msgs[2].Role)
 		assertToolCalls(t, msgs[2].ToolCalls, []ParsedToolCall{{
@@ -260,9 +261,10 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		require.NotNil(t, sess)
 		assert.Equal(t, 2, len(msgs))
 		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
-			ToolUseID: "call_spawn",
-			ToolName:  "spawn_agent",
-			Category:  "Task",
+			ToolUseID:         "call_spawn",
+			ToolName:          "spawn_agent",
+			Category:          "Task",
+			SubagentSessionID: "codex:" + childID,
 		}})
 		assertToolResultEvents(t, msgs[1].ToolCalls[0].ResultEvents, []ParsedToolResultEvent{{
 			ToolUseID:         "call_spawn",


### PR DESCRIPTION
## Summary
- populate `subagent_session_id` on Codex `spawn_agent` tool calls once the spawned agent id is known
- align Codex inline subagent rendering with the existing Claude Task/Agent contract
- update Codex parser regression coverage for spawn-agent result and notification fallback paths

## Validation
- `go test -count=1 ./internal/parser -run TestParseCodexSession_FunctionCalls`
- `go test -count=1 ./internal/db -run 'Test(LinkSubagentSessions|ToolCallSubagentSessionID)'`\n- `go test -count=1 ./internal/sync -run 'TestIncrementalSync_CodexSubagentAppendFallsBackToFullParse|Test.*Subagent'`