### PR TITLE
fix: link Claude subagent tool calls

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,10 +27,19 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 25: Codex parser now also links codex_app subagents
+// Bumped to 26: Claude parser now (a) links Task / Agent tool
+// calls to child subagent sessions via toolUseResult.agentId
+// when queue/progress mappings are absent, populating
+// tool_calls.subagent_session_id, and (b) merges additive
+// same-message.id assistant chunks instead of keeping only the
+// last entry, preserving sibling tool_use blocks and
+// progressively-built text. Existing rows need re-parsing so
+// these linkages and merged content show up.
+//
+// (25: Codex parser now also links codex_app subagents
 // via collab_agent_spawn_end event_msgs, wait_agent function
 // calls, and agent_path subagent notifications. Existing rows
-// need re-parsing so codex_app subagent linkage works.
+// need re-parsing so codex_app subagent linkage works.)
 //
 // (24: Codex parser now annotates spawn_agent tool calls
 // with subagent_session_id once the spawned agent id is known.
@@ -68,7 +77,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 25
+const dataVersion = 26
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -436,6 +436,29 @@ func (db *DB) MaxOrdinal(sessionID string) int {
 	return int(n.Int64)
 }
 
+// LastClaudeMessageID returns the claude_message_id of the
+// highest-ordinal assistant message in a session whose
+// claude_message_id is non-empty, or "" if none exists. The sync
+// engine uses this to detect cross-sync splits of a single
+// streaming response (next sync's first appended assistant entry
+// shares the message.id of the previously-stored last assistant).
+func (db *DB) LastClaudeMessageID(sessionID string) string {
+	var s sql.NullString
+	err := db.getReader().QueryRow(
+		`SELECT claude_message_id FROM messages
+		 WHERE session_id = ?
+		   AND role = 'assistant'
+		   AND claude_message_id != ''
+		 ORDER BY ordinal DESC
+		 LIMIT 1`,
+		sessionID,
+	).Scan(&s)
+	if err != nil || !s.Valid {
+		return ""
+	}
+	return s.String
+}
+
 // savedPin captures the minimal pin state needed to re-attach a pin
 // after a full message replacement. source_uuid is the preferred
 // identifier because it survives rewrites where the ordinal stream

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -1188,8 +1188,13 @@ func claudeBlockExistsIn(
 }
 
 func replaceClaudeMessageContent(line string, blocks []gjson.Result) string {
+	// UseNumber preserves the raw textual form of JSON numbers so
+	// re-marshaling doesn't truncate large integers (e.g. usage
+	// token counts) or change scientific notation.
+	dec := json.NewDecoder(strings.NewReader(line))
+	dec.UseNumber()
 	var top map[string]any
-	if err := json.Unmarshal([]byte(line), &top); err != nil {
+	if err := dec.Decode(&top); err != nil {
 		return line
 	}
 	msg, ok := top["message"].(map[string]any)

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -180,8 +180,9 @@ func ParseClaudeSession(
 			continue
 		}
 
-		// Extract cwd and gitBranch from user entries.
+		// Collect subagent links and cwd/gitBranch from user entries.
 		if entryType == "user" {
+			collectToolResultAgentID(line, subagentMap)
 			if cwd == "" {
 				cwd = gjson.Get(line, "cwd").Str
 			}
@@ -238,11 +239,12 @@ func ParseClaudeSession(
 		!gjson.Valid(lastLine) &&
 		!fileEndsWithNewline(f, info.Size())
 
-	// Collapse consecutive assistant entries that share the same
-	// message.id — these are streaming progress snapshots of a
-	// single response. Keep only the last entry per message.id
-	// run (it has the final content and token counts).
-	entries = collapseStreamingDuplicates(entries)
+	// Merge consecutive assistant entries that share the same
+	// message.id. Claude Code writes both cumulative streaming
+	// snapshots and additive chunks for one response under the same
+	// provider message id. Keep final metadata/token usage while
+	// preserving distinct content blocks from the whole run.
+	entries = mergeClaudeAssistantMessageChunks(entries)
 
 	fileInfo := FileInfo{
 		Path:  path,
@@ -332,6 +334,14 @@ var ErrDAGDetected = fmt.Errorf(
 	"incremental parse: DAG uuid detected",
 )
 
+// ErrClaudeIncrementalNeedsFullParse signals that appended Claude
+// lines contain content the incremental path cannot stitch into
+// already-stored rows (subagent linkage updates from
+// toolUseResult.agentId, or same-message.id chunk merging).
+var ErrClaudeIncrementalNeedsFullParse = fmt.Errorf(
+	"incremental parse: appended Claude lines require full parse",
+)
+
 func ParseClaudeSessionFrom(
 	path string,
 	offset int64,
@@ -396,6 +406,15 @@ func ParseClaudeSessionFrom(
 		return nil, time.Time{}, 0, ErrDAGDetected
 	}
 
+	// Subagent linkage updates (toolUseResult.agentId) and
+	// same-message.id chunk merging both need state the full
+	// parser builds across the whole file. Bail to a full parse
+	// when appended lines contain either.
+	if needsClaudeFullParse(entries) {
+		return nil, time.Time{}, 0,
+			ErrClaudeIncrementalNeedsFullParse
+	}
+
 	msgs, _, endedAt := extractMessagesFrom(
 		entries, startOrdinal,
 	)
@@ -416,6 +435,32 @@ func ParseClaudeSessionFrom(
 		endedAt = latestTS
 	}
 	return msgs, endedAt, consumed, nil
+}
+
+// needsClaudeFullParse returns true when appended entries contain
+// either a tool_result with toolUseResult.agentId (whose linkage
+// must update an already-stored tool_call row) or a consecutive
+// same-message.id assistant run (whose chunks the full parser
+// merges into one message). Both cases require a full re-parse.
+func needsClaudeFullParse(entries []dagEntry) bool {
+	var prevAssistantMID string
+	for _, e := range entries {
+		if e.entryType == "user" {
+			if gjson.Get(e.line, "toolUseResult.agentId").Str != "" {
+				return true
+			}
+		}
+		if e.entryType == "assistant" {
+			mid := gjson.Get(e.line, "message.id").Str
+			if mid != "" && mid == prevAssistantMID {
+				return true
+			}
+			prevAssistantMID = mid
+			continue
+		}
+		prevAssistantMID = ""
+	}
+	return false
 }
 
 // hasDAGFork returns true if the entries contain a fork —
@@ -804,6 +849,44 @@ func parseDAG(
 	return results, nil
 }
 
+func collectToolResultAgentID(line string, subagentMap map[string]string) {
+	agentID := gjson.Get(line, "toolUseResult.agentId").Str
+	if agentID == "" {
+		return
+	}
+	sessionID := agentID
+	if !strings.HasPrefix(sessionID, "agent-") {
+		sessionID = "agent-" + sessionID
+	}
+
+	content := gjson.Get(line, "message.content")
+	if !content.IsArray() {
+		return
+	}
+	var toolUseID string
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").Str != "tool_result" {
+			return true
+		}
+		tuid := block.Get("tool_use_id").Str
+		if tuid == "" {
+			return true
+		}
+		if toolUseID != "" {
+			toolUseID = ""
+			return false
+		}
+		toolUseID = tuid
+		return true
+	})
+	if toolUseID == "" {
+		return
+	}
+	if _, exists := subagentMap[toolUseID]; !exists {
+		subagentMap[toolUseID] = sessionID
+	}
+}
+
 // extractQueuedCommand parses a Claude Code attachment entry and
 // returns the queued_command prompt if present. Other attachment
 // types (e.g. task_reminder) return ok=false. Whitespace-only or
@@ -917,12 +1000,12 @@ func queuedCommandMessage(
 	}
 }
 
-// collapseStreamingDuplicates removes consecutive assistant entries
-// that share the same message.id. Claude Code writes multiple JSONL
-// lines as a response streams — each has the same message.id but
-// progressively more output tokens. Only the last entry in each
-// same-message.id run has the final content and token counts.
-func collapseStreamingDuplicates(entries []dagEntry) []dagEntry {
+// mergeClaudeAssistantMessageChunks merges consecutive assistant
+// entries that share the same message.id. Claude Code uses this shape
+// both for cumulative streaming snapshots and for additive chunks of a
+// single response. The last entry owns metadata and token usage; the
+// merged message content keeps each distinct block in first-seen order.
+func mergeClaudeAssistantMessageChunks(entries []dagEntry) []dagEntry {
 	if len(entries) <= 1 {
 		return entries
 	}
@@ -933,24 +1016,189 @@ func collapseStreamingDuplicates(entries []dagEntry) []dagEntry {
 		if entries[i].entryType == "assistant" {
 			mid = gjson.Get(entries[i].line, "message.id").Str
 		}
-
-		// Look ahead: if next entries are assistant with same
-		// message.id, skip to the last one in the run.
-		if mid != "" {
-			j := i + 1
-			for j < len(entries) &&
-				entries[j].entryType == "assistant" &&
-				gjson.Get(entries[j].line, "message.id").Str == mid {
-				j++
-			}
-			// Keep only the last entry (j-1) in the run.
-			result = append(result, entries[j-1])
-			i = j - 1
-		} else {
+		if mid == "" {
 			result = append(result, entries[i])
+			continue
 		}
+
+		j := i + 1
+		for j < len(entries) &&
+			entries[j].entryType == "assistant" &&
+			gjson.Get(entries[j].line, "message.id").Str == mid {
+			j++
+		}
+		if j == i+1 {
+			result = append(result, entries[i])
+		} else {
+			result = append(result, mergeClaudeAssistantRun(entries[i:j]))
+		}
+		i = j - 1
 	}
 	return result
+}
+
+// mergeClaudeAssistantRun collapses one same-message.id assistant
+// run into a single dagEntry. For each snapshot in the run we decide
+// whether it is a cumulative continuation of the merged-so-far (its
+// leading blocks align by type, tool_use id, and text equal-or-prefix)
+// or an additive chunk (distinct new content). Cumulative snapshots
+// update overlapping positions in place and append any trailing blocks;
+// additive snapshots append blocks not already present.
+//
+// This avoids two failure modes of position-only or ordinal-only
+// matching: (1) treating distinct text blocks that happen to share a
+// byte prefix as one evolving block, and (2) collapsing additive
+// single-block chunks because they reuse the same ordinal.
+func mergeClaudeAssistantRun(run []dagEntry) dagEntry {
+	base := run[len(run)-1]
+	var merged []gjson.Result
+
+	for _, e := range run {
+		content := gjson.Get(e.line, "message.content")
+		if !content.IsArray() {
+			continue
+		}
+		merged = mergeClaudeSnapshot(merged, claudeContentBlocks(content))
+	}
+	if len(merged) == 0 {
+		return base
+	}
+	base.line = replaceClaudeMessageContent(base.line, merged)
+	return base
+}
+
+func claudeContentBlocks(content gjson.Result) []gjson.Result {
+	var blocks []gjson.Result
+	content.ForEach(func(_, b gjson.Result) bool {
+		if b.Raw != "" {
+			blocks = append(blocks, b)
+		}
+		return true
+	})
+	return blocks
+}
+
+func mergeClaudeSnapshot(
+	merged, snapshot []gjson.Result,
+) []gjson.Result {
+	if claudeSnapshotIsCumulative(merged, snapshot) {
+		for i, block := range snapshot {
+			if i < len(merged) {
+				merged[i] = pickClaudeLatestBlock(merged[i], block)
+				continue
+			}
+			merged = append(merged, block)
+		}
+		return merged
+	}
+	for _, block := range snapshot {
+		if !claudeBlockExistsIn(block, merged) {
+			merged = append(merged, block)
+		}
+	}
+	return merged
+}
+
+func claudeSnapshotIsCumulative(
+	merged, snapshot []gjson.Result,
+) bool {
+	if len(merged) == 0 || len(snapshot) == 0 {
+		return true
+	}
+	n := min(len(snapshot), len(merged))
+	for i := range n {
+		if !claudeBlocksAlign(merged[i], snapshot[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func claudeBlocksAlign(a, b gjson.Result) bool {
+	if a.Get("type").Str != b.Get("type").Str {
+		return false
+	}
+	switch a.Get("type").Str {
+	case "text":
+		ta := a.Get("text").Str
+		tb := b.Get("text").Str
+		return ta == tb ||
+			strings.HasPrefix(tb, ta) ||
+			strings.HasPrefix(ta, tb)
+	case "tool_use":
+		ida := a.Get("id").Str
+		idb := b.Get("id").Str
+		if ida != "" && idb != "" {
+			return ida == idb
+		}
+		return a.Raw == b.Raw
+	default:
+		return a.Raw == b.Raw
+	}
+}
+
+func pickClaudeLatestBlock(existing, candidate gjson.Result) gjson.Result {
+	if existing.Get("type").Str != candidate.Get("type").Str {
+		return candidate
+	}
+	switch existing.Get("type").Str {
+	case "text":
+		if len(candidate.Get("text").Str) >=
+			len(existing.Get("text").Str) {
+			return candidate
+		}
+		return existing
+	case "tool_use":
+		return candidate
+	default:
+		return existing
+	}
+}
+
+func claudeBlockExistsIn(
+	target gjson.Result, blocks []gjson.Result,
+) bool {
+	targetType := target.Get("type").Str
+	targetID := target.Get("id").Str
+	for _, b := range blocks {
+		if b.Get("type").Str != targetType {
+			continue
+		}
+		if targetType == "tool_use" && targetID != "" {
+			if b.Get("id").Str == targetID {
+				return true
+			}
+			continue
+		}
+		if b.Raw == target.Raw {
+			return true
+		}
+	}
+	return false
+}
+
+func replaceClaudeMessageContent(line string, blocks []gjson.Result) string {
+	var top map[string]any
+	if err := json.Unmarshal([]byte(line), &top); err != nil {
+		return line
+	}
+	msg, ok := top["message"].(map[string]any)
+	if !ok {
+		return line
+	}
+	content := make([]json.RawMessage, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Raw == "" {
+			continue
+		}
+		content = append(content, json.RawMessage(block.Raw))
+	}
+	msg["content"] = content
+	encoded, err := json.Marshal(top)
+	if err != nil {
+		return line
+	}
+	return string(encoded)
 }
 
 // countUserTurns counts all user entries reachable from a

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -1045,20 +1045,30 @@ func mergeClaudeAssistantMessageChunks(entries []dagEntry) []dagEntry {
 // update overlapping positions in place and append any trailing blocks;
 // additive snapshots append blocks not already present.
 //
-// This avoids two failure modes of position-only or ordinal-only
-// matching: (1) treating distinct text blocks that happen to share a
-// byte prefix as one evolving block, and (2) collapsing additive
-// single-block chunks because they reuse the same ordinal.
+// Once any entry in the run has stop_reason="end_turn", the message
+// has terminated; subsequent same-message.id entries are treated as
+// additive distinct chunks rather than streaming snapshots, even if
+// their text would otherwise prefix-match.
 func mergeClaudeAssistantRun(run []dagEntry) dagEntry {
 	base := run[len(run)-1]
 	var merged []gjson.Result
+	// Once a snapshot in the run has stop_reason="end_turn" the
+	// message has terminated. Any further same-message.id entries
+	// are additive distinct chunks rather than streaming snapshots,
+	// so cumulative prefix-matching must be skipped.
+	runEnded := false
 
 	for _, e := range run {
 		content := gjson.Get(e.line, "message.content")
 		if !content.IsArray() {
 			continue
 		}
-		merged = mergeClaudeSnapshot(merged, claudeContentBlocks(content))
+		merged = mergeClaudeSnapshot(
+			merged, claudeContentBlocks(content), runEnded,
+		)
+		if gjson.Get(e.line, "message.stop_reason").Str == "end_turn" {
+			runEnded = true
+		}
 	}
 	if len(merged) == 0 {
 		return base
@@ -1079,9 +1089,9 @@ func claudeContentBlocks(content gjson.Result) []gjson.Result {
 }
 
 func mergeClaudeSnapshot(
-	merged, snapshot []gjson.Result,
+	merged, snapshot []gjson.Result, runEnded bool,
 ) []gjson.Result {
-	if claudeSnapshotIsCumulative(merged, snapshot) {
+	if !runEnded && claudeSnapshotIsCumulative(merged, snapshot) {
 		for i, block := range snapshot {
 			if i < len(merged) {
 				merged[i] = pickClaudeLatestBlock(merged[i], block)
@@ -1105,16 +1115,6 @@ func claudeSnapshotIsCumulative(
 	if len(merged) == 0 || len(snapshot) == 0 {
 		return true
 	}
-	// Single-block snapshots have no structural backup beyond a
-	// coincidental text prefix. Two distinct additive text chunks
-	// where the second begins with the first byte-for-byte would
-	// otherwise be classified as cumulative growth and collapsed.
-	// Require exact-equal alignment in that case; multi-block
-	// snapshots can rely on prefix matching because additional
-	// aligned blocks supply structural evidence.
-	if len(snapshot) == 1 {
-		return claudeBlocksAlignStrict(merged[0], snapshot[0])
-	}
 	n := min(len(snapshot), len(merged))
 	for i := range n {
 		if !claudeBlocksAlign(merged[i], snapshot[i]) {
@@ -1135,29 +1135,6 @@ func claudeBlocksAlign(a, b gjson.Result) bool {
 		return ta == tb ||
 			strings.HasPrefix(tb, ta) ||
 			strings.HasPrefix(ta, tb)
-	case "tool_use":
-		ida := a.Get("id").Str
-		idb := b.Get("id").Str
-		if ida != "" && idb != "" {
-			return ida == idb
-		}
-		return a.Raw == b.Raw
-	default:
-		return a.Raw == b.Raw
-	}
-}
-
-// claudeBlocksAlignStrict is like claudeBlocksAlign but rejects
-// text prefix matches — only exact text equality counts. Tool_use
-// blocks still align by id (cumulative growth of input is fine
-// because the id ties them to one logical call).
-func claudeBlocksAlignStrict(a, b gjson.Result) bool {
-	if a.Get("type").Str != b.Get("type").Str {
-		return false
-	}
-	switch a.Get("type").Str {
-	case "text":
-		return a.Get("text").Str == b.Get("text").Str
 	case "tool_use":
 		ida := a.Get("id").Str
 		idb := b.Get("id").Str

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -1105,6 +1105,16 @@ func claudeSnapshotIsCumulative(
 	if len(merged) == 0 || len(snapshot) == 0 {
 		return true
 	}
+	// Single-block snapshots have no structural backup beyond a
+	// coincidental text prefix. Two distinct additive text chunks
+	// where the second begins with the first byte-for-byte would
+	// otherwise be classified as cumulative growth and collapsed.
+	// Require exact-equal alignment in that case; multi-block
+	// snapshots can rely on prefix matching because additional
+	// aligned blocks supply structural evidence.
+	if len(snapshot) == 1 {
+		return claudeBlocksAlignStrict(merged[0], snapshot[0])
+	}
 	n := min(len(snapshot), len(merged))
 	for i := range n {
 		if !claudeBlocksAlign(merged[i], snapshot[i]) {
@@ -1125,6 +1135,29 @@ func claudeBlocksAlign(a, b gjson.Result) bool {
 		return ta == tb ||
 			strings.HasPrefix(tb, ta) ||
 			strings.HasPrefix(ta, tb)
+	case "tool_use":
+		ida := a.Get("id").Str
+		idb := b.Get("id").Str
+		if ida != "" && idb != "" {
+			return ida == idb
+		}
+		return a.Raw == b.Raw
+	default:
+		return a.Raw == b.Raw
+	}
+}
+
+// claudeBlocksAlignStrict is like claudeBlocksAlign but rejects
+// text prefix matches — only exact text equality counts. Tool_use
+// blocks still align by id (cumulative growth of input is fine
+// because the id ties them to one logical call).
+func claudeBlocksAlignStrict(a, b gjson.Result) bool {
+	if a.Get("type").Str != b.Get("type").Str {
+		return false
+	}
+	switch a.Get("type").Str {
+	case "text":
+		return a.Get("text").Str == b.Get("text").Str
 	case "tool_use":
 		ida := a.Get("id").Str
 		idb := b.Get("id").Str

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -733,6 +734,129 @@ func TestParseClaudeSessionFrom_LinearUUID(
 	assert.False(t, endedAt.IsZero())
 }
 
+// Appended user entry carries toolUseResult.agentId, which the
+// incremental path can't propagate to an already-stored tool_call
+// row. ParseClaudeSessionFrom must signal full-parse fallback so
+// the engine re-parses the whole session.
+func TestParseClaudeSessionFrom_ToolUseResultAgentIDFallsBack(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+	)
+	path := createTestFile(
+		t, "inc-tool-result-agentid.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := `{"type":"user","uuid":"u1",` +
+		`"parentUuid":"pre",` +
+		`"timestamp":"` + tsEarlyS5 +
+		`","message":{"content":[` +
+		`{"type":"tool_result","tool_use_id":"toolu_x",` +
+		`"content":"done"}]},` +
+		`"toolUseResult":{"status":"completed",` +
+		`"agentId":"abc123"}}` + "\n"
+
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseClaudeSessionFrom(path, offset, 1)
+	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
+	assert.True(t, IsIncrementalFullParseFallback(err))
+}
+
+// Two appended assistant entries with the same message.id form a
+// run that the full parser merges into one message; the incremental
+// path would otherwise produce two separate stored messages, so it
+// must signal full-parse fallback.
+func TestParseClaudeSessionFrom_SameMessageIDFallsBack(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+	)
+	path := createTestFile(
+		t, "inc-same-msgid.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	a1 := `{"type":"assistant","uuid":"a1",` +
+		`"parentUuid":"pre",` +
+		`"timestamp":"` + tsEarlyS5 +
+		`","message":{"id":"msg_run","content":[` +
+		`{"type":"text","text":"Hi"}]}}` + "\n"
+	a2 := `{"type":"assistant","uuid":"a2",` +
+		`"parentUuid":"a1",` +
+		`"timestamp":"` + tsLate +
+		`","message":{"id":"msg_run","content":[` +
+		`{"type":"text","text":"Hi there"}]}}` + "\n"
+
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(a1 + a2)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseClaudeSessionFrom(path, offset, 1)
+	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
+	assert.True(t, IsIncrementalFullParseFallback(err))
+}
+
+// Sanity: a benign incremental append (one user, one assistant
+// with a unique message.id, no toolUseResult.agentId) must NOT
+// trigger fallback.
+func TestParseClaudeSessionFrom_BenignAppendNoFallback(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+	)
+	path := createTestFile(
+		t, "inc-benign.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	u := `{"type":"user","uuid":"u1",` +
+		`"parentUuid":"pre",` +
+		`"timestamp":"` + tsEarlyS5 +
+		`","message":{"content":"more input"}}` + "\n"
+	a := `{"type":"assistant","uuid":"a1","parentUuid":"u1",` +
+		`"timestamp":"` + tsLate +
+		`","message":{"id":"msg_unique","content":[` +
+		`{"type":"text","text":"reply"}]}}` + "\n"
+
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(u + a)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 1)
+	require.NoError(t, err)
+	assert.Len(t, newMsgs, 2)
+}
+
 func TestParseClaudeSession_TerminationStatus(t *testing.T) {
 	t.Run("clean", func(t *testing.T) {
 		content := loadFixture(t, "claude/valid_session.jsonl")
@@ -982,6 +1106,107 @@ func TestParseClaudeSession_ExtractsMessageIDAndRequestID(t *testing.T) {
 	if m.OutputTokens != 20 {
 		t.Errorf("OutputTokens = %d, want 20", m.OutputTokens)
 	}
+}
+
+func TestParseClaudeSession_SameMessageIDStreamingSnapshots(t *testing.T) {
+	lines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_stream","content":[{"type":"text","text":"Work"}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_stream","content":[{"type":"text","text":"Working"},{"type":"tool_use","id":"toolu_same","name":"Agent","input":{"description":"same","subagent_type":"Explore","prompt":"same"}}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:03Z","uuid":"a3","parentUuid":"a2","message":{"id":"msg_stream","content":[{"type":"text","text":"Working"},{"type":"tool_use","id":"toolu_same","name":"Agent","input":{"description":"same","subagent_type":"Explore","prompt":"same"}}],"usage":{"input_tokens":1,"output_tokens":3},"stop_reason":"tool_use"}}`,
+	}
+
+	_, msgs := runClaudeParserTest(
+		t, "same-message-streaming.jsonl", testjsonl.JoinJSONL(lines...),
+	)
+
+	require.Len(t, msgs, 2)
+	msg := msgs[1]
+	assert.Equal(t, "Working\n[Task: same (Explore)]", msg.Content)
+	assert.Equal(t, 3, msg.OutputTokens)
+	assert.Len(t, msg.ToolCalls, 1)
+	assert.Equal(t, "toolu_same", msg.ToolCalls[0].ToolUseID)
+}
+
+// Cumulative snapshots where the same tool_use id appears with
+// progressively more complete input JSON across snapshots. Without
+// id-keyed dedup these would each be a distinct raw block and produce
+// duplicate tool calls; the latest snapshot must win.
+func TestParseClaudeSession_SameMessageIDProgressiveToolUseInput(t *testing.T) {
+	lines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_grow","content":[{"type":"text","text":"Work"},{"type":"tool_use","id":"toolu_grow","name":"Agent","input":{"description":"insp"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_grow","content":[{"type":"text","text":"Working"},{"type":"tool_use","id":"toolu_grow","name":"Agent","input":{"description":"inspect","subagent_type":"Explore"}}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:03Z","uuid":"a3","parentUuid":"a2","message":{"id":"msg_grow","content":[{"type":"text","text":"Working on it"},{"type":"tool_use","id":"toolu_grow","name":"Agent","input":{"description":"inspect schema","subagent_type":"Explore","prompt":"inspect the schema"}}],"usage":{"input_tokens":1,"output_tokens":3},"stop_reason":"tool_use"}}`,
+	}
+
+	_, msgs := runClaudeParserTest(
+		t, "progressive-tool-input.jsonl", testjsonl.JoinJSONL(lines...),
+	)
+
+	require.Len(t, msgs, 2)
+	msg := msgs[1]
+	require.Len(t, msg.ToolCalls, 1)
+	tc := msg.ToolCalls[0]
+	assert.Equal(t, "toolu_grow", tc.ToolUseID)
+	assert.JSONEq(t, `{"description":"inspect schema","subagent_type":"Explore","prompt":"inspect the schema"}`, tc.InputJSON)
+	assert.Equal(t, 3, msg.OutputTokens)
+	assert.Contains(t, msg.Content, "Working on it")
+}
+
+// Additive same-message.id chunks where each chunk has one distinct
+// text block. Ordinal-only matching would have collapsed all three
+// to whichever was longest; cumulative-vs-additive detection sees
+// that each chunk fails the leading-block alignment check and
+// appends them as distinct content.
+func TestParseClaudeSession_SameMessageIDAdditiveDistinctTextBlocks(t *testing.T) {
+	lines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_add","content":[{"type":"text","text":"First sentence."}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"end_turn"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_add","content":[{"type":"text","text":"Second sentence."}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"end_turn"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:03Z","uuid":"a3","parentUuid":"a2","message":{"id":"msg_add","content":[{"type":"text","text":"Third sentence."}],"usage":{"input_tokens":1,"output_tokens":3},"stop_reason":"end_turn"}}`,
+	}
+
+	_, msgs := runClaudeParserTest(
+		t, "additive-distinct-text.jsonl", testjsonl.JoinJSONL(lines...),
+	)
+
+	require.Len(t, msgs, 2)
+	msg := msgs[1]
+	require.Equal(t, RoleAssistant, msg.Role)
+	assert.Contains(t, msg.Content, "First sentence.")
+	assert.Contains(t, msg.Content, "Second sentence.")
+	assert.Contains(t, msg.Content, "Third sentence.")
+}
+
+// Cumulative streaming snapshots of one response that contains
+// text + tool_use + text. The third block in the second snapshot
+// happens to start with the first text block's exact bytes. Snapshot-
+// level cumulative detection keeps both text blocks separately; the
+// prior prefix heuristic would have collapsed the pre-tool intro into
+// the post-tool follow-up.
+func TestParseClaudeSession_SameMessageIDPrefixCollidingTextBlocks(t *testing.T) {
+	lines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_prefix","content":[{"type":"text","text":"Looking at this"},{"type":"tool_use","id":"toolu_one","name":"Read","input":{"file_path":"/tmp/foo.txt"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_prefix","content":[{"type":"text","text":"Looking at this"},{"type":"tool_use","id":"toolu_one","name":"Read","input":{"file_path":"/tmp/foo.txt"}},{"type":"text","text":"Looking at this code carefully."}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"end_turn"}}`,
+	}
+
+	_, msgs := runClaudeParserTest(
+		t, "prefix-colliding-text.jsonl", testjsonl.JoinJSONL(lines...),
+	)
+
+	require.Len(t, msgs, 2)
+	msg := msgs[1]
+	require.Equal(t, RoleAssistant, msg.Role)
+	// Both distinct text blocks must survive — the second is
+	// post-tool follow-up, not a streaming continuation of the first.
+	assert.Equal(t, 2, strings.Count(msg.Content, "Looking at this"),
+		"both distinct text blocks should appear in merged content; got %q",
+		msg.Content)
+	assert.Contains(t, msg.Content, "Looking at this code carefully.")
+	require.Len(t, msg.ToolCalls, 1)
+	assert.Equal(t, "toolu_one", msg.ToolCalls[0].ToolUseID)
 }
 
 func TestParseClaudeSession_CompactBoundary(t *testing.T) {

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -1227,6 +1227,32 @@ func TestParseClaudeSession_SameMessageIDStreamingSingleBlockReplaces(t *testing
 	assert.Equal(t, "Hello world", msg.Content)
 }
 
+// Same-message.id chunk merging round-trips the base entry's JSON
+// through Unmarshal/Marshal to swap in the merged content blocks.
+// json.Unmarshal decodes numbers as float64 by default, which
+// truncates integers larger than 2^53. Use json.Decoder.UseNumber
+// to preserve the raw textual form so large integer fields (e.g.
+// future large token-count metrics) survive the merge.
+func TestParseClaudeSession_SameMessageIDPreservesLargeIntegers(t *testing.T) {
+	// 9999999999999999 > 2^53 — float64 cannot represent it exactly.
+	const bigInt = "9999999999999999"
+	lines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_big","content":[{"type":"text","text":"Hi"}],"usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":` + bigInt + `},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_big","content":[{"type":"text","text":"Hi there"}],"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":` + bigInt + `},"stop_reason":"end_turn"}}`,
+	}
+
+	_, msgs := runClaudeParserTest(
+		t, "big-int.jsonl", testjsonl.JoinJSONL(lines...),
+	)
+	require.Len(t, msgs, 2)
+	assert.Contains(
+		t, string(msgs[1].TokenUsage), bigInt,
+		"large integer in usage must survive the merge "+
+			"round-trip; got %s", string(msgs[1].TokenUsage),
+	)
+}
+
 // Cumulative streaming snapshots of one response that contains
 // text + tool_use + text. The third block in the second snapshot
 // happens to start with the first text block's exact bytes. Snapshot-

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -1180,10 +1180,11 @@ func TestParseClaudeSession_SameMessageIDAdditiveDistinctTextBlocks(t *testing.T
 }
 
 // Two single-text-block additive chunks where the second's text
-// begins byte-for-byte with the first. Without strict alignment
-// for single-block snapshots, the prefix relationship would be
-// classified as cumulative growth and the first block would be
-// overwritten by the second.
+// begins byte-for-byte with the first AND the first chunk's
+// stop_reason="end_turn" marks the message as already terminated.
+// Subsequent same-message.id chunks are additive rather than
+// streaming snapshots, so the prefix relationship must NOT be
+// classified as cumulative growth.
 func TestParseClaudeSession_SameMessageIDAdditivePrefixCollidingSingleBlocks(t *testing.T) {
 	lines := []string{
 		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
@@ -1200,6 +1201,30 @@ func TestParseClaudeSession_SameMessageIDAdditivePrefixCollidingSingleBlocks(t *
 	require.Equal(t, RoleAssistant, msg.Role)
 	assert.Contains(t, msg.Content, "First.")
 	assert.Contains(t, msg.Content, "First. Continued.")
+}
+
+// Two single-text-block snapshots where the second extends the
+// first as a byte-for-byte prefix and neither has finalized the
+// message (no stop_reason="end_turn" in the first snapshot). The
+// merge must treat this as cumulative streaming and REPLACE the
+// partial snapshot — not concatenate as additive content.
+func TestParseClaudeSession_SameMessageIDStreamingSingleBlockReplaces(t *testing.T) {
+	lines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_partial","content":[{"type":"text","text":"Hello"}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_partial","content":[{"type":"text","text":"Hello world"}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"end_turn"}}`,
+	}
+
+	_, msgs := runClaudeParserTest(
+		t, "streaming-single-block.jsonl", testjsonl.JoinJSONL(lines...),
+	)
+
+	require.Len(t, msgs, 2)
+	msg := msgs[1]
+	require.Equal(t, RoleAssistant, msg.Role)
+	// Exact equality: the partial "Hello" must be replaced by the
+	// final "Hello world", not joined as "Hello\nHello world".
+	assert.Equal(t, "Hello world", msg.Content)
 }
 
 // Cumulative streaming snapshots of one response that contains

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -1179,6 +1179,29 @@ func TestParseClaudeSession_SameMessageIDAdditiveDistinctTextBlocks(t *testing.T
 	assert.Contains(t, msg.Content, "Third sentence.")
 }
 
+// Two single-text-block additive chunks where the second's text
+// begins byte-for-byte with the first. Without strict alignment
+// for single-block snapshots, the prefix relationship would be
+// classified as cumulative growth and the first block would be
+// overwritten by the second.
+func TestParseClaudeSession_SameMessageIDAdditivePrefixCollidingSingleBlocks(t *testing.T) {
+	lines := []string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_pref","content":[{"type":"text","text":"First."}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"end_turn"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_pref","content":[{"type":"text","text":"First. Continued."}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"end_turn"}}`,
+	}
+
+	_, msgs := runClaudeParserTest(
+		t, "additive-prefix-single.jsonl", testjsonl.JoinJSONL(lines...),
+	)
+
+	require.Len(t, msgs, 2)
+	msg := msgs[1]
+	require.Equal(t, RoleAssistant, msg.Role)
+	assert.Contains(t, msg.Content, "First.")
+	assert.Contains(t, msg.Content, "First. Continued.")
+}
+
 // Cumulative streaming snapshots of one response that contains
 // text + tool_use + text. The third block in the second snapshot
 // happens to start with the first text block's exact bytes. Snapshot-

--- a/internal/parser/claude_subagent_test.go
+++ b/internal/parser/claude_subagent_test.go
@@ -75,6 +75,92 @@ func TestSubagentSessionIDMapping(t *testing.T) {
 			},
 		},
 		{
+			name: "Agent Tool Result Agent ID",
+			lines: []string{
+				`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"u2","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_agent_result","name":"Agent","input":{"description":"inspect schema","subagent_type":"Explore","prompt":"inspect the schema"}}]}}`,
+				`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u3","parentUuid":"u2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_agent_result","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"abc123def4567890"}}`,
+			},
+			wantTools: []ParsedToolCall{
+				{ToolUseID: "toolu_agent_result", ToolName: "Agent", Category: "Task", SubagentSessionID: "agent-abc123def4567890"},
+			},
+		},
+		{
+			name: "Same Message ID Additive Agent Tool Uses",
+			lines: []string{
+				`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"summarize with subagents"},"cwd":"/tmp"}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_same","content":[{"type":"text","text":"Launching agents."}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_same","content":[{"type":"tool_use","id":"toolu_first","name":"Agent","input":{"description":"first","subagent_type":"Explore","prompt":"first"}}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"tool_use"}}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:03Z","uuid":"a3","parentUuid":"a2","message":{"id":"msg_same","content":[{"type":"tool_use","id":"toolu_second","name":"Agent","input":{"description":"second","subagent_type":"Explore","prompt":"second"}}],"usage":{"input_tokens":1,"output_tokens":3},"stop_reason":"tool_use"}}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:04Z","uuid":"a4","parentUuid":"a3","message":{"id":"msg_same","content":[{"type":"tool_use","id":"toolu_third","name":"Agent","input":{"description":"third","subagent_type":"Explore","prompt":"third"}}],"usage":{"input_tokens":1,"output_tokens":4},"stop_reason":"tool_use"}}`,
+				`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"r1","parentUuid":"a2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_first","content":"done first"}]},"toolUseResult":{"status":"completed","agentId":"childfirst"}}`,
+				`{"type":"user","timestamp":"2024-01-01T10:00:06Z","uuid":"r2","parentUuid":"a3","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_second","content":"done second"}]},"toolUseResult":{"status":"completed","agentId":"childsecond"}}`,
+				`{"type":"user","timestamp":"2024-01-01T10:00:07Z","uuid":"r3","parentUuid":"a4","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_third","content":"done third"}]},"toolUseResult":{"status":"completed","agentId":"childthird"}}`,
+			},
+			wantTools: []ParsedToolCall{
+				{ToolUseID: "toolu_first", ToolName: "Agent", Category: "Task", SubagentSessionID: "agent-childfirst"},
+				{ToolUseID: "toolu_second", ToolName: "Agent", Category: "Task", SubagentSessionID: "agent-childsecond"},
+				{ToolUseID: "toolu_third", ToolName: "Agent", Category: "Task", SubagentSessionID: "agent-childthird"},
+			},
+		},
+		{
+			name: "Queue Mapping Beats Tool Result Agent ID",
+			lines: []string{
+				`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"u2","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_agent_result","name":"Agent","input":{"description":"inspect schema","subagent_type":"Explore","prompt":"inspect the schema"}}]}}`,
+				`{"type":"queue-operation","operation":"enqueue","timestamp":"2024-01-01T10:00:02Z","sessionId":"test-session","content":"{\"task_id\":\"queuefirst\",\"tool_use_id\":\"toolu_agent_result\",\"description\":\"inspect schema\",\"task_type\":\"local_agent\"}"}`,
+				`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u3","parentUuid":"u2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_agent_result","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"resultfallback"}}`,
+			},
+			wantTools: []ParsedToolCall{
+				{ToolUseID: "toolu_agent_result", ToolName: "Agent", Category: "Task", SubagentSessionID: "agent-queuefirst"},
+			},
+		},
+		{
+			name: "Tool Result Agent ID Non-Task Tool Unchanged",
+			lines: []string{
+				`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"u2","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_read_result","name":"Read","input":{"file_path":"/tmp/foo.txt"}}]}}`,
+				`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u3","parentUuid":"u2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_read_result","content":"file contents"}]},"toolUseResult":{"status":"completed","agentId":"notasubagent"}}`,
+			},
+			wantTools: []ParsedToolCall{
+				{ToolUseID: "toolu_read_result", ToolName: "Read", Category: "Read", SubagentSessionID: ""},
+			},
+		},
+		{
+			name: "Tool Result Agent ID Multiple Results Ignored",
+			lines: []string{
+				`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"u2","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_first_result","name":"Agent","input":{"description":"first","subagent_type":"Explore","prompt":"first"}},{"type":"tool_use","id":"toolu_second_result","name":"Agent","input":{"description":"second","subagent_type":"Explore","prompt":"second"}}]}}`,
+				`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u3","parentUuid":"u2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_first_result","content":"first done"},{"type":"tool_result","tool_use_id":"toolu_second_result","content":"second done"}]},"toolUseResult":{"status":"completed","agentId":"ambiguousagent"}}`,
+			},
+			wantTools: []ParsedToolCall{
+				{ToolUseID: "toolu_first_result", ToolName: "Agent", Category: "Task", SubagentSessionID: ""},
+				{ToolUseID: "toolu_second_result", ToolName: "Agent", Category: "Task", SubagentSessionID: ""},
+			},
+		},
+		{
+			name: "Tool Result Agent ID String Content Skipped",
+			lines: []string{
+				`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"u2","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_string_content","name":"Agent","input":{"description":"x","subagent_type":"Explore","prompt":"x"}}]}}`,
+				`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u3","parentUuid":"u2","message":{"content":"plain string"},"toolUseResult":{"status":"completed","agentId":"strayagent"}}`,
+			},
+			wantTools: []ParsedToolCall{
+				{ToolUseID: "toolu_string_content", ToolName: "Agent", Category: "Task", SubagentSessionID: ""},
+			},
+		},
+		{
+			name: "Tool Result Agent ID No Tool Result Blocks Skipped",
+			lines: []string{
+				`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,
+				`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"u2","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_no_result","name":"Agent","input":{"description":"x","subagent_type":"Explore","prompt":"x"}}]}}`,
+				`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u3","parentUuid":"u2","message":{"content":[{"type":"text","text":"acknowledged"}]},"toolUseResult":{"status":"completed","agentId":"strayagent"}}`,
+			},
+			wantTools: []ParsedToolCall{
+				{ToolUseID: "toolu_no_result", ToolName: "Agent", Category: "Task", SubagentSessionID: ""},
+			},
+		},
+		{
 			name: "Non-Task Tool Unchanged",
 			lines: []string{
 				`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"hello"},"cwd":"/tmp"}`,

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1315,9 +1315,10 @@ func ParseCodexSessionFrom(
 }
 
 // IsIncrementalFullParseFallback reports whether an incremental
-// Codex parse error requires the caller to fall back to a full parse.
+// parse error requires the caller to fall back to a full parse.
 func IsIncrementalFullParseFallback(err error) bool {
-	return errors.Is(err, errCodexIncrementalNeedsFullParse)
+	return errors.Is(err, errCodexIncrementalNeedsFullParse) ||
+		errors.Is(err, ErrClaudeIncrementalNeedsFullParse)
 }
 
 func isCodexSystemMessage(content string) bool {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2455,7 +2455,14 @@ func (e *Engine) tryIncrementalJSONL(
 				"incremental %s %s: %v (explicit full parse fallback)",
 				agent, file.Path, err,
 			)
-			return processResult{}, false
+			// The fallback fires when appended lines update
+			// already-stored rows (toolUseResult.agentId
+			// linkage, same-message.id chunk merging). The
+			// full parse must replace existing messages —
+			// otherwise the append-only write path skips
+			// rows whose ordinal ≤ maxOrd and the updates
+			// are silently dropped.
+			return processResult{forceReplace: true}, false
 		}
 		log.Printf(
 			"incremental %s %s: %v (full parse)",

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1952,8 +1952,9 @@ func (e *Engine) collectAndBatch(
 		} else {
 			for _, pr := range r.results {
 				pending = append(pending, pendingWrite{
-					sess: pr.Session,
-					msgs: pr.Messages,
+					sess:         pr.Session,
+					msgs:         pr.Messages,
+					forceReplace: r.forceReplace,
 				})
 			}
 		}
@@ -2032,6 +2033,13 @@ type processResult struct {
 	err         error
 	incremental *incrementalUpdate
 	cacheSkip   bool
+	// forceReplace requests full message replacement on write,
+	// even when the existing rows would otherwise be left in
+	// place. Set when a fall-through to full parse is recovering
+	// from a cross-sync streaming split: the new merged messages
+	// reuse the existing ordinals, so the default append-only
+	// writeMessages would silently drop the rewrite.
+	forceReplace bool
 }
 
 func (e *Engine) processFile(
@@ -2302,13 +2310,18 @@ func (e *Engine) processClaude(
 	}
 
 	// Try incremental parse for append-only JSONL files
-	// that have already been synced.
-	if res, ok := e.tryIncrementalJSONL(
+	// that have already been synced. When the incremental path
+	// declines but signals forceReplace (e.g. cross-sync split
+	// recovery), carry the flag onto the full-parse result so the
+	// write path uses ReplaceSessionMessages.
+	res, ok := e.tryIncrementalJSONL(
 		file, info, parser.AgentClaude,
 		parser.ParseClaudeSessionFrom,
-	); ok {
+	)
+	if ok {
 		return res
 	}
+	forceReplace := res.forceReplace
 
 	// Determine project name from cwd if possible
 	project := parser.GetProjectName(file.Project)
@@ -2345,7 +2358,7 @@ func (e *Engine) processClaude(
 
 	parser.InferRelationshipTypes(results)
 
-	return processResult{results: results}
+	return processResult{results: results, forceReplace: forceReplace}
 }
 
 // incrementalParseFunc reads new JSONL lines from a file
@@ -2479,6 +2492,32 @@ func (e *Engine) tryIncrementalJSONL(
 			}, true
 		}
 		return processResult{skip: true}, true
+	}
+
+	// Claude cross-sync split detection: when the first appended
+	// assistant message shares its provider message id with the
+	// last already-stored assistant message for this session, the
+	// previous sync stopped mid-stream. The incremental path would
+	// store the new chunk as a separate message instead of merging
+	// it into the existing one — fall back to a full parse so the
+	// chunk merge sees the whole run. forceReplace tells the
+	// downstream write path to use ReplaceSessionMessages: the
+	// merged tail reuses existing ordinals, so the default
+	// append-only writeMessages would silently drop it.
+	if agent == parser.AgentClaude {
+		first := newMsgs[0]
+		if first.Role == parser.RoleAssistant &&
+			first.ClaudeMessageID != "" {
+			if e.db.LastClaudeMessageID(inc.ID) ==
+				first.ClaudeMessageID {
+				log.Printf(
+					"incremental %s %s: appended chunk shares"+
+						" message.id with stored tail, full parse",
+					agent, file.Path,
+				)
+				return processResult{forceReplace: true}, false
+			}
+		}
 	}
 
 	newUserCount := countUserMsgs(newMsgs)
@@ -3354,8 +3393,9 @@ func isAutomatedFromSession(s db.Session) bool {
 }
 
 type pendingWrite struct {
-	sess parser.ParsedSession
-	msgs []parser.ParsedMessage
+	sess         parser.ParsedSession
+	msgs         []parser.ParsedMessage
+	forceReplace bool
 }
 
 func (e *Engine) writeBatch(
@@ -3407,8 +3447,8 @@ func (e *Engine) writeBatch(
 			continue
 		}
 
-		replaceMessages := forceReplace || stale ||
-			pw.sess.Agent == parser.AgentOpenCode
+		replaceMessages := forceReplace || pw.forceReplace ||
+			stale || pw.sess.Agent == parser.AgentOpenCode
 
 		var werr error
 		if replaceMessages {
@@ -3487,7 +3527,7 @@ func (e *Engine) writeBatchBulk(
 		if !ok {
 			continue
 		}
-		replaceMessages := forceReplace ||
+		replaceMessages := forceReplace || pw.forceReplace ||
 			pw.sess.Agent == parser.AgentOpenCode
 		writes = append(writes, db.SessionBatchWrite{
 			Session:         s,

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5773,9 +5773,11 @@ func TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse(t *testing.T) 
 	if string(msgs[1].Role) != "assistant" {
 		t.Fatalf("msgs[1].Role = %q, want assistant", msgs[1].Role)
 	}
-	if !strings.Contains(msgs[1].Content, "Hello world") {
+	// The partial snapshot ("Hello") must be REPLACED by the final
+	// snapshot ("Hello world"), not concatenated as additive content.
+	if msgs[1].Content != "Hello world" {
 		t.Errorf(
-			"msgs[1].Content = %q, want it to contain %q",
+			"msgs[1].Content = %q, want exactly %q",
 			msgs[1].Content, "Hello world",
 		)
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1396,6 +1396,134 @@ func TestSyncSubagentSetsParentSessionID(t *testing.T) {
 	}
 }
 
+func TestSyncClaudeToolResultAgentIDLinksSubagentToolCall(t *testing.T) {
+	env := setupTestEnv(t)
+
+	parentContent := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"Build the feature"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"u2","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_agent_result","name":"Agent","input":{"description":"inspect schema","subagent_type":"Explore","prompt":"inspect the schema"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"u3","parentUuid":"u2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_agent_result","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"abc123def4567890"}}`,
+	}, "\n")
+
+	env.writeClaudeSession(
+		t, "test-proj", "parent-agentid.jsonl", parentContent,
+	)
+
+	subContent := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithSessionID(
+			tsEarly, "Do subtask", "parent-agentid",
+		).
+		AddClaudeAssistant(tsEarlyS5, "Subtask done.").
+		String()
+
+	env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"test-proj", "parent-agentid",
+			"subagents", "agent-abc123def4567890.jsonl",
+		),
+		subContent,
+	)
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 2, Synced: 2, Skipped: 0})
+
+	var got string
+	err := env.db.Reader().QueryRow(`
+		SELECT subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"parent-agentid", "toolu_agent_result",
+	).Scan(&got)
+	if err != nil {
+		t.Fatalf("query linked subagent tool call: %v", err)
+	}
+	if got != "agent-abc123def4567890" {
+		t.Errorf(
+			"subagent_session_id = %q, want %q",
+			got, "agent-abc123def4567890",
+		)
+	}
+}
+
+func TestSyncClaudeSameMessageIDAgentChunksLinkAllSubagents(t *testing.T) {
+	env := setupTestEnv(t)
+
+	parentContent := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"summarize with subagents"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_same","content":[{"type":"text","text":"Launching agents."}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:02Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_same","content":[{"type":"tool_use","id":"toolu_first","name":"Agent","input":{"description":"first","subagent_type":"Explore","prompt":"first"}}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:03Z","uuid":"a3","parentUuid":"a2","message":{"id":"msg_same","content":[{"type":"tool_use","id":"toolu_second","name":"Agent","input":{"description":"second","subagent_type":"Explore","prompt":"second"}}],"usage":{"input_tokens":1,"output_tokens":3},"stop_reason":"tool_use"}}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:04Z","uuid":"a4","parentUuid":"a3","message":{"id":"msg_same","content":[{"type":"tool_use","id":"toolu_third","name":"Agent","input":{"description":"third","subagent_type":"Explore","prompt":"third"}}],"usage":{"input_tokens":1,"output_tokens":4},"stop_reason":"tool_use"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:05Z","uuid":"r1","parentUuid":"a2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_first","content":"done first"}]},"toolUseResult":{"status":"completed","agentId":"childfirst"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:06Z","uuid":"r2","parentUuid":"a3","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_second","content":"done second"}]},"toolUseResult":{"status":"completed","agentId":"childsecond"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:07Z","uuid":"r3","parentUuid":"a4","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_third","content":"done third"}]},"toolUseResult":{"status":"completed","agentId":"childthird"}}`,
+	}, "\n")
+
+	env.writeClaudeSession(
+		t, "test-proj", "parent-same-message.jsonl", parentContent,
+	)
+
+	for _, child := range []string{"childfirst", "childsecond", "childthird"} {
+		subContent := testjsonl.NewSessionBuilder().
+			AddClaudeUserWithSessionID(
+				tsEarly, "Do "+child, "parent-same-message",
+			).
+			AddClaudeAssistant(tsEarlyS5, child+" done.").
+			String()
+		env.writeSession(
+			t, env.claudeDir,
+			filepath.Join(
+				"test-proj", "parent-same-message",
+				"subagents", "agent-"+child+".jsonl",
+			),
+			subContent,
+		)
+	}
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 4, Synced: 4, Skipped: 0})
+
+	rows, err := env.db.Reader().Query(`
+		SELECT tool_use_id, subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ?
+		ORDER BY tool_use_id`,
+		"parent-same-message",
+	)
+	if err != nil {
+		t.Fatalf("query linked subagent tool calls: %v", err)
+	}
+	defer rows.Close()
+
+	got := map[string]string{}
+	for rows.Next() {
+		var toolUseID, subagentSessionID string
+		if err := rows.Scan(&toolUseID, &subagentSessionID); err != nil {
+			t.Fatalf("scan linked subagent tool call: %v", err)
+		}
+		got[toolUseID] = subagentSessionID
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate linked subagent tool calls: %v", err)
+	}
+
+	want := map[string]string{
+		"toolu_first":  "agent-childfirst",
+		"toolu_second": "agent-childsecond",
+		"toolu_third":  "agent-childthird",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("linked tool calls = %v, want %v", got, want)
+	}
+	for toolUseID, wantSessionID := range want {
+		if got[toolUseID] != wantSessionID {
+			t.Errorf(
+				"%s subagent_session_id = %q, want %q",
+				toolUseID, got[toolUseID], wantSessionID,
+			)
+		}
+	}
+}
+
 func TestSyncPathsClaudeSubagent(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5783,6 +5783,93 @@ func TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse(t *testing.T) 
 	}
 }
 
+// TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall covers
+// the cross-sync subagent linkage case: the first sync stores an
+// assistant tool_use row with no subagent_session_id, and a later sync
+// appends a tool_result whose toolUseResult.agentId should populate the
+// already-stored tool_call. The parser signals
+// IsIncrementalFullParseFallback, so the full-parse fallback must run
+// with forceReplace=true; otherwise the append-only write path skips
+// the existing row and the linkage is silently dropped.
+func TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall(t *testing.T) {
+	env := setupTestEnv(t)
+
+	parentInitial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_one","content":[{"type":"tool_use","id":"toolu_late","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+	)
+
+	path := env.writeClaudeSession(
+		t, "proj-late-link", "parent-late-link.jsonl", parentInitial,
+	)
+
+	subContent := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithSessionID(
+			tsEarly, "do thing", "parent-late-link",
+		).
+		AddClaudeAssistant(tsEarlyS5, "done").
+		String()
+	env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"proj-late-link", "parent-late-link",
+			"subagents", "agent-childlate.jsonl",
+		),
+		subContent,
+	)
+
+	env.engine.SyncAll(context.Background(), nil)
+
+	// Linkage starts empty (the toolUseResult hasn't appeared yet).
+	var got sql.NullString
+	if err := env.db.Reader().QueryRow(`
+		SELECT subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"parent-late-link", "toolu_late",
+	).Scan(&got); err != nil {
+		t.Fatalf("query before append: %v", err)
+	}
+	if got.Valid && got.String != "" {
+		t.Fatalf(
+			"subagent_session_id = %q before tool_result, want empty",
+			got.String,
+		)
+	}
+
+	// Append a tool_result with toolUseResult.agentId pointing at
+	// the existing subagent session. Incremental parse will return
+	// ErrClaudeIncrementalNeedsFullParse so the engine must full-
+	// parse with forceReplace to update the stored tool_call row.
+	toolResult := `{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_late","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"childlate"}}`
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	if _, err := f.WriteString(toolResult + "\n"); err != nil {
+		f.Close()
+		t.Fatalf("append: %v", err)
+	}
+	f.Close()
+
+	env.engine.SyncPaths([]string{path})
+
+	if err := env.db.Reader().QueryRow(`
+		SELECT subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"parent-late-link", "toolu_late",
+	).Scan(&got); err != nil {
+		t.Fatalf("query after append: %v", err)
+	}
+	if got.String != "agent-childlate" {
+		t.Errorf(
+			"subagent_session_id = %q, want %q",
+			got.String, "agent-childlate",
+		)
+	}
+}
+
 func TestIncrementalSync_CodexAppend(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5683,6 +5683,104 @@ func TestIncrementalSync_ClaudeFileReplaced(t *testing.T) {
 	}
 }
 
+// TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse covers
+// the cross-sync split case: the first sync stores a partial assistant
+// snapshot (one of several streaming snapshots) and the next sync
+// appends a later snapshot of the SAME response (same message.id).
+// The engine must detect the shared id and fall back to a full parse
+// so the chunk merge collapses both snapshots into one assistant
+// message instead of two.
+func TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse(t *testing.T) {
+	env := setupTestEnv(t)
+
+	first, err := json.Marshal(map[string]any{
+		"type":      "assistant",
+		"timestamp": tsZeroS5,
+		"uuid":      "a1",
+		"message": map[string]any{
+			"id":    "msg_split",
+			"model": "claude-sonnet-4-20250514",
+			"usage": map[string]any{
+				"input_tokens":  10,
+				"output_tokens": 1,
+			},
+			"content": []map[string]any{
+				{"type": "text", "text": "Hello"},
+			},
+			"stop_reason": "tool_use",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal first snapshot: %v", err)
+	}
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsZero),
+		string(first),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "split-stream.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	assertSessionMessageCount(t, env.db, "split-stream", 2)
+
+	// Append a continuation snapshot with the same message.id —
+	// this is the second half of the same streaming response.
+	second, err := json.Marshal(map[string]any{
+		"type":       "assistant",
+		"timestamp":  tsEarly,
+		"uuid":       "a2",
+		"parentUuid": "a1",
+		"message": map[string]any{
+			"id":    "msg_split",
+			"model": "claude-sonnet-4-20250514",
+			"usage": map[string]any{
+				"input_tokens":  10,
+				"output_tokens": 2,
+			},
+			"content": []map[string]any{
+				{"type": "text", "text": "Hello world"},
+			},
+			"stop_reason": "end_turn",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal second snapshot: %v", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	if _, err := f.WriteString(string(second) + "\n"); err != nil {
+		f.Close()
+		t.Fatalf("append: %v", err)
+	}
+	f.Close()
+
+	env.engine.SyncPaths([]string{path})
+
+	// After the full-parse fallback, the two same-message.id
+	// snapshots are merged into ONE assistant message — total
+	// message count stays at 2 (user + merged assistant).
+	assertSessionMessageCount(t, env.db, "split-stream", 2)
+
+	msgs := fetchMessages(t, env.db, "split-stream")
+	if len(msgs) != 2 {
+		t.Fatalf("len(msgs) = %d, want 2", len(msgs))
+	}
+	if string(msgs[1].Role) != "assistant" {
+		t.Fatalf("msgs[1].Role = %q, want assistant", msgs[1].Role)
+	}
+	if !strings.Contains(msgs[1].Content, "Hello world") {
+		t.Errorf(
+			"msgs[1].Content = %q, want it to contain %q",
+			msgs[1].Content, "Hello world",
+		)
+	}
+}
+
 func TestIncrementalSync_CodexAppend(t *testing.T) {
 	env := setupTestEnv(t)
 


### PR DESCRIPTION
  ## Summary
  - Link Claude `Task` / `Agent` tool calls to child subagent sessions using result-side `toolUseResult.agentId` when
  queue/progress mapping is absent.
  - Preserve sibling Claude subagent tool calls when Claude emits additive same-`message.id` assistant chunks.
  - Keep streaming snapshot behavior by replacing progressive partial text with the latest text block while still
  preserving distinct additive content blocks.

  ## Context
  This is the Claude-side version of the inline subagent-linking contract addressed for Codex in #444 / #458.

  The UI already renders inline subagent sessions when `tool_calls.subagent_session_id` is populated. This PR makes
  Claude ingestion populate that existing field in more cases, so child sessions that are already ingested can appear
  inline under the exact parent `Task` / `Agent` tool call that launched them.

  ## Backfill note
  This changes parsed tool-call metadata for existing Claude rows. Existing archives will need a full parser
  reprocess / data-version bump to backfill inline links.

  This PR intentionally does not bump `dataVersion`; maintainers should decide whether to trigger that reparse.

  ## Validation
  - `go test ./internal/parser ./internal/sync -count=1`
  - `git diff --check origin/main...HEAD`

  If you add screenshots later, I’d add a final section:

  ## Visual Check   
  - Before: Claude rendered the three sibling `Task` calls, but none had an inline linked subagent session. <img width="960" height="463" alt="image" src="https://github.com/user-attachments/assets/f0b0417e-476f-4763-ba43-dc49e469e4c9" />
  - After: The same three sibling `Task` calls are preserved. <img width="959" height="514" alt="image" src="https://github.com/user-attachments/assets/f5c15e57-6737-41a0-8e33-71d3c610d10a" />
