### PR TITLE
deps: batch update 11 dependencies

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
             org.opencontainers.image.title=agentsview
             org.opencontainers.image.description=Local web viewer for AI agent sessions
 
-      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
           echo "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
           echo "image=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
+      - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ steps.vars.outputs.image }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/virtual-core": "3.14.0",
-        "dompurify": "3.4.1",
+        "dompurify": "3.4.2",
         "marked": "18.0.3"
       },
       "devDependencies": {
@@ -1037,9 +1037,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@types/dompurify": "3.2.0",
         "jsdom": "29.1.0",
         "svelte": "5.55.5",
-        "svelte-check": "4.4.5",
+        "svelte-check": "4.4.8",
         "typescript": "6.0.3",
         "vite": "^8.0.10",
         "vitest": "^4.1.5"
@@ -1809,9 +1809,9 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.5.tgz",
-      "integrity": "sha512-1bSwIRCvvmSHrlK52fOlZmVtUZgil43jNL/2H18pRpa+eQjzGt6e3zayxhp1S7GajPFKNM/2PMCG+DZFHlG9fw==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.8.tgz",
+      "integrity": "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@playwright/test": "1.58.2",
-        "@sveltejs/vite-plugin-svelte": "7.0.0",
+        "@sveltejs/vite-plugin-svelte": "7.1.1",
         "@tsconfig/svelte": "5.0.8",
         "@types/dompurify": "3.2.0",
         "jsdom": "29.1.1",
@@ -661,9 +661,9 @@
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.0.0.tgz",
-      "integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.1.tgz",
+      "integrity": "sha512-FOJdbE5pxae68DoTBJ49t1dIA7TSmMHR6CsuJhX90cO/UfrEMHA7KJNUj3WdZuUDJPu4ujqpJ2Tgqd2gTWr6Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@tanstack/virtual-core": "3.14.0",
         "dompurify": "3.4.1",
-        "marked": "18.0.2"
+        "marked": "18.0.3"
       },
       "devDependencies": {
         "@playwright/test": "1.58.2",
@@ -1496,9 +1496,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
-      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "@sveltejs/vite-plugin-svelte": "7.0.0",
         "@tsconfig/svelte": "5.0.8",
         "@types/dompurify": "3.2.0",
-        "jsdom": "29.1.0",
+        "jsdom": "29.1.1",
         "svelte": "5.55.5",
         "svelte-check": "4.4.8",
         "typescript": "6.0.3",
@@ -1167,9 +1167,9 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
-      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",
-    "@sveltejs/vite-plugin-svelte": "7.0.0",
+    "@sveltejs/vite-plugin-svelte": "7.1.1",
     "@tsconfig/svelte": "5.0.8",
     "@types/dompurify": "3.2.0",
     "jsdom": "29.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@sveltejs/vite-plugin-svelte": "7.0.0",
     "@tsconfig/svelte": "5.0.8",
     "@types/dompurify": "3.2.0",
-    "jsdom": "29.1.0",
+    "jsdom": "29.1.1",
     "svelte": "5.55.5",
     "svelte-check": "4.4.8",
     "typescript": "6.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@tanstack/virtual-core": "3.14.0",
-    "dompurify": "3.4.1",
+    "dompurify": "3.4.2",
     "marked": "18.0.3"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "@types/dompurify": "3.2.0",
     "jsdom": "29.1.0",
     "svelte": "5.55.5",
-    "svelte-check": "4.4.5",
+    "svelte-check": "4.4.8",
     "typescript": "6.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.1.5"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@tanstack/virtual-core": "3.14.0",
     "dompurify": "3.4.1",
-    "marked": "18.0.2"
+    "marked": "18.0.3"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/fsnotify/fsnotify v1.10.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/jackc/pgx/v5 v5.9.2

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fsnotify/fsnotify v1.10.0 h1:Xx/5Ydg9CeBDX/wi4VJqStNtohYjitZhhlHt4h3St1M=
-github.com/fsnotify/fsnotify v1.10.0/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=


### PR DESCRIPTION
Consolidates the following dependabot updates:

- #464 -- bump docker/login-action from 3.7.0 to 4.1.0
- #465 -- bump github.com/fsnotify/fsnotify from 1.10.0 to 1.10.1
- #466 -- bump docker/setup-buildx-action from 3.12.0 to 4.0.0
- #467 -- bump docker/metadata-action from 5.10.0 to 6.0.0
- #468 -- bump svelte-check from 4.4.5 to 4.4.8 in /frontend
- #469 -- bump docker/build-push-action from 6.19.2 to 7.1.0
- #470 -- bump docker/setup-qemu-action from 3.7.0 to 4.0.0
- #471 -- bump marked from 18.0.2 to 18.0.3 in /frontend
- #472 -- bump jsdom from 29.1.0 to 29.1.1 in /frontend
- #473 -- bump @sveltejs/vite-plugin-svelte from 7.0.0 to 7.1.1 in /frontend
- #474 -- bump dompurify from 3.4.1 to 3.4.2 in /frontend

Closes #464, #465, #466, #467, #468, #469, #470, #471, #472, #473, #474