### PR TITLE
Fix Windows desktop update sidecar lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,27 @@ jobs:
         env:
           CGO_ENABLED: "1"
 
+  desktop-windows-unit:
+    name: Desktop Unit Tests (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Prepare placeholder sidecar resource
+        shell: pwsh
+        run: |
+          $hostTriple = (rustc -vV | Select-String '^host: ').ToString() -replace '^host:\s+', ''
+          if (-not $hostTriple) {
+            throw "could not determine Rust host triple"
+          }
+          New-Item -ItemType Directory -Force desktop/src-tauri/binaries | Out-Null
+          New-Item -ItemType File -Force "desktop/src-tauri/binaries/agentsview-$hostTriple.exe" | Out-Null
+
+      - name: Run Windows desktop update tests
+        run: cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib install_downloaded_update
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ struct SidecarState {
     child: Mutex<Option<SidecarProcess>>,
     backend_port: Mutex<Option<u16>>,
     active_generation: Mutex<Option<u64>>,
+    stopping_generation: Mutex<Option<u64>>,
     terminated_generation: Mutex<u64>,
     termination: Condvar,
     next_generation: AtomicU64,
@@ -553,6 +554,9 @@ fn save_sidecar(app: &AppHandle, child: CommandChild) -> Result<u64, DynError> {
     if let Ok(mut active_generation) = state.active_generation.lock() {
         *active_generation = Some(generation);
     }
+    if let Ok(mut stopping_generation) = state.stopping_generation.lock() {
+        *stopping_generation = None;
+    }
     Ok(generation)
 }
 
@@ -581,6 +585,7 @@ fn handle_sidecar_terminated(
         set_sidecar_port(state, None);
     }
     clear_sidecar_child_if_current(state, generation);
+    clear_stopping_generation_if_current(state, generation);
     record_sidecar_terminated(state, generation);
     !startup_handled.swap(true, Ordering::SeqCst)
 }
@@ -605,6 +610,29 @@ fn clear_sidecar_child_if_current(state: &SidecarState, generation: u64) {
         .map(|process| process.generation)
         .is_some_and(|active_generation| active_generation == generation)
     {
+        *guard = None;
+    }
+}
+
+fn mark_sidecar_stopping(state: &SidecarState, generation: u64) {
+    if let Ok(mut guard) = state.stopping_generation.lock() {
+        *guard = Some(generation);
+    }
+}
+
+fn current_stopping_generation(state: &SidecarState) -> Option<u64> {
+    state
+        .stopping_generation
+        .lock()
+        .ok()
+        .and_then(|guard| *guard)
+}
+
+fn clear_stopping_generation_if_current(state: &SidecarState, generation: u64) {
+    let Ok(mut guard) = state.stopping_generation.lock() else {
+        return;
+    };
+    if *guard == Some(generation) {
         *guard = None;
     }
 }
@@ -1135,22 +1163,28 @@ fn stop_backend_inner(app: &AppHandle, wait_timeout: Option<Duration>) -> bool {
             guard.take()
         };
         let Some(process) = process else {
+            if let Some(generation) = current_stopping_generation(&state) {
+                return finish_backend_stop_wait(
+                    app,
+                    &state,
+                    generation,
+                    wait_for_sidecar_termination(&state, generation, timeout),
+                );
+            }
             clear_sidecar_port(app);
             return true;
         };
         let generation = process.generation;
+        mark_sidecar_stopping(&state, generation);
         if let Err(err) = process.child.kill() {
             eprintln!("[agentsview] failed to stop sidecar: {err}");
         }
-        let terminated = wait_for_sidecar_termination(&state, generation, timeout);
-        if terminated {
-            let _ = mark_sidecar_inactive_if_current(&state, generation);
-            clear_sidecar_child_if_current(&state, generation);
-            clear_sidecar_port(app);
-        } else {
-            eprintln!("[agentsview] timed out waiting for sidecar to stop before update install");
-        }
-        return terminated;
+        return finish_backend_stop_wait(
+            app,
+            &state,
+            generation,
+            wait_for_sidecar_termination(&state, generation, timeout),
+        );
     }
 
     let process = {
@@ -1172,6 +1206,23 @@ fn stop_backend_inner(app: &AppHandle, wait_timeout: Option<Duration>) -> bool {
     }
     clear_sidecar_port(app);
     true
+}
+
+fn finish_backend_stop_wait(
+    app: &AppHandle,
+    state: &SidecarState,
+    generation: u64,
+    terminated: bool,
+) -> bool {
+    if terminated {
+        let _ = mark_sidecar_inactive_if_current(state, generation);
+        clear_sidecar_child_if_current(state, generation);
+        clear_stopping_generation_if_current(state, generation);
+        clear_sidecar_port(app);
+    } else {
+        eprintln!("[agentsview] timed out waiting for sidecar to stop before update install");
+    }
+    terminated
 }
 
 fn restart_backend_after_update_failure(handle: &AppHandle) {
@@ -1415,6 +1466,10 @@ mod tests {
             .active_generation
             .lock()
             .expect("lock active_generation") = Some(1);
+        *state
+            .stopping_generation
+            .lock()
+            .expect("lock stopping_generation") = Some(1);
         let startup_handled = AtomicBool::new(false);
 
         assert!(handle_sidecar_terminated(&state, &startup_handled, 1));
@@ -1427,6 +1482,14 @@ mod tests {
             None
         );
         assert!(startup_handled.load(Ordering::SeqCst));
+        assert_eq!(
+            state
+                .stopping_generation
+                .lock()
+                .expect("lock stopping_generation after terminated")
+                .to_owned(),
+            None
+        );
 
         // Termination handling is idempotent for state and should only
         // report first-time transition once.

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1269,20 +1269,22 @@ fn stop_backend_inner(app: &AppHandle, wait_timeout: Option<Duration>) -> bool {
     if let Some(timeout) = wait_timeout {
         begin_update_stop_wait(&state);
         let mut waited_generation = None;
-        let process = {
-            let Ok(mut guard) = state.child.lock() else {
+        let active_generation = {
+            let Ok(guard) = state.child.lock() else {
                 end_update_stop_wait(&state);
                 return false;
             };
-            guard.take()
+            guard.as_ref().map(|process| {
+                let generation = process.generation;
+                mark_sidecar_stopping(&state, generation);
+                if let Err(err) = request_sidecar_stop(process) {
+                    eprintln!("[agentsview] failed to stop sidecar: {err}");
+                }
+                generation
+            })
         };
-        let stopped = if let Some(process) = process {
-            let generation = process.generation;
+        let stopped = if let Some(generation) = active_generation {
             waited_generation = Some(generation);
-            mark_sidecar_stopping(&state, generation);
-            if let Err(err) = process.child.kill() {
-                eprintln!("[agentsview] failed to stop sidecar: {err}");
-            }
             finish_backend_stop_wait(
                 app,
                 &state,
@@ -1346,6 +1348,51 @@ fn finish_backend_stop_wait(
         eprintln!("[agentsview] timed out waiting for sidecar to stop before update install");
     }
     terminated
+}
+
+fn request_sidecar_stop(process: &SidecarProcess) -> io::Result<()> {
+    request_process_stop(process.child.pid())
+}
+
+#[cfg(windows)]
+fn request_process_stop(pid: u32) -> io::Result<()> {
+    let status = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "taskkill failed for pid {pid} with status {status}"
+        )))
+    }
+}
+
+#[cfg(unix)]
+fn request_process_stop(pid: u32) -> io::Result<()> {
+    let status = std::process::Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "kill failed for pid {pid} with status {status}"
+        )))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn request_process_stop(pid: u32) -> io::Result<()> {
+    Err(io::Error::other(format!(
+        "stopping pid {pid} is unsupported on this platform"
+    )))
 }
 
 fn restart_backend_after_update(handle: AppHandle) {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ struct SidecarState {
     backend_port: Mutex<Option<u16>>,
     active_generation: Mutex<Option<u64>>,
     stopping_generation: Mutex<Option<u64>>,
+    restart_after_stop_timeout_generation: Mutex<Option<u64>>,
     terminated_generation: Mutex<u64>,
     termination: Condvar,
     next_generation: AtomicU64,
@@ -557,6 +558,9 @@ fn save_sidecar(app: &AppHandle, child: CommandChild) -> Result<u64, DynError> {
     if let Ok(mut stopping_generation) = state.stopping_generation.lock() {
         *stopping_generation = None;
     }
+    if let Ok(mut restart_generation) = state.restart_after_stop_timeout_generation.lock() {
+        *restart_generation = None;
+    }
     Ok(generation)
 }
 
@@ -635,6 +639,23 @@ fn clear_stopping_generation_if_current(state: &SidecarState, generation: u64) {
     if *guard == Some(generation) {
         *guard = None;
     }
+}
+
+fn mark_restart_after_stop_timeout(state: &SidecarState, generation: u64) {
+    if let Ok(mut guard) = state.restart_after_stop_timeout_generation.lock() {
+        *guard = Some(generation);
+    }
+}
+
+fn take_restart_after_stop_timeout_if_current(state: &SidecarState, generation: u64) -> bool {
+    let Ok(mut guard) = state.restart_after_stop_timeout_generation.lock() else {
+        return false;
+    };
+    if *guard == Some(generation) {
+        *guard = None;
+        return true;
+    }
+    false
 }
 
 fn record_sidecar_terminated(state: &SidecarState, generation: u64) {
@@ -728,12 +749,18 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u6
                         "[agentsview] sidecar terminated (code: {:?}, signal: {:?})",
                         payload.code, payload.signal
                     );
-                    let state = window.app_handle().state::<SidecarState>();
+                    let handle = window.app_handle().clone();
+                    let state = handle.state::<SidecarState>();
+                    let restart_after_stop_timeout =
+                        take_restart_after_stop_timeout_if_current(&state, generation);
                     if handle_sidecar_terminated(&state, startup_handled.as_ref(), generation) {
                         let _ = window.eval(
                             "window.__setStatus(\
                              'AgentsView backend exited before startup completed.');",
                         );
+                    }
+                    if restart_after_stop_timeout {
+                        restart_backend_after_update(handle);
                     }
                     break;
                 }
@@ -1248,6 +1275,7 @@ fn finish_backend_stop_wait(
         clear_stopping_generation_if_current(state, generation);
         clear_sidecar_port(app);
     } else {
+        mark_restart_after_stop_timeout(state, generation);
         eprintln!("[agentsview] timed out waiting for sidecar to stop before update install");
     }
     terminated
@@ -1522,6 +1550,17 @@ mod tests {
         // Termination handling is idempotent for state and should only
         // report first-time transition once.
         assert!(!handle_sidecar_terminated(&state, &startup_handled, 1));
+    }
+
+    #[test]
+    fn restart_after_stop_timeout_is_consumed_for_matching_generation() {
+        let state = SidecarState::default();
+
+        mark_restart_after_stop_timeout(&state, 2);
+
+        assert!(!take_restart_after_stop_timeout_if_current(&state, 1));
+        assert!(take_restart_after_stop_timeout_if_current(&state, 2));
+        assert!(!take_restart_after_stop_timeout_if_current(&state, 2));
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -807,14 +807,14 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u6
                     );
                     let handle = window.app_handle().clone();
                     let state = handle.state::<SidecarState>();
-                    let restart_after_stop_timeout =
-                        take_restart_after_stop_timeout_for_terminated_sidecar(&state, generation);
                     if handle_sidecar_terminated(&state, startup_handled.as_ref(), generation) {
                         let _ = window.eval(
                             "window.__setStatus(\
                              'AgentsView backend exited before startup completed.');",
                         );
                     }
+                    let restart_after_stop_timeout =
+                        take_restart_after_stop_timeout_for_terminated_sidecar(&state, generation);
                     if restart_after_stop_timeout {
                         restart_backend_after_update(handle);
                     }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1318,6 +1318,8 @@ fn stop_backend_inner(app: &AppHandle, wait_timeout: Option<Duration>) -> bool {
     };
     if let Some(process) = process.as_ref() {
         let _ = mark_sidecar_inactive_if_current(&state, process.generation);
+        clear_restart_after_stop_timeout_if_current(&state, process.generation);
+        clear_stopping_generation_if_current(&state, process.generation);
     }
 
     if let Some(process) = process {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1054,11 +1054,12 @@ async fn check_for_updates(handle: &AppHandle, silent: bool) {
     } else {
         None
     };
+    let backend_stopped_for_update = windows_backend_stopped == Some(true);
 
     if let Err(err) = install_downloaded_update(
         update_bytes,
         windows_backend_stopped,
-        || restart_backend_after_update_failure(handle),
+        || restart_backend_after_update(handle.clone()),
         |bytes| update.install(bytes),
     ) {
         eprintln!("[agentsview] update install failed: {err}");
@@ -1081,10 +1082,18 @@ async fn check_for_updates(handle: &AppHandle, silent: bool) {
     )
     .await;
 
-    if restart {
-        let _ = handle.emit("restart", ());
-        handle.restart();
-    }
+    let emit_handle = handle.clone();
+    let restart_handle = handle.clone();
+    let backend_handle = handle.clone();
+    finish_successful_update(
+        backend_stopped_for_update,
+        restart,
+        || {
+            let _ = emit_handle.emit("restart", ());
+        },
+        || restart_handle.restart(),
+        || restart_backend_after_update(backend_handle),
+    );
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1125,6 +1134,25 @@ where
             }
             Err(InstallDownloadedUpdateError::Install(err))
         }
+    }
+}
+
+fn finish_successful_update<E, A, B>(
+    backend_stopped_for_update: bool,
+    restart_confirmed: bool,
+    emit_restart: E,
+    restart_app: A,
+    restart_backend: B,
+) where
+    E: FnOnce(),
+    A: FnOnce(),
+    B: FnOnce(),
+{
+    if restart_confirmed {
+        emit_restart();
+        restart_app();
+    } else if backend_stopped_for_update {
+        restart_backend();
     }
 }
 
@@ -1225,9 +1253,9 @@ fn finish_backend_stop_wait(
     terminated
 }
 
-fn restart_backend_after_update_failure(handle: &AppHandle) {
-    if let Err(err) = launch_backend_from_handle(handle) {
-        eprintln!("[agentsview] failed to restart backend after update failure: {err}");
+fn restart_backend_after_update(handle: AppHandle) {
+    if let Err(err) = launch_backend_from_handle(&handle) {
+        eprintln!("[agentsview] failed to restart backend after update: {err}");
     }
 }
 
@@ -1577,6 +1605,24 @@ mod tests {
         assert_eq!(
             events.lock().expect("lock events").as_slice(),
             ["install", "restart"]
+        );
+    }
+
+    #[test]
+    fn finish_successful_update_restarts_backend_when_windows_restart_is_declined() {
+        let events = Mutex::new(Vec::new());
+
+        finish_successful_update(
+            true,
+            false,
+            || events.lock().expect("lock events").push("emit-restart"),
+            || events.lock().expect("lock events").push("restart-app"),
+            || events.lock().expect("lock events").push("restart-backend"),
+        );
+
+        assert_eq!(
+            events.lock().expect("lock events").as_slice(),
+            ["restart-backend"]
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -7,8 +7,8 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::net::{Ipv4Addr, SocketAddrV4, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -27,14 +27,24 @@ const PREFERRED_PORT: u16 = 8080;
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(125);
 const LOGIN_SHELL_ENV_TIMEOUT: Duration = Duration::from_secs(3);
+const UPDATE_SIDECAR_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 
 type DynError = Box<dyn Error>;
 type CommandRx = Receiver<CommandEvent>;
 
 #[derive(Default)]
 struct SidecarState {
-    child: Mutex<Option<CommandChild>>,
+    child: Mutex<Option<SidecarProcess>>,
     backend_port: Mutex<Option<u16>>,
+    active_generation: Mutex<Option<u64>>,
+    terminated_generation: Mutex<u64>,
+    termination: Condvar,
+    next_generation: AtomicU64,
+}
+
+struct SidecarProcess {
+    child: CommandChild,
+    generation: u64,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -94,9 +104,10 @@ pub fn run() {
 
 fn launch_backend(app: &mut App) -> Result<(), DynError> {
     let window = main_window(app)?;
-    let (rx, child) = spawn_sidecar(app)?;
+    let handle = app.handle().clone();
+    let (rx, child) = spawn_sidecar(&handle)?;
 
-    save_sidecar(app, child)?;
+    let generation = save_sidecar(&handle, child)?;
 
     let focus_window = window.clone();
     let focus_handle = app.handle().clone();
@@ -114,12 +125,20 @@ fn launch_backend(app: &mut App) -> Result<(), DynError> {
         }
     });
 
-    forward_sidecar_logs(rx, window);
+    forward_sidecar_logs(rx, window, generation);
 
     Ok(())
 }
 
-fn spawn_sidecar(app: &App) -> Result<(CommandRx, CommandChild), DynError> {
+fn launch_backend_from_handle(handle: &AppHandle) -> Result<(), DynError> {
+    let window = main_window_from_handle(handle)?;
+    let (rx, child) = spawn_sidecar(handle)?;
+    let generation = save_sidecar(handle, child)?;
+    forward_sidecar_logs(rx, window, generation);
+    Ok(())
+}
+
+fn spawn_sidecar(app: &AppHandle) -> Result<(CommandRx, CommandChild), DynError> {
     let port_arg = PREFERRED_PORT.to_string();
     let mut command = app.shell().sidecar("agentsview")?;
     for (key, value) in sidecar_env() {
@@ -523,14 +542,18 @@ where
     Some(PathBuf::from(combined))
 }
 
-fn save_sidecar(app: &App, child: CommandChild) -> Result<(), DynError> {
+fn save_sidecar(app: &AppHandle, child: CommandChild) -> Result<u64, DynError> {
     let state = app.state::<SidecarState>();
+    let generation = state.next_generation.fetch_add(1, Ordering::SeqCst) + 1;
     let mut guard = state
         .child
         .lock()
         .map_err(|_| io::Error::other("sidecar state lock poisoned"))?;
-    *guard = Some(child);
-    Ok(())
+    *guard = Some(SidecarProcess { child, generation });
+    if let Ok(mut active_generation) = state.active_generation.lock() {
+        *active_generation = Some(generation);
+    }
+    Ok(generation)
 }
 
 fn save_sidecar_port(app: &AppHandle, port: u16) {
@@ -549,12 +572,80 @@ fn set_sidecar_port(state: &SidecarState, port: Option<u16>) {
     }
 }
 
-fn handle_sidecar_terminated(state: &SidecarState, startup_handled: &AtomicBool) -> bool {
-    set_sidecar_port(state, None);
+fn handle_sidecar_terminated(
+    state: &SidecarState,
+    startup_handled: &AtomicBool,
+    generation: u64,
+) -> bool {
+    if mark_sidecar_inactive_if_current(state, generation) {
+        set_sidecar_port(state, None);
+    }
+    clear_sidecar_child_if_current(state, generation);
+    record_sidecar_terminated(state, generation);
     !startup_handled.swap(true, Ordering::SeqCst)
 }
 
-fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow) {
+fn mark_sidecar_inactive_if_current(state: &SidecarState, generation: u64) -> bool {
+    let Ok(mut guard) = state.active_generation.lock() else {
+        return false;
+    };
+    if *guard == Some(generation) {
+        *guard = None;
+        return true;
+    }
+    false
+}
+
+fn clear_sidecar_child_if_current(state: &SidecarState, generation: u64) {
+    let Ok(mut guard) = state.child.lock() else {
+        return;
+    };
+    if guard
+        .as_ref()
+        .map(|process| process.generation)
+        .is_some_and(|active_generation| active_generation == generation)
+    {
+        *guard = None;
+    }
+}
+
+fn record_sidecar_terminated(state: &SidecarState, generation: u64) {
+    if let Ok(mut guard) = state.terminated_generation.lock() {
+        if *guard < generation {
+            *guard = generation;
+        }
+        state.termination.notify_all();
+    }
+}
+
+fn wait_for_sidecar_termination(state: &SidecarState, generation: u64, timeout: Duration) -> bool {
+    let Ok(mut guard) = state.terminated_generation.lock() else {
+        return false;
+    };
+    let deadline = Instant::now() + timeout;
+    loop {
+        if *guard >= generation {
+            return true;
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        match state.termination.wait_timeout(guard, remaining) {
+            Ok((next_guard, result)) => {
+                guard = next_guard;
+                if result.timed_out() && *guard < generation {
+                    return false;
+                }
+            }
+            Err(_) => return false,
+        }
+    }
+}
+
+fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u64) {
     let startup_handled = Arc::new(AtomicBool::new(false));
     let first_output = Arc::new(AtomicBool::new(false));
     let timeout_window = window.clone();
@@ -610,7 +701,7 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow) {
                         payload.code, payload.signal
                     );
                     let state = window.app_handle().state::<SidecarState>();
-                    if handle_sidecar_terminated(&state, startup_handled.as_ref()) {
+                    if handle_sidecar_terminated(&state, startup_handled.as_ref(), generation) {
                         let _ = window.eval(
                             "window.__setStatus(\
                              'AgentsView backend exited before startup completed.');",
@@ -629,6 +720,12 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow) {
 
 fn main_window(app: &App) -> Result<WebviewWindow, DynError> {
     app.get_webview_window("main")
+        .ok_or_else(|| io::Error::other("missing main window").into())
+}
+
+fn main_window_from_handle(handle: &AppHandle) -> Result<WebviewWindow, DynError> {
+    handle
+        .get_webview_window("main")
         .ok_or_else(|| io::Error::other("missing main window").into())
 }
 
@@ -928,8 +1025,9 @@ async fn check_for_updates(handle: &AppHandle, silent: bool) {
         cfg!(target_os = "windows"),
         || {
             // Windows locks the bundled sidecar executable while it is running.
-            stop_backend(handle);
+            stop_backend_and_wait(handle, UPDATE_SIDECAR_STOP_TIMEOUT)
         },
+        || restart_backend_after_update_failure(handle),
         |bytes| update.install(bytes),
     ) {
         eprintln!("[agentsview] update install failed: {err}");
@@ -958,20 +1056,50 @@ async fn check_for_updates(handle: &AppHandle, silent: bool) {
     }
 }
 
-fn install_downloaded_update<S, I, E>(
+#[derive(Debug, PartialEq, Eq)]
+enum InstallDownloadedUpdateError<E> {
+    BackendStopTimedOut,
+    Install(E),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for InstallDownloadedUpdateError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BackendStopTimedOut => write!(f, "backend did not stop before update install"),
+            Self::Install(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl<E: std::fmt::Debug + std::fmt::Display> Error for InstallDownloadedUpdateError<E> {}
+
+fn install_downloaded_update<S, R, I, E>(
     update_bytes: Vec<u8>,
     is_windows: bool,
     stop_backend: S,
+    restart_backend: R,
     install: I,
-) -> Result<(), E>
+) -> Result<(), InstallDownloadedUpdateError<E>>
 where
-    S: FnOnce(),
+    S: FnOnce() -> bool,
+    R: FnOnce(),
     I: FnOnce(Vec<u8>) -> Result<(), E>,
 {
     if is_windows {
-        stop_backend();
+        if !stop_backend() {
+            restart_backend();
+            return Err(InstallDownloadedUpdateError::BackendStopTimedOut);
+        }
     }
-    install(update_bytes)
+    match install(update_bytes) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            if is_windows {
+                restart_backend();
+            }
+            Err(InstallDownloadedUpdateError::Install(err))
+        }
+    }
 }
 
 async fn dialog_confirm(handle: &AppHandle, title: &str, message: &str) -> bool {
@@ -990,17 +1118,49 @@ async fn dialog_confirm(handle: &AppHandle, title: &str, message: &str) -> bool 
 }
 
 fn stop_backend(app: &AppHandle) {
-    let state = app.state::<SidecarState>();
-    let Ok(mut guard) = state.child.lock() else {
-        return;
-    };
+    let _ = stop_backend_inner(app, None);
+}
 
-    if let Some(child) = guard.take() {
-        if let Err(err) = child.kill() {
+fn stop_backend_and_wait(app: &AppHandle, timeout: Duration) -> bool {
+    stop_backend_inner(app, Some(timeout))
+}
+
+fn stop_backend_inner(app: &AppHandle, wait_timeout: Option<Duration>) -> bool {
+    let state = app.state::<SidecarState>();
+    let process = {
+        let Ok(mut guard) = state.child.lock() else {
+            return false;
+        };
+        guard.take()
+    };
+    if let Some(process) = process.as_ref() {
+        let _ = mark_sidecar_inactive_if_current(&state, process.generation);
+    }
+
+    if let Some(process) = process {
+        if let Err(err) = process.child.kill() {
             eprintln!("[agentsview] failed to stop sidecar: {err}");
         }
+        clear_sidecar_port(app);
+        if let Some(timeout) = wait_timeout {
+            let terminated = wait_for_sidecar_termination(&state, process.generation, timeout);
+            if !terminated {
+                eprintln!(
+                    "[agentsview] timed out waiting for sidecar to stop before update install"
+                );
+            }
+            return terminated;
+        }
+        return true;
     }
     clear_sidecar_port(app);
+    true
+}
+
+fn restart_backend_after_update_failure(handle: &AppHandle) {
+    if let Err(err) = launch_backend_from_handle(handle) {
+        eprintln!("[agentsview] failed to restart backend after update failure: {err}");
+    }
 }
 
 fn wait_for_server(port: u16, timeout: Duration) -> bool {
@@ -1234,9 +1394,13 @@ mod tests {
     fn handle_sidecar_terminated_clears_port_and_marks_startup() {
         let state = SidecarState::default();
         set_sidecar_port(&state, Some(18080));
+        *state
+            .active_generation
+            .lock()
+            .expect("lock active_generation") = Some(1);
         let startup_handled = AtomicBool::new(false);
 
-        assert!(handle_sidecar_terminated(&state, &startup_handled));
+        assert!(handle_sidecar_terminated(&state, &startup_handled, 1));
         assert_eq!(
             state
                 .backend_port
@@ -1249,7 +1413,7 @@ mod tests {
 
         // Termination handling is idempotent for state and should only
         // report first-time transition once.
-        assert!(!handle_sidecar_terminated(&state, &startup_handled));
+        assert!(!handle_sidecar_terminated(&state, &startup_handled, 1));
     }
 
     #[test]
@@ -1259,7 +1423,11 @@ mod tests {
         let result = install_downloaded_update(
             b"update-bytes".to_vec(),
             true,
-            || events.lock().expect("lock events").push("stop"),
+            || {
+                events.lock().expect("lock events").push("stop");
+                true
+            },
+            || events.lock().expect("lock events").push("restart"),
             |bytes| {
                 assert_eq!(bytes, b"update-bytes");
                 events.lock().expect("lock events").push("install");
@@ -1281,7 +1449,11 @@ mod tests {
         let result = install_downloaded_update(
             b"update-bytes".to_vec(),
             false,
-            || events.lock().expect("lock events").push("stop"),
+            || {
+                events.lock().expect("lock events").push("stop");
+                true
+            },
+            || events.lock().expect("lock events").push("restart"),
             |bytes| {
                 assert_eq!(bytes, b"update-bytes");
                 events.lock().expect("lock events").push("install");
@@ -1291,6 +1463,63 @@ mod tests {
 
         assert_eq!(result, Ok(()));
         assert_eq!(events.lock().expect("lock events").as_slice(), ["install"]);
+    }
+
+    #[test]
+    fn install_downloaded_update_skips_install_and_restarts_backend_when_windows_stop_times_out() {
+        let events = Mutex::new(Vec::new());
+
+        let result = install_downloaded_update(
+            b"update-bytes".to_vec(),
+            true,
+            || {
+                events.lock().expect("lock events").push("stop");
+                false
+            },
+            || events.lock().expect("lock events").push("restart"),
+            |_| {
+                events.lock().expect("lock events").push("install");
+                Ok::<(), ()>(())
+            },
+        );
+
+        assert_eq!(
+            result,
+            Err(InstallDownloadedUpdateError::BackendStopTimedOut)
+        );
+        assert_eq!(
+            events.lock().expect("lock events").as_slice(),
+            ["stop", "restart"]
+        );
+    }
+
+    #[test]
+    fn install_downloaded_update_restarts_backend_after_windows_install_failure() {
+        let events = Mutex::new(Vec::new());
+
+        let result = install_downloaded_update(
+            b"update-bytes".to_vec(),
+            true,
+            || {
+                events.lock().expect("lock events").push("stop");
+                true
+            },
+            || events.lock().expect("lock events").push("restart"),
+            |bytes| {
+                assert_eq!(bytes, b"update-bytes");
+                events.lock().expect("lock events").push("install");
+                Err::<(), &str>("install failed")
+            },
+        );
+
+        assert_eq!(
+            result,
+            Err(InstallDownloadedUpdateError::Install("install failed"))
+        );
+        assert_eq!(
+            events.lock().expect("lock events").as_slice(),
+            ["stop", "install", "restart"]
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -906,7 +906,29 @@ async fn check_for_updates(handle: &AppHandle, silent: bool) {
         return;
     }
 
-    if let Err(err) = update.download_and_install(|_, _| {}, || {}).await {
+    let update_bytes = match update.download(|_, _| {}, || {}).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            eprintln!("[agentsview] update download failed: {err}");
+            let h = handle.clone();
+            handle
+                .dialog()
+                .message(
+                    "Failed to download the update. \
+                     Please try downloading manually from the releases page.",
+                )
+                .title("Update Failed")
+                .show(move |_| restore_webview_focus(&h));
+            return;
+        }
+    };
+
+    if should_stop_backend_before_update_install(cfg!(target_os = "windows")) {
+        // Windows locks the bundled sidecar executable while it is running.
+        stop_backend(handle);
+    }
+
+    if let Err(err) = update.install(update_bytes) {
         eprintln!("[agentsview] update install failed: {err}");
         let h = handle.clone();
         handle
@@ -931,6 +953,10 @@ async fn check_for_updates(handle: &AppHandle, silent: bool) {
         let _ = handle.emit("restart", ());
         handle.restart();
     }
+}
+
+fn should_stop_backend_before_update_install(is_windows: bool) -> bool {
+    is_windows
 }
 
 async fn dialog_confirm(handle: &AppHandle, title: &str, message: &str) -> bool {
@@ -1209,6 +1235,12 @@ mod tests {
         // Termination handling is idempotent for state and should only
         // report first-time transition once.
         assert!(!handle_sidecar_terminated(&state, &startup_handled));
+    }
+
+    #[test]
+    fn should_stop_backend_before_update_install_only_on_windows() {
+        assert!(should_stop_backend_before_update_install(true));
+        assert!(!should_stop_backend_before_update_install(false));
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1020,13 +1020,16 @@ async fn check_for_updates(handle: &AppHandle, silent: bool) {
         }
     };
 
+    let windows_backend_stopped = if cfg!(target_os = "windows") {
+        // Windows locks the bundled sidecar executable while it is running.
+        Some(stop_backend_and_wait(handle.clone(), UPDATE_SIDECAR_STOP_TIMEOUT).await)
+    } else {
+        None
+    };
+
     if let Err(err) = install_downloaded_update(
         update_bytes,
-        cfg!(target_os = "windows"),
-        || {
-            // Windows locks the bundled sidecar executable while it is running.
-            stop_backend_and_wait(handle, UPDATE_SIDECAR_STOP_TIMEOUT)
-        },
+        windows_backend_stopped,
         || restart_backend_after_update_failure(handle),
         |bytes| update.install(bytes),
     ) {
@@ -1073,27 +1076,23 @@ impl<E: std::fmt::Display> std::fmt::Display for InstallDownloadedUpdateError<E>
 
 impl<E: std::fmt::Debug + std::fmt::Display> Error for InstallDownloadedUpdateError<E> {}
 
-fn install_downloaded_update<S, R, I, E>(
+fn install_downloaded_update<R, I, E>(
     update_bytes: Vec<u8>,
-    is_windows: bool,
-    stop_backend: S,
+    windows_backend_stopped: Option<bool>,
     restart_backend: R,
     install: I,
 ) -> Result<(), InstallDownloadedUpdateError<E>>
 where
-    S: FnOnce() -> bool,
     R: FnOnce(),
     I: FnOnce(Vec<u8>) -> Result<(), E>,
 {
-    if is_windows {
-        if !stop_backend() {
-            return Err(InstallDownloadedUpdateError::BackendStopTimedOut);
-        }
+    if windows_backend_stopped == Some(false) {
+        return Err(InstallDownloadedUpdateError::BackendStopTimedOut);
     }
     match install(update_bytes) {
         Ok(()) => Ok(()),
         Err(err) => {
-            if is_windows {
+            if windows_backend_stopped.is_some() {
                 restart_backend();
             }
             Err(InstallDownloadedUpdateError::Install(err))
@@ -1120,12 +1119,40 @@ fn stop_backend(app: &AppHandle) {
     let _ = stop_backend_inner(app, None);
 }
 
-fn stop_backend_and_wait(app: &AppHandle, timeout: Duration) -> bool {
-    stop_backend_inner(app, Some(timeout))
+async fn stop_backend_and_wait(app: AppHandle, timeout: Duration) -> bool {
+    tauri::async_runtime::spawn_blocking(move || stop_backend_inner(&app, Some(timeout)))
+        .await
+        .unwrap_or(false)
 }
 
 fn stop_backend_inner(app: &AppHandle, wait_timeout: Option<Duration>) -> bool {
     let state = app.state::<SidecarState>();
+    if let Some(timeout) = wait_timeout {
+        let process = {
+            let Ok(mut guard) = state.child.lock() else {
+                return false;
+            };
+            guard.take()
+        };
+        let Some(process) = process else {
+            clear_sidecar_port(app);
+            return true;
+        };
+        let generation = process.generation;
+        if let Err(err) = process.child.kill() {
+            eprintln!("[agentsview] failed to stop sidecar: {err}");
+        }
+        let terminated = wait_for_sidecar_termination(&state, generation, timeout);
+        if terminated {
+            let _ = mark_sidecar_inactive_if_current(&state, generation);
+            clear_sidecar_child_if_current(&state, generation);
+            clear_sidecar_port(app);
+        } else {
+            eprintln!("[agentsview] timed out waiting for sidecar to stop before update install");
+        }
+        return terminated;
+    }
+
     let process = {
         let Ok(mut guard) = state.child.lock() else {
             return false;
@@ -1141,15 +1168,6 @@ fn stop_backend_inner(app: &AppHandle, wait_timeout: Option<Duration>) -> bool {
             eprintln!("[agentsview] failed to stop sidecar: {err}");
         }
         clear_sidecar_port(app);
-        if let Some(timeout) = wait_timeout {
-            let terminated = wait_for_sidecar_termination(&state, process.generation, timeout);
-            if !terminated {
-                eprintln!(
-                    "[agentsview] timed out waiting for sidecar to stop before update install"
-                );
-            }
-            return terminated;
-        }
         return true;
     }
     clear_sidecar_port(app);
@@ -1416,16 +1434,12 @@ mod tests {
     }
 
     #[test]
-    fn install_downloaded_update_stops_backend_before_install_on_windows() {
+    fn install_downloaded_update_installs_after_windows_backend_stop() {
         let events = Mutex::new(Vec::new());
 
         let result = install_downloaded_update(
             b"update-bytes".to_vec(),
-            true,
-            || {
-                events.lock().expect("lock events").push("stop");
-                true
-            },
+            Some(true),
             || events.lock().expect("lock events").push("restart"),
             |bytes| {
                 assert_eq!(bytes, b"update-bytes");
@@ -1435,23 +1449,16 @@ mod tests {
         );
 
         assert_eq!(result, Ok(()));
-        assert_eq!(
-            events.lock().expect("lock events").as_slice(),
-            ["stop", "install"]
-        );
+        assert_eq!(events.lock().expect("lock events").as_slice(), ["install"]);
     }
 
     #[test]
-    fn install_downloaded_update_does_not_stop_backend_on_non_windows() {
+    fn install_downloaded_update_installs_without_backend_stop_on_non_windows() {
         let events = Mutex::new(Vec::new());
 
         let result = install_downloaded_update(
             b"update-bytes".to_vec(),
-            false,
-            || {
-                events.lock().expect("lock events").push("stop");
-                true
-            },
+            None,
             || events.lock().expect("lock events").push("restart"),
             |bytes| {
                 assert_eq!(bytes, b"update-bytes");
@@ -1470,11 +1477,7 @@ mod tests {
 
         let result = install_downloaded_update(
             b"update-bytes".to_vec(),
-            true,
-            || {
-                events.lock().expect("lock events").push("stop");
-                false
-            },
+            Some(false),
             || events.lock().expect("lock events").push("restart"),
             |_| {
                 events.lock().expect("lock events").push("install");
@@ -1486,7 +1489,7 @@ mod tests {
             result,
             Err(InstallDownloadedUpdateError::BackendStopTimedOut)
         );
-        assert_eq!(events.lock().expect("lock events").as_slice(), ["stop"]);
+        assert!(events.lock().expect("lock events").is_empty());
     }
 
     #[test]
@@ -1495,11 +1498,7 @@ mod tests {
 
         let result = install_downloaded_update(
             b"update-bytes".to_vec(),
-            true,
-            || {
-                events.lock().expect("lock events").push("stop");
-                true
-            },
+            Some(true),
             || events.lock().expect("lock events").push("restart"),
             |bytes| {
                 assert_eq!(bytes, b"update-bytes");
@@ -1514,7 +1513,7 @@ mod tests {
         );
         assert_eq!(
             events.lock().expect("lock events").as_slice(),
-            ["stop", "install", "restart"]
+            ["install", "restart"]
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1087,7 +1087,6 @@ where
 {
     if is_windows {
         if !stop_backend() {
-            restart_backend();
             return Err(InstallDownloadedUpdateError::BackendStopTimedOut);
         }
     }
@@ -1466,7 +1465,7 @@ mod tests {
     }
 
     #[test]
-    fn install_downloaded_update_skips_install_and_restarts_backend_when_windows_stop_times_out() {
+    fn install_downloaded_update_does_not_restart_after_windows_stop_timeout() {
         let events = Mutex::new(Vec::new());
 
         let result = install_downloaded_update(
@@ -1487,10 +1486,7 @@ mod tests {
             result,
             Err(InstallDownloadedUpdateError::BackendStopTimedOut)
         );
-        assert_eq!(
-            events.lock().expect("lock events").as_slice(),
-            ["stop", "restart"]
-        );
+        assert_eq!(events.lock().expect("lock events").as_slice(), ["stop"]);
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::net::{Ipv4Addr, SocketAddrV4, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -39,6 +39,7 @@ struct SidecarState {
     active_generation: Mutex<Option<u64>>,
     stopping_generation: Mutex<Option<u64>>,
     restart_after_stop_timeout_generation: Mutex<Option<u64>>,
+    active_update_stop_waiters: AtomicUsize,
     terminated_generation: Mutex<u64>,
     termination: Condvar,
     next_generation: AtomicU64,
@@ -647,6 +648,14 @@ fn mark_restart_after_stop_timeout(state: &SidecarState, generation: u64) {
     }
 }
 
+fn clear_restart_after_stop_timeout_if_current(state: &SidecarState, generation: u64) {
+    if let Ok(mut guard) = state.restart_after_stop_timeout_generation.lock() {
+        if *guard == Some(generation) {
+            *guard = None;
+        }
+    }
+}
+
 fn take_restart_after_stop_timeout_if_current(state: &SidecarState, generation: u64) -> bool {
     let Ok(mut guard) = state.restart_after_stop_timeout_generation.lock() else {
         return false;
@@ -658,6 +667,46 @@ fn take_restart_after_stop_timeout_if_current(state: &SidecarState, generation: 
     false
 }
 
+fn begin_update_stop_wait(state: &SidecarState) {
+    state
+        .active_update_stop_waiters
+        .fetch_add(1, Ordering::SeqCst);
+}
+
+fn end_update_stop_wait(state: &SidecarState) {
+    let previous = state
+        .active_update_stop_waiters
+        .fetch_sub(1, Ordering::SeqCst);
+    debug_assert!(previous > 0);
+}
+
+fn has_active_update_stop_waiter(state: &SidecarState) -> bool {
+    state.active_update_stop_waiters.load(Ordering::SeqCst) > 0
+}
+
+fn take_restart_after_stop_timeout_for_terminated_sidecar(
+    state: &SidecarState,
+    generation: u64,
+) -> bool {
+    if has_active_update_stop_waiter(state) {
+        return false;
+    }
+    take_restart_after_stop_timeout_if_current(state, generation)
+}
+
+fn restart_backend_after_stop_timeout_if_terminated(
+    app: &AppHandle,
+    state: &SidecarState,
+    generation: u64,
+) {
+    if !sidecar_generation_terminated(state, generation) {
+        return;
+    }
+    if take_restart_after_stop_timeout_for_terminated_sidecar(state, generation) {
+        restart_backend_after_update(app.clone());
+    }
+}
+
 fn record_sidecar_terminated(state: &SidecarState, generation: u64) {
     if let Ok(mut guard) = state.terminated_generation.lock() {
         if *guard < generation {
@@ -665,6 +714,13 @@ fn record_sidecar_terminated(state: &SidecarState, generation: u64) {
         }
         state.termination.notify_all();
     }
+}
+
+fn sidecar_generation_terminated(state: &SidecarState, generation: u64) -> bool {
+    state
+        .terminated_generation
+        .lock()
+        .is_ok_and(|guard| *guard >= generation)
 }
 
 fn wait_for_sidecar_termination(state: &SidecarState, generation: u64, timeout: Duration) -> bool {
@@ -752,7 +808,7 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u6
                     let handle = window.app_handle().clone();
                     let state = handle.state::<SidecarState>();
                     let restart_after_stop_timeout =
-                        take_restart_after_stop_timeout_if_current(&state, generation);
+                        take_restart_after_stop_timeout_for_terminated_sidecar(&state, generation);
                     if handle_sidecar_terminated(&state, startup_handled.as_ref(), generation) {
                         let _ = window.eval(
                             "window.__setStatus(\
@@ -1211,35 +1267,45 @@ async fn stop_backend_and_wait(app: AppHandle, timeout: Duration) -> bool {
 fn stop_backend_inner(app: &AppHandle, wait_timeout: Option<Duration>) -> bool {
     let state = app.state::<SidecarState>();
     if let Some(timeout) = wait_timeout {
+        begin_update_stop_wait(&state);
+        let mut waited_generation = None;
         let process = {
             let Ok(mut guard) = state.child.lock() else {
+                end_update_stop_wait(&state);
                 return false;
             };
             guard.take()
         };
-        let Some(process) = process else {
-            if let Some(generation) = current_stopping_generation(&state) {
-                return finish_backend_stop_wait(
-                    app,
-                    &state,
-                    generation,
-                    wait_for_sidecar_termination(&state, generation, timeout),
-                );
+        let stopped = if let Some(process) = process {
+            let generation = process.generation;
+            waited_generation = Some(generation);
+            mark_sidecar_stopping(&state, generation);
+            if let Err(err) = process.child.kill() {
+                eprintln!("[agentsview] failed to stop sidecar: {err}");
             }
+            finish_backend_stop_wait(
+                app,
+                &state,
+                generation,
+                wait_for_sidecar_termination(&state, generation, timeout),
+            )
+        } else if let Some(generation) = current_stopping_generation(&state) {
+            waited_generation = Some(generation);
+            finish_backend_stop_wait(
+                app,
+                &state,
+                generation,
+                wait_for_sidecar_termination(&state, generation, timeout),
+            )
+        } else {
             clear_sidecar_port(app);
-            return true;
+            true
         };
-        let generation = process.generation;
-        mark_sidecar_stopping(&state, generation);
-        if let Err(err) = process.child.kill() {
-            eprintln!("[agentsview] failed to stop sidecar: {err}");
+        end_update_stop_wait(&state);
+        if let Some(generation) = waited_generation {
+            restart_backend_after_stop_timeout_if_terminated(app, &state, generation);
         }
-        return finish_backend_stop_wait(
-            app,
-            &state,
-            generation,
-            wait_for_sidecar_termination(&state, generation, timeout),
-        );
+        return stopped;
     }
 
     let process = {
@@ -1270,6 +1336,7 @@ fn finish_backend_stop_wait(
     terminated: bool,
 ) -> bool {
     if terminated {
+        clear_restart_after_stop_timeout_if_current(state, generation);
         let _ = mark_sidecar_inactive_if_current(state, generation);
         clear_sidecar_child_if_current(state, generation);
         clear_stopping_generation_if_current(state, generation);
@@ -1561,6 +1628,24 @@ mod tests {
         assert!(!take_restart_after_stop_timeout_if_current(&state, 1));
         assert!(take_restart_after_stop_timeout_if_current(&state, 2));
         assert!(!take_restart_after_stop_timeout_if_current(&state, 2));
+    }
+
+    #[test]
+    fn restart_after_stop_timeout_waits_for_active_update_stop_waiter() {
+        let state = SidecarState::default();
+
+        mark_restart_after_stop_timeout(&state, 2);
+        begin_update_stop_wait(&state);
+
+        assert!(!take_restart_after_stop_timeout_for_terminated_sidecar(
+            &state, 2
+        ));
+
+        end_update_stop_wait(&state);
+
+        assert!(take_restart_after_stop_timeout_for_terminated_sidecar(
+            &state, 2
+        ));
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -923,12 +923,15 @@ async fn check_for_updates(handle: &AppHandle, silent: bool) {
         }
     };
 
-    if should_stop_backend_before_update_install(cfg!(target_os = "windows")) {
-        // Windows locks the bundled sidecar executable while it is running.
-        stop_backend(handle);
-    }
-
-    if let Err(err) = update.install(update_bytes) {
+    if let Err(err) = install_downloaded_update(
+        update_bytes,
+        cfg!(target_os = "windows"),
+        || {
+            // Windows locks the bundled sidecar executable while it is running.
+            stop_backend(handle);
+        },
+        |bytes| update.install(bytes),
+    ) {
         eprintln!("[agentsview] update install failed: {err}");
         let h = handle.clone();
         handle
@@ -955,8 +958,20 @@ async fn check_for_updates(handle: &AppHandle, silent: bool) {
     }
 }
 
-fn should_stop_backend_before_update_install(is_windows: bool) -> bool {
-    is_windows
+fn install_downloaded_update<S, I, E>(
+    update_bytes: Vec<u8>,
+    is_windows: bool,
+    stop_backend: S,
+    install: I,
+) -> Result<(), E>
+where
+    S: FnOnce(),
+    I: FnOnce(Vec<u8>) -> Result<(), E>,
+{
+    if is_windows {
+        stop_backend();
+    }
+    install(update_bytes)
 }
 
 async fn dialog_confirm(handle: &AppHandle, title: &str, message: &str) -> bool {
@@ -1238,9 +1253,44 @@ mod tests {
     }
 
     #[test]
-    fn should_stop_backend_before_update_install_only_on_windows() {
-        assert!(should_stop_backend_before_update_install(true));
-        assert!(!should_stop_backend_before_update_install(false));
+    fn install_downloaded_update_stops_backend_before_install_on_windows() {
+        let events = Mutex::new(Vec::new());
+
+        let result = install_downloaded_update(
+            b"update-bytes".to_vec(),
+            true,
+            || events.lock().expect("lock events").push("stop"),
+            |bytes| {
+                assert_eq!(bytes, b"update-bytes");
+                events.lock().expect("lock events").push("install");
+                Ok::<(), ()>(())
+            },
+        );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(
+            events.lock().expect("lock events").as_slice(),
+            ["stop", "install"]
+        );
+    }
+
+    #[test]
+    fn install_downloaded_update_does_not_stop_backend_on_non_windows() {
+        let events = Mutex::new(Vec::new());
+
+        let result = install_downloaded_update(
+            b"update-bytes".to_vec(),
+            false,
+            || events.lock().expect("lock events").push("stop"),
+            |bytes| {
+                assert_eq!(bytes, b"update-bytes");
+                events.lock().expect("lock events").push("install");
+                Ok::<(), ()>(())
+            },
+        );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(events.lock().expect("lock events").as_slice(), ["install"]);
     }
 
     #[test]

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -86,7 +86,7 @@ func setupWithServerOpts(
 	opts ...setupOption,
 ) *testEnv {
 	t.Helper()
-	dir := t.TempDir()
+	dir := tempDirWithRetryCleanup(t)
 	dbPath := filepath.Join(dir, "test.db")
 
 	database, err := db.Open(dbPath)
@@ -179,7 +179,7 @@ func setupWithServerOpts(
 // engine or live-refresh broadcaster.
 func setupPGMode(t *testing.T) *testEnv {
 	t.Helper()
-	dir := t.TempDir()
+	dir := tempDirWithRetryCleanup(t)
 	dbPath := filepath.Join(dir, "test.db")
 
 	database, err := db.Open(dbPath)
@@ -227,6 +227,26 @@ func setupPGMode(t *testing.T) *testEnv {
 		broadcaster: nil,
 		dataDir:     dir,
 	}
+}
+
+func tempDirWithRetryCleanup(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "agentsview-server-test-*")
+	if err != nil {
+		t.Fatalf("creating temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		var removeErr error
+		for range 20 {
+			removeErr = os.RemoveAll(dir)
+			if removeErr == nil {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		t.Errorf("removing temp dir %s: %v", dir, removeErr)
+	})
+	return dir
 }
 
 func (te *testEnv) writeProjectFile(


### PR DESCRIPTION
## Summary
- fix Windows desktop self-update by downloading the update before stopping the bundled Go sidecar
- stop the sidecar only immediately before Tauri installs the downloaded update on Windows, so `agentsview.exe` is not locked
- replace the weak platform helper test with tests that assert stop/install ordering on Windows and non-Windows behavior

## Root Cause
The Tauri desktop app launches the Go backend as a bundled sidecar. On Windows, the running sidecar keeps `agentsview.exe` locked, so Tauri's installer cannot replace it during a desktop update.

Fixes #485.

## Validation
- `mise exec -- cargo fmt --check`
- `mise exec -- go test ./internal/update`
- `cargo test install_downloaded_update` through `VsDevCmd.bat` after preparing `desktop/src-tauri/binaries/agentsview-x86_64-pc-windows-msvc.exe`