### PR TITLE
Clarify insight generation in read-only mode

### DIFF
--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -491,6 +491,7 @@ describe("generateInsight SSE parsing", () => {
         ok: false,
         status: 500,
         body: null,
+        text: () => Promise.resolve(""),
       }),
     );
 
@@ -503,6 +504,42 @@ describe("generateInsight SSE parsing", () => {
     activeHandles.push(handle);
 
     await expect(handle.done).rejects.toThrow("500");
+  });
+
+  it("surfaces backend error text on non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 501,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              error:
+                "insight generation is not available in read-only mode",
+            }),
+          ),
+      }),
+    );
+
+    const { generateInsight } = await import("./client.js");
+    const handle = generateInsight({
+      type: "daily_activity",
+      date_from: "2025-01-15",
+      date_to: "2025-01-15",
+    });
+    activeHandles.push(handle);
+
+    try {
+      await handle.done;
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as InstanceType<typeof ApiError>).status).toBe(501);
+      expect((e as InstanceType<typeof ApiError>).message).toBe(
+        "insight generation is not available in read-only mode",
+      );
+    }
   });
 });
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -117,14 +117,36 @@ export class ApiError extends Error {
 }
 
 function apiErrorMessage(status: number, body: string): string {
-  return body.trim() || `API ${status}`;
+  const text = body.trim();
+  if (!text) return `API ${status}`;
+
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "error" in parsed &&
+      typeof parsed.error === "string" &&
+      parsed.error
+    ) {
+      return parsed.error;
+    }
+  } catch {
+    // Plain-text error body.
+  }
+
+  return text;
+}
+
+async function responseErrorMessage(res: Response): Promise<string> {
+  const body = await res.text().catch(() => "");
+  return apiErrorMessage(res.status, body);
 }
 
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${getBase()}${path}`, authHeaders(init));
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
   return res.json() as Promise<T>;
 }
@@ -694,8 +716,7 @@ export async function starSession(id: string): Promise<void> {
     method: "PUT",
   }));
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
 }
 
@@ -704,8 +725,7 @@ export async function unstarSession(id: string): Promise<void> {
     method: "DELETE",
   }));
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
 }
 
@@ -718,8 +738,7 @@ export async function bulkStarSessions(
     body: JSON.stringify({ session_ids: sessionIds }),
   }));
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
 }
 
@@ -871,8 +890,7 @@ export async function deleteWorktreeMapping(id: number): Promise<void> {
     authHeaders({ method: "DELETE" }),
   );
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
 }
 
@@ -1022,8 +1040,7 @@ export async function deleteInsight(id: number): Promise<void> {
     method: "DELETE",
   }));
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
 }
 
@@ -1052,8 +1069,11 @@ export function generateInsight(
       signal: controller.signal,
     }));
 
-    if (!res.ok || !res.body) {
-      throw new Error(`Generate request failed: ${res.status}`);
+    if (!res.ok) {
+      throw new ApiError(res.status, await responseErrorMessage(res));
+    }
+    if (!res.body) {
+      throw new Error("Generate request failed: empty response");
     }
 
     const reader = res.body.getReader();
@@ -1163,8 +1183,7 @@ export async function deleteSession(id: string): Promise<void> {
     method: "DELETE",
   }));
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
 }
 
@@ -1173,8 +1192,7 @@ export async function restoreSession(id: string): Promise<void> {
     method: "POST",
   }));
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
 }
 
@@ -1185,8 +1203,7 @@ export async function permanentDeleteSession(
     method: "DELETE",
   }));
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
 }
 
@@ -1353,8 +1370,7 @@ export async function unpinMessage(
     authHeaders({ method: "DELETE" }),
   );
   if (!res.ok) {
-    const body = await res.text();
-    throw new ApiError(res.status, apiErrorMessage(res.status, body));
+    throw new ApiError(res.status, await responseErrorMessage(res));
   }
 }
 

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -3,6 +3,7 @@ export interface VersionInfo {
   version: string;
   commit: string;
   build_date: string;
+  read_only?: boolean;
 }
 
 /** Matches Go Session struct in internal/db/sessions.go */

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { insights } from "../../stores/insights.svelte.js";
   import { sessions } from "../../stores/sessions.svelte.js";
+  import { sync } from "../../stores/sync.svelte.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import type { InsightType, AgentName } from "../../api/types.js";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
@@ -12,6 +13,12 @@
     | "agent_analysis";
 
   let promptExpanded = $state(false);
+  const readOnly = $derived(
+    sync.serverVersion?.read_only === true,
+  );
+  const generationUnavailable = $derived(
+    sync.serverVersion === null || readOnly,
+  );
 
   const uiMode: UIMode = $derived.by(() => {
     if (insights.type === "agent_analysis") {
@@ -96,6 +103,7 @@
   }
 
   function handleGenerate() {
+    if (generationUnavailable) return;
     insights.generate();
   }
 
@@ -249,7 +257,12 @@
         <button
           class="generate-btn"
           onclick={handleGenerate}
-          disabled={insights.loading}
+          disabled={insights.loading || generationUnavailable}
+          title={readOnly
+            ? "Unavailable in read-only remote mode"
+            : sync.serverVersion === null
+              ? "Waiting for server version"
+              : "Generate insight"}
         >
           <svg
             class="generate-icon"
@@ -263,6 +276,11 @@
           Generate
         </button>
       </div>
+      {#if readOnly}
+        <div class="readonly-note">
+          Read-only remote mode cannot save generated insights.
+        </div>
+      {/if}
     </div>
 
     <div class="list-area">
@@ -736,6 +754,13 @@
 
   .generate-icon {
     opacity: 0.9;
+  }
+
+  .readonly-note {
+    padding: 4px 2px 0;
+    font-size: 10px;
+    line-height: 1.35;
+    color: var(--text-muted);
   }
 
   /* ── List Area ── */


### PR DESCRIPTION
## Summary

- surface backend JSON error messages through `ApiError`, including failed insight generation requests
- reuse the shared response error helper across custom API methods
- disable Insights generation until server mode is known and explain read-only remote mode

## Tracking

Refs https://github.com/tpn/agentsview/issues/1

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage npm --prefix frontend test -- src/lib/api/client.test.ts`
- `npm --prefix frontend run check`
- `npm --prefix frontend run build`
- Roborev 3-agent reviews for `d99ba5a`: codex job 1193, claude-code job 1194, gemini job 1195; all passed
- Roborev 3-agent reviews for `d8fe988`: codex job 1196, claude-code job 1197, gemini job 1198; all passed

Co-Authored-By: GPT-5 Codex <codex@openai.com>