### PR TITLE
Add Normal/Focused transcript mode to HTML exports

### DIFF
--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -283,11 +283,13 @@ type exportData struct {
 }
 
 type exportMessage struct {
-	RoleClass   string
-	ExtraClass  string
-	Role        string
-	Timestamp   string
-	ContentHTML template.HTML
+	Ordinal       int
+	RoleClass     string
+	ExtraClass    string
+	Role          string
+	Timestamp     string
+	ContentHTML   template.HTML
+	FocusedHidden bool
 }
 
 var exportTmpl = template.Must(
@@ -458,6 +460,9 @@ main { max-width: 900px; margin: 0 auto; padding: 16px; }
   margin-bottom: 4px; font-style: normal;
 }
 .message.thinking-only { display: none; }
+#transcript-focused:checked ~ main .message.focused-hidden {
+  display: none;
+}
 #thinking-toggle:checked ~ main .thinking-block {
   display: block;
 }
@@ -487,6 +492,8 @@ main { max-width: 900px; margin: 0 auto; padding: 16px; }
   color: var(--text-primary);
   cursor: pointer; font-size: 11px;
 }
+#transcript-normal:checked ~ header label[for="transcript-normal"],
+#transcript-focused:checked ~ header label[for="transcript-focused"],
 #thinking-toggle:checked ~ header label[for="thinking-toggle"],
 #sort-toggle:checked ~ header label[for="sort-toggle"] {
   background: var(--accent-blue); color: #fff;
@@ -515,6 +522,8 @@ footer a:hover { text-decoration: underline; }
 </style>
 </head>
 <body>
+<input type="radio" id="transcript-normal" name="transcript-mode" class="toggle-input" checked>
+<input type="radio" id="transcript-focused" name="transcript-mode" class="toggle-input">
 <input type="checkbox" id="thinking-toggle" class="toggle-input">
 <input type="checkbox" id="sort-toggle" class="toggle-input">
 <header>
@@ -528,6 +537,8 @@ footer a:hover { text-decoration: underline; }
   </div>
 </div>
 <div class="controls">
+  <label for="transcript-normal" class="toggle-label">Normal</label>
+  <label for="transcript-focused" class="toggle-label">Focused</label>
   <label for="thinking-toggle" class="toggle-label">Thinking</label>
   <label for="sort-toggle" class="toggle-label">Newest first</label>
   <button class="theme-btn" onclick="document.documentElement.classList.toggle('dark');this.textContent=document.documentElement.classList.contains('dark')?'Light':'Dark'">Dark</button>
@@ -536,7 +547,7 @@ footer a:hover { text-decoration: underline; }
 </header>
 <main><div class="messages">
 {{- range .Messages}}
-<div class="message {{.RoleClass}}{{.ExtraClass}}"><div class="message-header"><span class="message-role">{{.Role}}</span><span class="message-time">{{.Timestamp}}</span></div><div class="message-content">{{.ContentHTML}}</div></div>
+<div class="message {{.RoleClass}}{{.ExtraClass}}{{if .FocusedHidden}} focused-hidden{{end}}" data-ordinal="{{.Ordinal}}"><div class="message-header"><span class="message-role">{{.Role}}</span><span class="message-time">{{.Timestamp}}</span></div><div class="message-content">{{.ContentHTML}}</div></div>
 {{- end}}
 </div></main>
 <footer>Exported from <a href="https://github.com/wesm/agentsview">agentsview</a></footer>
@@ -565,6 +576,7 @@ func generateExportHTML(
 		Messages:     make([]exportMessage, len(msgs)),
 	}
 
+	focusedVisible := focusedExportOrdinals(msgs)
 	for i, m := range msgs {
 		roleClass := "unknown"
 		if m.Role == "user" || m.Role == "assistant" {
@@ -576,11 +588,13 @@ func generateExportHTML(
 		}
 
 		data.Messages[i] = exportMessage{
-			RoleClass:   roleClass,
-			ExtraClass:  extraClass,
-			Role:        m.Role,
-			Timestamp:   formatTimestamp(m.Timestamp),
-			ContentHTML: template.HTML(formatContentForExport(m.Content)),
+			Ordinal:       m.Ordinal,
+			RoleClass:     roleClass,
+			ExtraClass:    extraClass,
+			Role:          m.Role,
+			Timestamp:     formatTimestamp(m.Timestamp),
+			ContentHTML:   template.HTML(formatContentForExport(m.Content)),
+			FocusedHidden: !focusedVisible[m.Ordinal],
 		}
 	}
 
@@ -599,11 +613,7 @@ var (
 	thinkingLegacyRe = regexp.MustCompile(
 		`(?s)\[Thinking\]\n?(.*?)(?:\n\[|\n\n|$)`)
 	toolBlockRe = regexp.MustCompile(
-		`(?s)\[(Tool|Read|Write|Edit|Bash|Glob|Grep|Task|Agent|` +
-			`Question|Todo List|Entering Plan Mode|` +
-			`Exiting Plan Mode|exec_command|shell_command|` +
-			`write_stdin|apply_patch|shell|parallel|` +
-			`view_image|request_user_input|update_plan` +
+		`(?s)\[(` + markdownToolNames +
 			`)([^\]]*)\](.*?)(?:\n\[|\n\n|$)`)
 )
 
@@ -628,6 +638,71 @@ func isThinkingOnly(content string) bool {
 	without := thinkingMarkedRe.ReplaceAllString(content, "")
 	without = thinkingLegacyRe.ReplaceAllString(without, "")
 	return strings.TrimSpace(without) == ""
+}
+
+func focusedExportOrdinals(msgs []db.Message) map[int]bool {
+	visible := make(map[int]bool, len(msgs))
+	pendingOrdinal := 0
+	hasPendingAssistant := false
+	toolAfterPendingAssistant := false
+
+	flushPending := func() {
+		if hasPendingAssistant && !toolAfterPendingAssistant {
+			visible[pendingOrdinal] = true
+		}
+		hasPendingAssistant = false
+		toolAfterPendingAssistant = false
+	}
+
+	for _, m := range msgs {
+		if isExportToolOnly(m) {
+			if hasPendingAssistant {
+				toolAfterPendingAssistant = true
+			}
+			continue
+		}
+
+		if m.IsCompactBoundary {
+			flushPending()
+			visible[m.Ordinal] = true
+			continue
+		}
+
+		if m.Role == "user" {
+			flushPending()
+			visible[m.Ordinal] = true
+			continue
+		}
+
+		// Match the app's focused transcript mode: consecutive
+		// assistant-like messages collapse to the last visible answer.
+		pendingOrdinal = m.Ordinal
+		hasPendingAssistant = true
+		toolAfterPendingAssistant = false
+	}
+
+	flushPending()
+	return visible
+}
+
+func isExportToolOnly(m db.Message) bool {
+	if m.Role != "assistant" || !m.HasToolUse {
+		return false
+	}
+	for _, segment := range parseMarkdownSegments(m) {
+		switch segment.Type {
+		case markdownSegmentThinking, markdownSegmentTool:
+			continue
+		case markdownSegmentText:
+			if strings.TrimSpace(segment.Content) == "" {
+				continue
+			}
+			return false
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // parseTimestamp tries RFC3339Nano then RFC3339.

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -460,14 +460,14 @@ main { max-width: 900px; margin: 0 auto; padding: 16px; }
   margin-bottom: 4px; font-style: normal;
 }
 .message.thinking-only { display: none; }
-#transcript-focused:checked ~ main .message.focused-hidden {
-  display: none;
-}
 #thinking-toggle:checked ~ main .thinking-block {
   display: block;
 }
 #thinking-toggle:checked ~ main .message.thinking-only {
   display: block;
+}
+#transcript-focused:checked ~ main .message.focused-hidden {
+  display: none;
 }
 .tool-block {
   border-left: 2px solid var(--accent-amber);
@@ -613,7 +613,7 @@ var (
 	thinkingLegacyRe = regexp.MustCompile(
 		`(?s)\[Thinking\]\n?(.*?)(?:\n\[|\n\n|$)`)
 	toolBlockRe = regexp.MustCompile(
-		`(?s)\[(` + markdownToolNames +
+		`(?s)\[(` + exportToolNames +
 			`)([^\]]*)\](.*?)(?:\n\[|\n\n|$)`)
 )
 
@@ -655,16 +655,20 @@ func focusedExportOrdinals(msgs []db.Message) map[int]bool {
 	}
 
 	for _, m := range msgs {
+		if m.IsCompactBoundary {
+			flushPending()
+			visible[m.Ordinal] = true
+			continue
+		}
+
+		if m.IsSystem || isThinkingOnly(m.Content) {
+			continue
+		}
+
 		if isExportToolOnly(m) {
 			if hasPendingAssistant {
 				toolAfterPendingAssistant = true
 			}
-			continue
-		}
-
-		if m.IsCompactBoundary {
-			flushPending()
-			visible[m.Ordinal] = true
 			continue
 		}
 

--- a/internal/server/export_markdown.go
+++ b/internal/server/export_markdown.go
@@ -164,11 +164,13 @@ var (
 	mdCodeBlockRe      = regexp.MustCompile("(?s)```(\\w*)\\n(.*?)```")
 )
 
-const markdownToolNames = "Tool|Read|Write|Edit|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Agent|Skill|" +
+const exportToolNames = "Tool|Read|Write|Edit|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Agent|" +
 	"SendMessage|Question|Todo List|Entering Plan Mode|" +
 	"Exiting Plan Mode|exec_command|shell_command|" +
 	"write_stdin|apply_patch|shell|parallel|view_image|" +
 	"request_user_input|update_plan"
+
+const markdownToolNames = exportToolNames + "|Skill"
 
 var (
 	mdToolAliases = map[string]string{

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -461,6 +462,168 @@ func TestGenerateExportHTML_NilStartedAt(t *testing.T) {
 	html := generateExportHTML(session, nil)
 	if !strings.Contains(html, "<!DOCTYPE html>") {
 		t.Error("expected valid HTML even with nil StartedAt")
+	}
+}
+
+func TestGenerateExportHTML_TranscriptModeControls(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{
+		{
+			SessionID: "test-id", Ordinal: 0,
+			Role: "user", Content: "Please inspect",
+			Timestamp: "2025-01-15T10:00:00Z",
+		},
+		{
+			SessionID: "test-id", Ordinal: 1,
+			Role: "assistant", Content: "I'll check that",
+			Timestamp: "2025-01-15T10:00:01Z",
+		},
+		{
+			SessionID: "test-id", Ordinal: 2,
+			Role: "assistant", Content: "[Bash]\nls",
+			Timestamp:  "2025-01-15T10:00:02Z",
+			HasToolUse: true,
+		},
+		{
+			SessionID: "test-id", Ordinal: 3,
+			Role: "assistant", Content: "The answer",
+			Timestamp: "2025-01-15T10:00:03Z",
+		},
+	}
+
+	html := generateExportHTML(session, msgs)
+
+	assertContainsAll(t, html, []string{
+		`id="transcript-normal" name="transcript-mode" class="toggle-input" checked`,
+		`id="transcript-focused" name="transcript-mode" class="toggle-input"`,
+		`<label for="transcript-normal" class="toggle-label">Normal</label>`,
+		`<label for="transcript-focused" class="toggle-label">Focused</label>`,
+		`#transcript-focused:checked ~ main .message.focused-hidden`,
+		`class="message assistant focused-hidden" data-ordinal="1"`,
+		`class="message assistant focused-hidden" data-ordinal="2"`,
+		`class="message assistant" data-ordinal="3"`,
+	})
+	assertContainsNone(t, html, []string{
+		`class="message user focused-hidden" data-ordinal="0"`,
+		`class="message assistant focused-hidden" data-ordinal="3"`,
+	})
+}
+
+func TestFocusedExportOrdinals(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		msgs []db.Message
+		want []int
+	}{
+		{
+			name: "keeps final assistant before next user",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				exportAssistantMsg(1, "working"),
+				exportToolMsg(2, "[Read]\nfile"),
+				exportAssistantMsg(3, "final"),
+				exportUserMsg(4),
+			},
+			want: []int{0, 3, 4},
+		},
+		{
+			name: "drops terminal tool-only stretch",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				exportToolMsg(1, "[Bash]\nmake test"),
+			},
+			want: []int{0},
+		},
+		{
+			name: "drops consecutive tool blocks in one message",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				exportToolMsg(1, "[Read]\nold\n[Write]\nnew"),
+			},
+			want: []int{0},
+		},
+		{
+			name: "keeps terminal final assistant",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				exportToolMsg(1, "[Bash]\nmake test"),
+				exportAssistantMsg(2, "done"),
+			},
+			want: []int{0, 2},
+		},
+		{
+			name: "keeps only last assistant in consecutive assistant run",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				exportAssistantMsg(1, "first"),
+				exportAssistantMsg(2, "second"),
+				exportUserMsg(3),
+			},
+			want: []int{0, 2, 3},
+		},
+		{
+			name: "keeps answer before compact boundary",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				exportAssistantMsg(1, "answer"),
+				{
+					SessionID:         "test-id",
+					Ordinal:           2,
+					Role:              "assistant",
+					Content:           "[compact summary]",
+					IsCompactBoundary: true,
+				},
+				exportUserMsg(3),
+			},
+			want: []int{0, 1, 2, 3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			visible := focusedExportOrdinals(tt.msgs)
+			got := make([]int, 0, len(tt.msgs))
+			for _, msg := range tt.msgs {
+				if visible[msg.Ordinal] {
+					got = append(got, msg.Ordinal)
+				}
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("visible ordinals = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func exportUserMsg(ordinal int) db.Message {
+	return db.Message{
+		SessionID: "test-id",
+		Ordinal:   ordinal,
+		Role:      "user",
+		Content:   "user",
+	}
+}
+
+func exportAssistantMsg(ordinal int, content string) db.Message {
+	return db.Message{
+		SessionID: "test-id",
+		Ordinal:   ordinal,
+		Role:      "assistant",
+		Content:   content,
+	}
+}
+
+func exportToolMsg(ordinal int, content string) db.Message {
+	return db.Message{
+		SessionID:   "test-id",
+		Ordinal:     ordinal,
+		Role:        "assistant",
+		Content:     content,
+		HasToolUse:  true,
+		HasThinking: strings.Contains(content, "[Thinking]"),
 	}
 }
 

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -260,8 +260,20 @@ func TestFormatContentForExport_Escaping(t *testing.T) {
 			nil,
 		},
 		{
+			"SkillBlock",
+			"[Skill: planner]\nuse the plan\n[/Skill]",
+			[]string{"[Skill: planner]"},
+			[]string{`class="tool-block"`},
+		},
+		{
 			"BashToolBlock",
 			"[Bash ls -la]\noutput",
+			[]string{`class="tool-block"`},
+			nil,
+		},
+		{
+			"TaskCreateToolBlock",
+			"[TaskCreate: worker]\nrun task",
 			[]string{`class="tool-block"`},
 			nil,
 		},
@@ -504,6 +516,15 @@ func TestGenerateExportHTML_TranscriptModeControls(t *testing.T) {
 		`class="message assistant focused-hidden" data-ordinal="2"`,
 		`class="message assistant" data-ordinal="3"`,
 	})
+	if strings.Index(
+		html,
+		`#transcript-focused:checked ~ main .message.focused-hidden`,
+	) < strings.Index(
+		html,
+		`#thinking-toggle:checked ~ main .message.thinking-only`,
+	) {
+		t.Error("focused hide rule must follow thinking display rule")
+	}
 	assertContainsNone(t, html, []string{
 		`class="message user focused-hidden" data-ordinal="0"`,
 		`class="message assistant focused-hidden" data-ordinal="3"`,
@@ -564,6 +585,38 @@ func TestFocusedExportOrdinals(t *testing.T) {
 			want: []int{0, 2, 3},
 		},
 		{
+			name: "ignores thinking-only tail after final assistant",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				exportAssistantMsg(1, "answer"),
+				exportAssistantMsg(2, "[Thinking]\nfollow-up notes"),
+			},
+			want: []int{0, 1},
+		},
+		{
+			name: "ignores system messages",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				exportAssistantMsg(1, "answer"),
+				{
+					SessionID: "test-id",
+					Ordinal:   2,
+					Role:      "assistant",
+					Content:   "system progress",
+					IsSystem:  true,
+				},
+				{
+					SessionID: "test-id",
+					Ordinal:   3,
+					Role:      "user",
+					Content:   "system user event",
+					IsSystem:  true,
+				},
+				exportUserMsg(4),
+			},
+			want: []int{0, 1, 4},
+		},
+		{
 			name: "keeps answer before compact boundary",
 			msgs: []db.Message{
 				exportUserMsg(0),
@@ -573,6 +626,7 @@ func TestFocusedExportOrdinals(t *testing.T) {
 					Ordinal:           2,
 					Role:              "assistant",
 					Content:           "[compact summary]",
+					IsSystem:          true,
 					IsCompactBoundary: true,
 				},
 				exportUserMsg(3),


### PR DESCRIPTION
## Summary
- add Normal/Focused transcript controls to standalone HTML exports
- default exports to Normal so current behavior is preserved
- hide tool-only and superseded assistant/progress messages in Focused mode using self-contained CSS
- reuse the markdown segment parser for robust tool-only detection

Fixes #508

## Testing
- GOTOOLCHAIN=auto go test ./internal/server -run 'ExportHTML|ExportTemplate|FocusedExport' -count=1\n- GOTOOLCHAIN=auto go test ./internal/server -count=1\n- roborev 3-agent review on c4b1b32: codex, claude-code, gemini all passed