### PR TITLE
feat: add postgres curation metadata

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -65,13 +65,13 @@ type Store interface {
 	GetTopSessionsByCost(ctx context.Context, f UsageFilter, limit int) ([]TopSessionEntry, error)
 	GetUsageSessionCounts(ctx context.Context, f UsageFilter) (UsageSessionCounts, error)
 
-	// Stars (local-only; PG returns ErrReadOnly).
+	// Stars.
 	StarSession(sessionID string) (bool, error)
 	UnstarSession(sessionID string) error
 	ListStarredSessionIDs(ctx context.Context) ([]string, error)
 	BulkStarSessions(sessionIDs []string) error
 
-	// Pins (local-only; PG returns ErrReadOnly).
+	// Pins.
 	PinMessage(sessionID string, messageID int64, note *string) (int64, error)
 	UnpinMessage(sessionID string, messageID int64) error
 	ListPinnedMessages(ctx context.Context, sessionID string, project string) ([]PinnedMessage, error)

--- a/internal/postgres/curation.go
+++ b/internal/postgres/curation.go
@@ -113,6 +113,9 @@ func (s *Store) BulkStarSessions(sessionIDs []string) error {
 
 // PinMessage creates or updates a shared PG pin for a message. PG
 // exposes message IDs as the message ordinal, matching scanPGMessages.
+// On conflict, ordinal and source_uuid are refreshed from the current
+// message so the pin tracks whatever is at message_id today;
+// created_at is preserved by being absent from the SET clause.
 func (s *Store) PinMessage(
 	sessionID string, messageID int64, note *string,
 ) (int64, error) {
@@ -127,7 +130,10 @@ func (s *Store) PinMessage(
 			FROM messages m
 			WHERE m.session_id = $1 AND m.ordinal = $2
 			ON CONFLICT (session_id, message_id)
-			DO UPDATE SET note = EXCLUDED.note
+			DO UPDATE SET
+				note = EXCLUDED.note,
+				ordinal = EXCLUDED.ordinal,
+				source_uuid = EXCLUDED.source_uuid
 			RETURNING id
 		)
 		SELECT id FROM upsert`,

--- a/internal/postgres/curation.go
+++ b/internal/postgres/curation.go
@@ -1,0 +1,238 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// StarSession marks a session as starred in the shared PG dashboard
+// metadata. Returns false when the session does not exist.
+func (s *Store) StarSession(sessionID string) (bool, error) {
+	res, err := s.pg.Exec(`
+		INSERT INTO starred_sessions (session_id)
+		SELECT $1 WHERE EXISTS (
+			SELECT 1 FROM sessions WHERE id = $1
+		)
+		ON CONFLICT (session_id) DO NOTHING`,
+		sessionID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("starring session %s: %w", sessionID, err)
+	}
+	n, _ := res.RowsAffected()
+	if n > 0 {
+		return true, nil
+	}
+
+	var exists int
+	err = s.pg.QueryRow(
+		`SELECT 1 FROM sessions WHERE id = $1`,
+		sessionID,
+	).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("checking session %s: %w", sessionID, err)
+	}
+	return true, nil
+}
+
+// UnstarSession removes a session star from the shared PG dashboard
+// metadata.
+func (s *Store) UnstarSession(sessionID string) error {
+	if _, err := s.pg.Exec(
+		`DELETE FROM starred_sessions WHERE session_id = $1`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf("unstarring session %s: %w", sessionID, err)
+	}
+	return nil
+}
+
+// ListStarredSessionIDs returns shared PG-starred session IDs.
+func (s *Store) ListStarredSessionIDs(
+	ctx context.Context,
+) ([]string, error) {
+	rows, err := s.pg.QueryContext(ctx, `
+		SELECT session_id
+		FROM starred_sessions
+		ORDER BY created_at DESC, session_id DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("listing starred sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning starred session: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// BulkStarSessions stars multiple existing sessions in one transaction.
+// Unknown session IDs are skipped.
+func (s *Store) BulkStarSessions(sessionIDs []string) error {
+	if len(sessionIDs) == 0 {
+		return nil
+	}
+
+	tx, err := s.pg.Begin()
+	if err != nil {
+		return fmt.Errorf("beginning star transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO starred_sessions (session_id)
+		SELECT $1 WHERE EXISTS (
+			SELECT 1 FROM sessions WHERE id = $1
+		)
+		ON CONFLICT (session_id) DO NOTHING`)
+	if err != nil {
+		return fmt.Errorf("preparing star statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, id := range sessionIDs {
+		if _, err := stmt.Exec(id); err != nil {
+			return fmt.Errorf("starring session %s: %w", id, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// PinMessage creates or updates a shared PG pin for a message. PG
+// exposes message IDs as the message ordinal, matching scanPGMessages.
+func (s *Store) PinMessage(
+	sessionID string, messageID int64, note *string,
+) (int64, error) {
+	var id int64
+	err := s.pg.QueryRow(`
+		WITH upsert AS (
+			INSERT INTO pinned_messages (
+				session_id, message_id, ordinal, source_uuid, note
+			)
+			SELECT $1, m.ordinal, m.ordinal,
+				COALESCE(m.source_uuid, ''), $3
+			FROM messages m
+			WHERE m.session_id = $1 AND m.ordinal = $2
+			ON CONFLICT (session_id, message_id)
+			DO UPDATE SET note = EXCLUDED.note
+			RETURNING id
+		)
+		SELECT id FROM upsert`,
+		sessionID, messageID, note,
+	).Scan(&id)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("pinning message: %w", err)
+	}
+	return id, nil
+}
+
+// UnpinMessage removes a shared PG pin.
+func (s *Store) UnpinMessage(sessionID string, messageID int64) error {
+	if _, err := s.pg.Exec(
+		`DELETE FROM pinned_messages
+		 WHERE session_id = $1 AND message_id = $2`,
+		sessionID, messageID,
+	); err != nil {
+		return fmt.Errorf("unpinning message: %w", err)
+	}
+	return nil
+}
+
+// ListPinnedMessages returns shared PG pins, optionally filtered by
+// session or project. All-pins results include message and session
+// metadata for the pinned page.
+func (s *Store) ListPinnedMessages(
+	ctx context.Context, sessionID string, project string,
+) ([]db.PinnedMessage, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if sessionID != "" {
+		rows, err = s.pg.QueryContext(ctx, `
+			SELECT id, session_id, message_id, ordinal, note, created_at
+			FROM pinned_messages
+			WHERE session_id = $1
+			ORDER BY created_at DESC, id DESC`,
+			sessionID,
+		)
+	} else {
+		query := `
+			SELECT p.id, p.session_id, p.message_id, p.ordinal,
+				p.note, p.created_at, m.content, m.role,
+				s.project, s.agent, s.display_name, s.first_message
+			FROM pinned_messages p
+			JOIN sessions s
+				ON p.session_id = s.id
+				AND s.deleted_at IS NULL
+			LEFT JOIN messages m
+				ON m.session_id = p.session_id
+				AND m.ordinal = p.message_id`
+		args := []any{}
+		if project != "" {
+			query += " WHERE s.project = $1"
+			args = append(args, project)
+		}
+		query += " ORDER BY p.created_at DESC, p.id DESC LIMIT 500"
+		rows, err = s.pg.QueryContext(ctx, query, args...)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("listing pinned messages: %w", err)
+	}
+	defer rows.Close()
+
+	var pins []db.PinnedMessage
+	withContent := sessionID == ""
+	for rows.Next() {
+		p, scanErr := scanPGPinnedMessage(rows, withContent)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		pins = append(pins, p)
+	}
+	return pins, rows.Err()
+}
+
+func scanPGPinnedMessage(
+	rs interface{ Scan(dest ...any) error },
+	withContent bool,
+) (db.PinnedMessage, error) {
+	var p db.PinnedMessage
+	var createdAt time.Time
+	var err error
+	if withContent {
+		err = rs.Scan(
+			&p.ID, &p.SessionID, &p.MessageID,
+			&p.Ordinal, &p.Note, &createdAt,
+			&p.Content, &p.Role,
+			&p.SessionProject, &p.SessionAgent,
+			&p.SessionDisplayName, &p.SessionFirstMessage,
+		)
+	} else {
+		err = rs.Scan(
+			&p.ID, &p.SessionID, &p.MessageID,
+			&p.Ordinal, &p.Note, &createdAt,
+		)
+	}
+	if err != nil {
+		return p, fmt.Errorf("scanning pinned message: %w", err)
+	}
+	p.CreatedAt = FormatISO8601(createdAt)
+	return p, nil
+}

--- a/internal/postgres/curation_pgtest_test.go
+++ b/internal/postgres/curation_pgtest_test.go
@@ -555,3 +555,239 @@ func TestReconcilePinnedMessagesPrunesPinWhenSourceUUIDGone(t *testing.T) {
 		)
 	}
 }
+
+// TestReconcilePinnedMessagesKeepsPinOnLaterDuplicateSourceUUID
+// covers the case where multiple messages in the same session share
+// the same source_uuid (the schema permits it) and the pin sits on
+// the later duplicate. Reconciliation must keep the pin where it is
+// rather than relocating it to the lowest-ordinal duplicate.
+func TestReconcilePinnedMessagesKeepsPinOnLaterDuplicateSourceUUID(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_pin_dup_uuid_test"
+	pg, err := Open(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer pg.Close()
+	defer func() {
+		_, _ = pg.ExecContext(
+			context.Background(),
+			`DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+		)
+	}()
+
+	ctx := context.Background()
+	if _, err := pg.ExecContext(
+		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+	); err != nil {
+		t.Fatalf("drop schema: %v", err)
+	}
+	if err := EnsureSchema(ctx, pg, schema); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO sessions
+			(id, machine, project, agent, first_message,
+			 started_at, message_count, user_message_count)
+		VALUES
+			('pg-pin-dup-uuid', 'machine-a', 'proj-curation',
+			 'claude', 'duplicate source uuid',
+			 '2026-05-01T00:00:00Z'::timestamptz, 3, 1)`,
+	); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO messages
+			(session_id, ordinal, role, content, timestamp,
+			 content_length, source_uuid)
+		VALUES
+			('pg-pin-dup-uuid', 0, 'user', 'question',
+			 '2026-05-01T00:00:00Z'::timestamptz, 8,
+			 'uuid-question'),
+			('pg-pin-dup-uuid', 1, 'assistant', 'first answer',
+			 '2026-05-01T00:00:01Z'::timestamptz, 12,
+			 'uuid-shared'),
+			('pg-pin-dup-uuid', 2, 'assistant', 'second answer',
+			 '2026-05-01T00:00:02Z'::timestamptz, 13,
+			 'uuid-shared')`,
+	); err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO pinned_messages
+			(session_id, message_id, ordinal, source_uuid,
+			 note, created_at)
+		VALUES
+			('pg-pin-dup-uuid', 2, 2, 'uuid-shared',
+			 'pin on later duplicate',
+			 '2026-05-01T00:01:00Z'::timestamptz)`,
+	); err != nil {
+		t.Fatalf("insert pin: %v", err)
+	}
+
+	tx, err := pg.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if err := reconcilePinnedMessages(
+		ctx, tx, "pg-pin-dup-uuid",
+	); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("reconcilePinnedMessages: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit tx: %v", err)
+	}
+
+	store, err := NewStore(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	pins, err := store.ListPinnedMessages(ctx, "pg-pin-dup-uuid", "")
+	if err != nil {
+		t.Fatalf("ListPinnedMessages: %v", err)
+	}
+	if len(pins) != 1 {
+		t.Fatalf("pins = %d, want 1: %v", len(pins), pins)
+	}
+	if pins[0].MessageID != 2 || pins[0].Ordinal != 2 {
+		t.Fatalf(
+			"pin message/ordinal = %d/%d, want 2/2 (must not "+
+				"relocate to lower-ordinal duplicate)",
+			pins[0].MessageID, pins[0].Ordinal,
+		)
+	}
+}
+
+// TestPinMessageRepinRefreshesSourceUUID covers re-pinning the same
+// (session_id, message_id). The stored source_uuid must reflect the
+// message currently at message_id; otherwise the next reconciliation
+// would follow the stale uuid away from where the user just pinned.
+func TestPinMessageRepinRefreshesSourceUUID(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_pin_repin_test"
+	pg, err := Open(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer pg.Close()
+	defer func() {
+		_, _ = pg.ExecContext(
+			context.Background(),
+			`DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+		)
+	}()
+
+	ctx := context.Background()
+	if _, err := pg.ExecContext(
+		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+	); err != nil {
+		t.Fatalf("drop schema: %v", err)
+	}
+	if err := EnsureSchema(ctx, pg, schema); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO sessions
+			(id, machine, project, agent, first_message,
+			 started_at, message_count, user_message_count)
+		VALUES
+			('pg-pin-repin', 'machine-a', 'proj-curation',
+			 'claude', 'repin refreshes uuid',
+			 '2026-05-01T00:00:00Z'::timestamptz, 2, 1)`,
+	); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO messages
+			(session_id, ordinal, role, content, timestamp,
+			 content_length, source_uuid)
+		VALUES
+			('pg-pin-repin', 0, 'user', 'question',
+			 '2026-05-01T00:00:00Z'::timestamptz, 8,
+			 'uuid-question'),
+			('pg-pin-repin', 1, 'assistant', 'original',
+			 '2026-05-01T00:00:01Z'::timestamptz, 8,
+			 'uuid-original')`,
+	); err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+
+	store, err := NewStore(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	originalNote := "first"
+	if _, err := store.PinMessage("pg-pin-repin", 1, &originalNote); err != nil {
+		t.Fatalf("PinMessage initial: %v", err)
+	}
+	var initialSourceUUID, initialCreatedAt string
+	if err := pg.QueryRowContext(ctx, `
+		SELECT source_uuid, created_at::text
+		FROM pinned_messages
+		WHERE session_id = $1 AND message_id = $2`,
+		"pg-pin-repin", 1,
+	).Scan(&initialSourceUUID, &initialCreatedAt); err != nil {
+		t.Fatalf("query initial pin: %v", err)
+	}
+	if initialSourceUUID != "uuid-original" {
+		t.Fatalf(
+			"initial source_uuid = %q, want uuid-original",
+			initialSourceUUID,
+		)
+	}
+
+	// Simulate a session rewrite that replaces the message at
+	// ordinal 1 with a different message (different source_uuid)
+	// while reusing the ordinal.
+	if _, err := pg.ExecContext(ctx, `
+		UPDATE messages
+		SET source_uuid = 'uuid-replacement',
+			content = 'replaced'
+		WHERE session_id = $1 AND ordinal = $2`,
+		"pg-pin-repin", 1,
+	); err != nil {
+		t.Fatalf("update message source_uuid: %v", err)
+	}
+
+	updatedNote := "second"
+	if _, err := store.PinMessage("pg-pin-repin", 1, &updatedNote); err != nil {
+		t.Fatalf("PinMessage repin: %v", err)
+	}
+
+	var gotSourceUUID, gotCreatedAt string
+	var gotNote *string
+	if err := pg.QueryRowContext(ctx, `
+		SELECT source_uuid, note, created_at::text
+		FROM pinned_messages
+		WHERE session_id = $1 AND message_id = $2`,
+		"pg-pin-repin", 1,
+	).Scan(&gotSourceUUID, &gotNote, &gotCreatedAt); err != nil {
+		t.Fatalf("query repinned pin: %v", err)
+	}
+	if gotSourceUUID != "uuid-replacement" {
+		t.Fatalf(
+			"after repin source_uuid = %q, want uuid-replacement "+
+				"(stale source_uuid would steer the next reconciliation "+
+				"away from the current message)",
+			gotSourceUUID,
+		)
+	}
+	if gotNote == nil || *gotNote != updatedNote {
+		t.Fatalf("after repin note = %v, want %q", gotNote, updatedNote)
+	}
+	if gotCreatedAt != initialCreatedAt {
+		t.Fatalf(
+			"after repin created_at = %q, want %q (must be preserved)",
+			gotCreatedAt, initialCreatedAt,
+		)
+	}
+}

--- a/internal/postgres/curation_pgtest_test.go
+++ b/internal/postgres/curation_pgtest_test.go
@@ -1,0 +1,457 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestStoreStarsAndPins(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_curation_test"
+	pg, err := Open(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer pg.Close()
+	defer func() {
+		_, _ = pg.ExecContext(
+			context.Background(),
+			`DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+		)
+	}()
+
+	ctx := context.Background()
+	if _, err := pg.ExecContext(
+		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+	); err != nil {
+		t.Fatalf("drop schema: %v", err)
+	}
+	if err := EnsureSchema(ctx, pg, schema); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sessions
+			(id, machine, project, agent, first_message,
+			 started_at, message_count, user_message_count)
+		VALUES
+			('cur-star-1', 'machine-a', 'proj-curation',
+			 'codex', 'star one',
+			 '2026-05-01T00:00:00Z'::timestamptz, 0, 0),
+			('cur-star-2', 'machine-a', 'proj-curation',
+			 'codex', 'star two',
+			 '2026-05-01T00:01:00Z'::timestamptz, 0, 0),
+			('cur-pin-1', 'machine-a', 'proj-curation',
+			 'claude', 'pin source',
+			 '2026-05-01T00:02:00Z'::timestamptz, 2, 1)`)
+	if err != nil {
+		t.Fatalf("insert sessions: %v", err)
+	}
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO messages
+			(session_id, ordinal, role, content, timestamp,
+			 content_length, source_uuid)
+		VALUES
+			('cur-pin-1', 0, 'user', 'question',
+			 '2026-05-01T00:02:00Z'::timestamptz, 8,
+			 'uuid-question'),
+			('cur-pin-1', 1, 'assistant', 'answer',
+			 '2026-05-01T00:02:01Z'::timestamptz, 6,
+			 'uuid-answer')`)
+	if err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+
+	store, err := NewStore(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	ok, err := store.StarSession("cur-star-1")
+	if err != nil || !ok {
+		t.Fatalf("StarSession existing: ok=%v err=%v", ok, err)
+	}
+	ok, err = store.StarSession("missing")
+	if err != nil {
+		t.Fatalf("StarSession missing: %v", err)
+	}
+	if ok {
+		t.Fatal("StarSession missing = true, want false")
+	}
+	if err := store.BulkStarSessions(
+		[]string{"cur-star-2", "missing"},
+	); err != nil {
+		t.Fatalf("BulkStarSessions: %v", err)
+	}
+
+	ids, err := store.ListStarredSessionIDs(ctx)
+	if err != nil {
+		t.Fatalf("ListStarredSessionIDs: %v", err)
+	}
+	wantStars := map[string]bool{
+		"cur-star-1": true,
+		"cur-star-2": true,
+	}
+	if len(ids) != len(wantStars) {
+		t.Fatalf("starred ids = %v, want both stars", ids)
+	}
+	for _, id := range ids {
+		if !wantStars[id] {
+			t.Fatalf("unexpected starred id %q in %v", id, ids)
+		}
+	}
+	if err := store.UnstarSession("cur-star-1"); err != nil {
+		t.Fatalf("UnstarSession: %v", err)
+	}
+	ids, err = store.ListStarredSessionIDs(ctx)
+	if err != nil {
+		t.Fatalf("ListStarredSessionIDs after unstar: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "cur-star-2" {
+		t.Fatalf("starred ids after unstar = %v, want cur-star-2", ids)
+	}
+
+	note := "keep this"
+	pinID, err := store.PinMessage("cur-pin-1", 1, &note)
+	if err != nil {
+		t.Fatalf("PinMessage: %v", err)
+	}
+	if pinID == 0 {
+		t.Fatal("PinMessage returned 0, want row id")
+	}
+	updatedNote := "updated"
+	pinID2, err := store.PinMessage("cur-pin-1", 1, &updatedNote)
+	if err != nil {
+		t.Fatalf("PinMessage update: %v", err)
+	}
+	if pinID2 != pinID {
+		t.Fatalf("updated pin id = %d, want %d", pinID2, pinID)
+	}
+	missingPin, err := store.PinMessage("cur-pin-1", 99, nil)
+	if err != nil {
+		t.Fatalf("PinMessage missing message: %v", err)
+	}
+	if missingPin != 0 {
+		t.Fatalf("missing pin id = %d, want 0", missingPin)
+	}
+
+	pins, err := store.ListPinnedMessages(ctx, "cur-pin-1", "")
+	if err != nil {
+		t.Fatalf("ListPinnedMessages session: %v", err)
+	}
+	if len(pins) != 1 {
+		t.Fatalf("session pins = %d, want 1", len(pins))
+	}
+	if pins[0].MessageID != 1 || pins[0].Ordinal != 1 {
+		t.Fatalf(
+			"pin message/ordinal = %d/%d, want 1/1",
+			pins[0].MessageID, pins[0].Ordinal,
+		)
+	}
+	if pins[0].Note == nil || *pins[0].Note != updatedNote {
+		t.Fatalf("pin note = %v, want %q", pins[0].Note, updatedNote)
+	}
+
+	allPins, err := store.ListPinnedMessages(ctx, "", "proj-curation")
+	if err != nil {
+		t.Fatalf("ListPinnedMessages all: %v", err)
+	}
+	if len(allPins) != 1 {
+		t.Fatalf("all pins = %d, want 1", len(allPins))
+	}
+	if allPins[0].Content == nil || *allPins[0].Content != "answer" {
+		t.Fatalf("pin content = %v, want answer", allPins[0].Content)
+	}
+	if allPins[0].Role == nil || *allPins[0].Role != "assistant" {
+		t.Fatalf("pin role = %v, want assistant", allPins[0].Role)
+	}
+	if allPins[0].SessionProject == nil ||
+		*allPins[0].SessionProject != "proj-curation" {
+		t.Fatalf(
+			"pin project = %v, want proj-curation",
+			allPins[0].SessionProject,
+		)
+	}
+
+	if err := store.UnpinMessage("cur-pin-1", 1); err != nil {
+		t.Fatalf("UnpinMessage: %v", err)
+	}
+	pins, err = store.ListPinnedMessages(ctx, "cur-pin-1", "")
+	if err != nil {
+		t.Fatalf("ListPinnedMessages after unpin: %v", err)
+	}
+	if len(pins) != 0 {
+		t.Fatalf("pins after unpin = %d, want 0", len(pins))
+	}
+}
+
+func TestPushPreservesMultiplePGPinsBySourceUUID(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanPGSchema(t, pgURL)
+	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
+
+	local := testDB(t)
+	ps, err := New(
+		pgURL, "agentsview", local,
+		"curation-machine", true,
+		SyncOptions{},
+	)
+	if err != nil {
+		t.Fatalf("New sync: %v", err)
+	}
+	defer ps.Close()
+
+	ctx := context.Background()
+	if err := ps.EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	sess := db.Session{
+		ID:           "pg-pin-rewrite",
+		Project:      "proj-curation",
+		Machine:      "local",
+		Agent:        "codex",
+		MessageCount: 3,
+		CreatedAt:    "2026-05-01T00:00:00Z",
+	}
+	if err := local.UpsertSession(sess); err != nil {
+		t.Fatalf("UpsertSession first: %v", err)
+	}
+	if err := local.InsertMessages([]db.Message{
+		{
+			SessionID:  "pg-pin-rewrite",
+			Ordinal:    0,
+			Role:       "user",
+			Content:    "question",
+			SourceUUID: "uuid-question",
+		},
+		{
+			SessionID:  "pg-pin-rewrite",
+			Ordinal:    1,
+			Role:       "assistant",
+			Content:    "answer one",
+			SourceUUID: "uuid-answer-one",
+		},
+		{
+			SessionID:  "pg-pin-rewrite",
+			Ordinal:    2,
+			Role:       "assistant",
+			Content:    "answer two",
+			SourceUUID: "uuid-answer-two",
+		},
+	}); err != nil {
+		t.Fatalf("InsertMessages first: %v", err)
+	}
+	if _, err := ps.Push(ctx, false, nil); err != nil {
+		t.Fatalf("Push first: %v", err)
+	}
+
+	store, err := NewStore(pgURL, "agentsview", true)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	noteOne := "important one"
+	if _, err := store.PinMessage(
+		"pg-pin-rewrite", 1, &noteOne,
+	); err != nil {
+		t.Fatalf("PinMessage one: %v", err)
+	}
+	noteTwo := "important two"
+	if _, err := store.PinMessage(
+		"pg-pin-rewrite", 2, &noteTwo,
+	); err != nil {
+		t.Fatalf("PinMessage two: %v", err)
+	}
+
+	sess.MessageCount = 4
+	if err := local.UpsertSession(sess); err != nil {
+		t.Fatalf("UpsertSession second: %v", err)
+	}
+	if err := local.ReplaceSessionMessages(
+		"pg-pin-rewrite",
+		[]db.Message{
+			{
+				SessionID:  "pg-pin-rewrite",
+				Ordinal:    0,
+				Role:       "user",
+				Content:    "question",
+				SourceUUID: "uuid-question",
+			},
+			{
+				SessionID:         "pg-pin-rewrite",
+				Ordinal:           1,
+				Role:              "user",
+				Content:           "[compact]",
+				SourceUUID:        "uuid-boundary",
+				IsCompactBoundary: true,
+			},
+			{
+				SessionID:  "pg-pin-rewrite",
+				Ordinal:    2,
+				Role:       "assistant",
+				Content:    "answer one",
+				SourceUUID: "uuid-answer-one",
+			},
+			{
+				SessionID:  "pg-pin-rewrite",
+				Ordinal:    3,
+				Role:       "assistant",
+				Content:    "answer two",
+				SourceUUID: "uuid-answer-two",
+			},
+		},
+	); err != nil {
+		t.Fatalf("ReplaceSessionMessages: %v", err)
+	}
+
+	if _, err := ps.Push(ctx, true, nil); err != nil {
+		t.Fatalf("Push rewrite: %v", err)
+	}
+
+	pins, err := store.ListPinnedMessages(ctx, "pg-pin-rewrite", "")
+	if err != nil {
+		t.Fatalf("ListPinnedMessages: %v", err)
+	}
+	if len(pins) != 2 {
+		t.Fatalf("pins = %d, want 2", len(pins))
+	}
+
+	byNote := map[string]db.PinnedMessage{}
+	for _, pin := range pins {
+		if pin.Note == nil {
+			t.Fatalf("pin note = nil, want populated note")
+		}
+		byNote[*pin.Note] = pin
+	}
+	if pin, ok := byNote[noteOne]; !ok {
+		t.Fatalf("pin for %q missing: %v", noteOne, pins)
+	} else if pin.MessageID != 2 || pin.Ordinal != 2 {
+		t.Fatalf(
+			"pin one message/ordinal = %d/%d, want 2/2",
+			pin.MessageID, pin.Ordinal,
+		)
+	}
+	if pin, ok := byNote[noteTwo]; !ok {
+		t.Fatalf("pin for %q missing: %v", noteTwo, pins)
+	} else if pin.MessageID != 3 || pin.Ordinal != 3 {
+		t.Fatalf(
+			"pin two message/ordinal = %d/%d, want 3/3",
+			pin.MessageID, pin.Ordinal,
+		)
+	}
+}
+
+func TestReconcilePinnedMessagesPrefersCurrentTargetPin(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_pin_duplicate_test"
+	pg, err := Open(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer pg.Close()
+	defer func() {
+		_, _ = pg.ExecContext(
+			context.Background(),
+			`DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+		)
+	}()
+
+	ctx := context.Background()
+	if _, err := pg.ExecContext(
+		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+	); err != nil {
+		t.Fatalf("drop schema: %v", err)
+	}
+	if err := EnsureSchema(ctx, pg, schema); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO sessions
+			(id, machine, project, agent, first_message,
+			 started_at, message_count, user_message_count)
+		VALUES
+			('pg-pin-duplicate', 'machine-a', 'proj-curation',
+			 'codex', 'duplicate source repair',
+			 '2026-05-01T00:00:00Z'::timestamptz, 3, 1)`,
+	); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO messages
+			(session_id, ordinal, role, content, timestamp,
+			 content_length, source_uuid)
+		VALUES
+			('pg-pin-duplicate', 0, 'user', 'question',
+			 '2026-05-01T00:00:00Z'::timestamptz, 8,
+			 'uuid-question'),
+			('pg-pin-duplicate', 1, 'user', '[compact]',
+			 '2026-05-01T00:00:01Z'::timestamptz, 9,
+			 'uuid-boundary'),
+			('pg-pin-duplicate', 2, 'assistant', 'answer',
+			 '2026-05-01T00:00:02Z'::timestamptz, 6,
+			 'uuid-answer')`,
+	); err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO pinned_messages
+			(session_id, message_id, ordinal, source_uuid,
+			 note, created_at)
+		VALUES
+			('pg-pin-duplicate', 1, 1, 'uuid-answer',
+			 'stale note',
+			 '2026-05-01T00:01:00Z'::timestamptz),
+			('pg-pin-duplicate', 2, 2, 'uuid-answer',
+			 'current note',
+			 '2026-05-01T00:02:00Z'::timestamptz)`,
+	); err != nil {
+		t.Fatalf("insert pins: %v", err)
+	}
+
+	tx, err := pg.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if err := reconcilePinnedMessages(
+		ctx, tx, "pg-pin-duplicate",
+	); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("reconcilePinnedMessages: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit tx: %v", err)
+	}
+
+	store, err := NewStore(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	pins, err := store.ListPinnedMessages(ctx, "pg-pin-duplicate", "")
+	if err != nil {
+		t.Fatalf("ListPinnedMessages: %v", err)
+	}
+	if len(pins) != 1 {
+		t.Fatalf("pins = %d, want 1: %v", len(pins), pins)
+	}
+	if pins[0].MessageID != 2 || pins[0].Ordinal != 2 {
+		t.Fatalf(
+			"pin message/ordinal = %d/%d, want 2/2",
+			pins[0].MessageID, pins[0].Ordinal,
+		)
+	}
+	if pins[0].Note == nil || *pins[0].Note != "current note" {
+		t.Fatalf("pin note = %v, want current note", pins[0].Note)
+	}
+}

--- a/internal/postgres/curation_pgtest_test.go
+++ b/internal/postgres/curation_pgtest_test.go
@@ -455,3 +455,103 @@ func TestReconcilePinnedMessagesPrefersCurrentTargetPin(t *testing.T) {
 		t.Fatalf("pin note = %v, want current note", pins[0].Note)
 	}
 }
+
+// TestReconcilePinnedMessagesPrunesPinWhenSourceUUIDGone covers the
+// case where a source-backed pin's source_uuid no longer exists in
+// the messages table, but a different message now occupies the
+// pin's original ordinal. The pin must be deleted: otherwise it
+// would silently re-anchor on an unrelated message.
+func TestReconcilePinnedMessagesPrunesPinWhenSourceUUIDGone(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_pin_source_gone_test"
+	pg, err := Open(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer pg.Close()
+	defer func() {
+		_, _ = pg.ExecContext(
+			context.Background(),
+			`DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+		)
+	}()
+
+	ctx := context.Background()
+	if _, err := pg.ExecContext(
+		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
+	); err != nil {
+		t.Fatalf("drop schema: %v", err)
+	}
+	if err := EnsureSchema(ctx, pg, schema); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO sessions
+			(id, machine, project, agent, first_message,
+			 started_at, message_count, user_message_count)
+		VALUES
+			('pg-pin-source-gone', 'machine-a', 'proj-curation',
+			 'codex', 'source uuid gone',
+			 '2026-05-01T00:00:00Z'::timestamptz, 2, 1)`,
+	); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO messages
+			(session_id, ordinal, role, content, timestamp,
+			 content_length, source_uuid)
+		VALUES
+			('pg-pin-source-gone', 0, 'user', 'question',
+			 '2026-05-01T00:00:00Z'::timestamptz, 8,
+			 'uuid-question'),
+			('pg-pin-source-gone', 1, 'assistant', 'new answer',
+			 '2026-05-01T00:00:01Z'::timestamptz, 10,
+			 'uuid-new-answer')`,
+	); err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+	if _, err := pg.ExecContext(ctx, `
+		INSERT INTO pinned_messages
+			(session_id, message_id, ordinal, source_uuid,
+			 note, created_at)
+		VALUES
+			('pg-pin-source-gone', 1, 1, 'uuid-gone-forever',
+			 'stale pin',
+			 '2026-05-01T00:01:00Z'::timestamptz)`,
+	); err != nil {
+		t.Fatalf("insert pin: %v", err)
+	}
+
+	tx, err := pg.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if err := reconcilePinnedMessages(
+		ctx, tx, "pg-pin-source-gone",
+	); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("reconcilePinnedMessages: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit tx: %v", err)
+	}
+
+	store, err := NewStore(pgURL, schema, true)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	pins, err := store.ListPinnedMessages(ctx, "pg-pin-source-gone", "")
+	if err != nil {
+		t.Fatalf("ListPinnedMessages: %v", err)
+	}
+	if len(pins) != 0 {
+		t.Fatalf(
+			"pins = %d, want 0 (stale source_uuid should be pruned): %v",
+			len(pins), pins,
+		)
+	}
+}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -943,6 +943,11 @@ func (s *Sync) pushMessages(
 				"deleting stale pg messages: %w", err,
 			)
 		}
+		if err := reconcilePinnedMessages(
+			ctx, tx, sessionID,
+		); err != nil {
+			return 0, err
+		}
 		return 0, nil
 	}
 
@@ -1134,7 +1139,157 @@ func (s *Sync) pushMessages(
 		startOrdinal = nextOrdinal
 	}
 
+	if err := reconcilePinnedMessages(ctx, tx, sessionID); err != nil {
+		return count, err
+	}
+
 	return count, nil
+}
+
+func reconcilePinnedMessages(
+	ctx context.Context, tx *sql.Tx, sessionID string,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE pinned_messages p
+		SET source_uuid = m.source_uuid
+		FROM messages m
+		WHERE p.session_id = $1
+			AND m.session_id = p.session_id
+			AND m.ordinal = p.message_id
+			AND p.source_uuid = ''
+			AND m.source_uuid <> ''`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf(
+			"backfilling pg pin source_uuid: %w", err,
+		)
+	}
+
+	// Move shifted source-backed pins out of the real ordinal range
+	// first. Pins already on their resolved target stay in place so
+	// duplicate repairs prefer the current target row's metadata.
+	if _, err := tx.ExecContext(ctx, `
+		WITH matched AS (
+			SELECT DISTINCT ON (p.id)
+				p.id, p.message_id, p.ordinal,
+				m.ordinal AS target_ordinal
+			FROM pinned_messages p
+			JOIN messages m
+				ON m.session_id = p.session_id
+				AND m.source_uuid = p.source_uuid
+			WHERE p.session_id = $1
+				AND p.source_uuid <> ''
+			ORDER BY p.id, m.ordinal
+		),
+		numbered AS (
+			SELECT id,
+				ROW_NUMBER() OVER (ORDER BY id) AS temp_ordinal
+			FROM matched
+			WHERE target_ordinal <> message_id
+				OR target_ordinal <> ordinal
+		)
+		UPDATE pinned_messages p
+		SET message_id = (-2000000000 + numbered.temp_ordinal::INT),
+			ordinal = (-2000000000 + numbered.temp_ordinal::INT)
+		FROM numbered
+		WHERE p.id = numbered.id`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf(
+			"staging pg pins for source_uuid realignment: %w", err,
+		)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		WITH matched AS (
+			SELECT DISTINCT ON (p.id)
+				p.id, p.message_id, p.created_at,
+				m.ordinal AS target_ordinal
+			FROM pinned_messages p
+			JOIN messages m
+				ON m.session_id = p.session_id
+				AND m.source_uuid = p.source_uuid
+			WHERE p.session_id = $1
+				AND p.source_uuid <> ''
+			ORDER BY p.id, m.ordinal
+		),
+		ranked AS (
+			SELECT id, target_ordinal,
+				ROW_NUMBER() OVER (
+					PARTITION BY target_ordinal
+					ORDER BY
+						(message_id = target_ordinal) DESC,
+						created_at DESC,
+						id DESC
+				) AS target_rank
+			FROM matched
+		)
+		DELETE FROM pinned_messages p
+		USING ranked r
+		WHERE p.session_id = $1
+			AND r.target_rank = 1
+			AND p.message_id = r.target_ordinal
+			AND p.id <> r.id`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf(
+			"clearing pg pin target conflicts: %w", err,
+		)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		WITH matched AS (
+			SELECT DISTINCT ON (p.id)
+				p.id, p.message_id, p.created_at,
+				m.ordinal AS target_ordinal
+			FROM pinned_messages p
+			JOIN messages m
+				ON m.session_id = p.session_id
+				AND m.source_uuid = p.source_uuid
+			WHERE p.session_id = $1
+				AND p.source_uuid <> ''
+			ORDER BY p.id, m.ordinal
+		),
+		ranked AS (
+			SELECT id, target_ordinal,
+				ROW_NUMBER() OVER (
+					PARTITION BY target_ordinal
+					ORDER BY
+						(message_id = target_ordinal) DESC,
+						created_at DESC,
+						id DESC
+				) AS target_rank
+			FROM matched
+		)
+		UPDATE pinned_messages p
+		SET message_id = r.target_ordinal,
+			ordinal = r.target_ordinal
+		FROM ranked r
+		WHERE p.id = r.id
+			AND r.target_rank = 1`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf(
+			"realigning pg pins by source_uuid: %w", err,
+		)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM pinned_messages p
+		WHERE p.session_id = $1
+			AND NOT EXISTS (
+				SELECT 1 FROM messages m
+				WHERE m.session_id = p.session_id
+					AND m.ordinal = p.message_id
+			)`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf(
+			"pruning stale pg pins: %w", err,
+		)
+	}
+
+	return nil
 }
 
 func pgMessageTokenFingerprint(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1168,6 +1168,9 @@ func reconcilePinnedMessages(
 	// Move shifted source-backed pins out of the real ordinal range
 	// first. Pins already on their resolved target stay in place so
 	// duplicate repairs prefer the current target row's metadata.
+	// When multiple messages share a source_uuid (the schema allows
+	// it), prefer the message at the pin's current message_id so a
+	// correctly-placed pin is not relocated to a different duplicate.
 	if _, err := tx.ExecContext(ctx, `
 		WITH matched AS (
 			SELECT DISTINCT ON (p.id)
@@ -1179,7 +1182,9 @@ func reconcilePinnedMessages(
 				AND m.source_uuid = p.source_uuid
 			WHERE p.session_id = $1
 				AND p.source_uuid <> ''
-			ORDER BY p.id, m.ordinal
+			ORDER BY p.id,
+				CASE WHEN m.ordinal = p.message_id THEN 0 ELSE 1 END,
+				m.ordinal
 		),
 		numbered AS (
 			SELECT id,
@@ -1211,7 +1216,9 @@ func reconcilePinnedMessages(
 				AND m.source_uuid = p.source_uuid
 			WHERE p.session_id = $1
 				AND p.source_uuid <> ''
-			ORDER BY p.id, m.ordinal
+			ORDER BY p.id,
+				CASE WHEN m.ordinal = p.message_id THEN 0 ELSE 1 END,
+				m.ordinal
 		),
 		ranked AS (
 			SELECT id, target_ordinal,
@@ -1248,7 +1255,9 @@ func reconcilePinnedMessages(
 				AND m.source_uuid = p.source_uuid
 			WHERE p.session_id = $1
 				AND p.source_uuid <> ''
-			ORDER BY p.id, m.ordinal
+			ORDER BY p.id,
+				CASE WHEN m.ordinal = p.message_id THEN 0 ELSE 1 END,
+				m.ordinal
 		),
 		ranked AS (
 			SELECT id, target_ordinal,

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1274,13 +1274,31 @@ func reconcilePinnedMessages(
 		)
 	}
 
+	// Prune pins whose anchor no longer exists. For source-backed
+	// pins (source_uuid <> '') the canonical anchor is source_uuid,
+	// so a pin must be dropped when no message in this session has
+	// that source_uuid — otherwise a stale pin can survive on top
+	// of an unrelated message that now occupies the same ordinal.
+	// The ordinal-NOT-EXISTS clause additionally removes legacy
+	// pins (source_uuid = '') with a stale ordinal and clears any
+	// non-rank-1 duplicate left at the sentinel ordinal by step 2.
 	if _, err := tx.ExecContext(ctx, `
 		DELETE FROM pinned_messages p
 		WHERE p.session_id = $1
-			AND NOT EXISTS (
-				SELECT 1 FROM messages m
-				WHERE m.session_id = p.session_id
-					AND m.ordinal = p.message_id
+			AND (
+				(
+					p.source_uuid <> ''
+					AND NOT EXISTS (
+						SELECT 1 FROM messages m
+						WHERE m.session_id = p.session_id
+							AND m.source_uuid = p.source_uuid
+					)
+				)
+				OR NOT EXISTS (
+					SELECT 1 FROM messages m
+					WHERE m.session_id = p.session_id
+						AND m.ordinal = p.message_id
+				)
 			)`,
 		sessionID,
 	); err != nil {

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -130,6 +130,36 @@ CREATE INDEX IF NOT EXISTS idx_usage_events_session
 CREATE INDEX IF NOT EXISTS idx_usage_events_occurred
     ON usage_events (occurred_at);
 
+CREATE TABLE IF NOT EXISTS starred_sessions (
+    session_id TEXT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (session_id)
+        REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS pinned_messages (
+    id          BIGSERIAL PRIMARY KEY,
+    session_id  TEXT NOT NULL,
+    message_id  INT NOT NULL,
+    ordinal     INT NOT NULL,
+    source_uuid TEXT NOT NULL DEFAULT '',
+    note        TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (session_id)
+        REFERENCES sessions(id) ON DELETE CASCADE,
+    UNIQUE (session_id, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pinned_session
+    ON pinned_messages (session_id);
+
+CREATE INDEX IF NOT EXISTS idx_pinned_created
+    ON pinned_messages (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pinned_source_uuid
+    ON pinned_messages (session_id, source_uuid)
+    WHERE source_uuid <> '';
+
 CREATE TABLE IF NOT EXISTS model_pricing (
     model_pattern TEXT PRIMARY KEY,
     input_per_mtok DOUBLE PRECISION NOT NULL DEFAULT 0,
@@ -1190,6 +1220,27 @@ func CheckSchemaCompat(
 	if err != nil {
 		return fmt.Errorf(
 			"messages table missing required columns: %w",
+			err,
+		)
+	}
+	rows.Close()
+	rows, err = db.QueryContext(ctx,
+		`SELECT session_id, created_at
+		 FROM starred_sessions LIMIT 0`)
+	if err != nil {
+		return fmt.Errorf(
+			"starred_sessions table missing required columns: %w",
+			err,
+		)
+	}
+	rows.Close()
+	rows, err = db.QueryContext(ctx,
+		`SELECT id, session_id, message_id, ordinal,
+			source_uuid, note, created_at
+		 FROM pinned_messages LIMIT 0`)
+	if err != nil {
+		return fmt.Errorf(
+			"pinned_messages table missing required columns: %w",
 			err,
 		)
 	}

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -46,7 +46,9 @@ func (s *Store) SetCursorSecret(secret []byte) {
 	s.cursorSecret = append([]byte(nil), secret...)
 }
 
-// ReadOnly returns true; this is a read-only data source.
+// ReadOnly returns true because PG serve does not mutate synced
+// session content. Small dashboard-owned curation metadata (stars
+// and pins) is writable through dedicated methods.
 func (s *Store) ReadOnly() bool { return true }
 
 // GetSessionVersion returns the message count and a hash of
@@ -73,49 +75,8 @@ func (s *Store) GetSessionVersion(
 }
 
 // ------------------------------------------------------------
-// Write stubs (all return db.ErrReadOnly)
+// Unsupported write stubs (return db.ErrReadOnly)
 // ------------------------------------------------------------
-
-// StarSession is not supported in read-only mode.
-func (s *Store) StarSession(_ string) (bool, error) {
-	return false, db.ErrReadOnly
-}
-
-// UnstarSession is not supported in read-only mode.
-func (s *Store) UnstarSession(_ string) error {
-	return db.ErrReadOnly
-}
-
-// ListStarredSessionIDs returns an empty slice.
-func (s *Store) ListStarredSessionIDs(
-	_ context.Context,
-) ([]string, error) {
-	return []string{}, nil
-}
-
-// BulkStarSessions is not supported in read-only mode.
-func (s *Store) BulkStarSessions(_ []string) error {
-	return db.ErrReadOnly
-}
-
-// PinMessage is not supported in read-only mode.
-func (s *Store) PinMessage(
-	_ string, _ int64, _ *string,
-) (int64, error) {
-	return 0, db.ErrReadOnly
-}
-
-// UnpinMessage is not supported in read-only mode.
-func (s *Store) UnpinMessage(_ string, _ int64) error {
-	return db.ErrReadOnly
-}
-
-// ListPinnedMessages returns an empty slice.
-func (s *Store) ListPinnedMessages(
-	_ context.Context, _ string, _ string,
-) ([]db.PinnedMessage, error) {
-	return []db.PinnedMessage{}, nil
-}
 
 // InsertInsight is not supported in read-only mode.
 func (s *Store) InsertInsight(

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -846,23 +846,6 @@ func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
 		name string
 		fn   func() error
 	}{
-		{"StarSession", func() error {
-			_, err := store.StarSession("x")
-			return err
-		}},
-		{"UnstarSession", func() error {
-			return store.UnstarSession("x")
-		}},
-		{"BulkStarSessions", func() error {
-			return store.BulkStarSessions([]string{"x"})
-		}},
-		{"PinMessage", func() error {
-			_, err := store.PinMessage("x", 1, nil)
-			return err
-		}},
-		{"UnpinMessage", func() error {
-			return store.UnpinMessage("x", 1)
-		}},
 		{"InsertInsight", func() error {
 			_, err := store.InsertInsight(db.Insight{})
 			return err


### PR DESCRIPTION
 ## Summary

  - add PostgreSQL-backed dashboard curation metadata for starred sessions and pinned messages
  - keep pg serve read-only for synced session content while allowing stars and pins to be written to PostgreSQL
  - preserve pinned messages across PostgreSQL message rewrites, including shifted ordinal runs and duplicate source_uuid repair cases
  - Closes #484.

  ## Details

  This adds starred_sessions and pinned_messages tables to the PostgreSQL schema and implements the corresponding Store methods for pg serve.

  Pinned messages use PostgreSQL’s synthetic message ID convention where message_id matches message ordinal. During pg push, pinned messages are reconciled by source_uuid so
  pins can survive message rewrites where ordinals move, such as compact-boundary rows being inserted before previously pinned messages.

  ## Validation

  - go test ./internal/postgres
  - go test ./internal/db -run 'TestReplaceSessionMessagesPin'
  - go test -tags pgtest ./internal/postgres -run 'TestStoreStarsAndPins|TestPushPreservesMultiplePGPinsBySourceUUID|TestReconcilePinnedMessagesPrefersCurrentTargetPin' -v
 - PG tests compile locally but skip without TEST_PG_URL set.