### PR TITLE
fix: skip any slash command when computing session first_message preview

### DIFF
--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -1597,12 +1597,13 @@ func isCommandEnvelope(content string) bool {
 }
 
 // isSkippablePreviewCommand returns true when content is a Claude
-// Code slash command (e.g. /login, /plan, /clear). Detection is
-// generic: the trimmed content must start with "/" followed by one
-// or more letters or digits, then either end or be followed by
-// whitespace. This lets /login and /plan be skipped without
-// enumerating every command, while keeping file-path references
-// like "/usr/local/bin gives an error" visible as session titles.
+// Code slash command (e.g. /login, /plan, /roborev-fix). Detection
+// is generic: the trimmed content must start with "/" followed by one
+// or more letters, digits, hyphens, or underscores, then either end
+// or be followed by whitespace. Hyphens and underscores are included
+// because command envelopes normalise to names like /skill-name.
+// File-path references like "/usr/local/bin gives an error" are not
+// skipped because the embedded "/" terminates the match.
 func isSkippablePreviewCommand(content string) bool {
 	trimmed := strings.TrimSpace(content)
 	if !strings.HasPrefix(trimmed, "/") {
@@ -1615,9 +1616,9 @@ func isSkippablePreviewCommand(content string) bool {
 		if unicode.IsSpace(r) {
 			return i > 0
 		}
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
-			// A non-letter/digit character (e.g. another "/") means
-			// this is not a plain slash command.
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-' && r != '_' {
+			// Any other character (e.g. another "/") means this is not
+			// a plain slash command.
 			return false
 		}
 		i += size

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -1596,39 +1596,38 @@ func isCommandEnvelope(content string) bool {
 	return strings.TrimSpace(stripped) == ""
 }
 
-// previewSkippedCommands lists Claude Code commands that should
-// not be used as a session's first_message preview. When a
-// session opens with one of these, the parser skips past it and
-// picks the next real user message so the sidebar shows
-// something descriptive.
-var previewSkippedCommands = []string{"/clear", "/effort"}
-
-// isSkippablePreviewCommand returns true when content is a known
-// Claude Code command (optionally followed by arguments), for the
-// purpose of skipping it when computing first_message. Match is
-// word-boundary: the trimmed content must equal the command
-// exactly or be followed by a whitespace rune, so "/clearcache"
-// does not match "/clear".
+// isSkippablePreviewCommand returns true when content is a Claude
+// Code slash command (e.g. /login, /plan, /clear). Detection is
+// generic: the trimmed content must start with "/" followed by one
+// or more letters or digits, then either end or be followed by
+// whitespace. This lets /login and /plan be skipped without
+// enumerating every command, while keeping file-path references
+// like "/usr/local/bin gives an error" visible as session titles.
 func isSkippablePreviewCommand(content string) bool {
 	trimmed := strings.TrimSpace(content)
-	for _, cmd := range previewSkippedCommands {
-		if !strings.HasPrefix(trimmed, cmd) {
-			continue
-		}
-		if len(trimmed) == len(cmd) {
-			return true
-		}
-		r, _ := utf8.DecodeRuneInString(trimmed[len(cmd):])
-		if unicode.IsSpace(r) {
-			return true
-		}
+	if !strings.HasPrefix(trimmed, "/") {
+		return false
 	}
-	return false
+	rest := trimmed[1:]
+	i := 0
+	for i < len(rest) {
+		r, size := utf8.DecodeRuneInString(rest[i:])
+		if unicode.IsSpace(r) {
+			return i > 0
+		}
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			// A non-letter/digit character (e.g. another "/") means
+			// this is not a plain slash command.
+			return false
+		}
+		i += size
+	}
+	return i > 0
 }
 
 // firstMessageAndUserCount returns the preview string and the
 // total number of real (non-system) user turns. The preview skips
-// known Claude Code command envelopes like /clear and /effort so
+// Claude Code slash commands (e.g. /login, /plan, /clear) so
 // sessions that begin with a command still show a meaningful
 // preview; the user count always reflects every non-system user
 // turn, including skipped commands.

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -1514,6 +1514,7 @@ func TestIsSkippablePreviewCommand(t *testing.T) {
 		content string
 		want    bool
 	}{
+		// Explicit commands still work.
 		{"bare /clear", "/clear", true},
 		{"bare /effort", "/effort", true},
 		{"/clear with trailing space", "/clear ", true},
@@ -1522,13 +1523,19 @@ func TestIsSkippablePreviewCommand(t *testing.T) {
 		{"surrounded by whitespace", "  /clear  ", true},
 		{"/clear with tab", "/clear\tfoo", true},
 		{"/clear with newline", "/clear\nfoo", true},
+		// Generic slash commands are now skipped too.
+		{"bare /login", "/login", true},
+		{"bare /plan", "/plan", true},
+		{"/plan with args", "/plan my project", true},
+		{"/clearcache", "/clearcache", true},
+		{"/effortless", "/effortless", true},
+		{"/cleareffort", "/cleareffort", true},
+		{"arbitrary /unrelated", "/unrelated", true},
+		// Non-commands are not skipped.
 		{"empty string", "", false},
-		{"/clearcache (no word boundary)", "/clearcache", false},
-		{"/effortless (no word boundary)", "/effortless", false},
-		{"/cleareffort", "/cleareffort", false},
-		{"unrelated command", "/unrelated", false},
 		{"prose containing /clear", "hello /clear", false},
-		{"/clear-xyz (dash not whitespace)", "/clear-xyz", false},
+		{"/clear-xyz (hyphen terminates command word)", "/clear-xyz", false},
+		{"file path reference", "/usr/local/bin gives an error", false},
 		{"plain text", "Fix the login bug", false},
 	}
 	for _, tc := range cases {

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -211,7 +211,7 @@ func TestParseClaudeSession_SkippedMessages(t *testing.T) {
 		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
 		assert.Equal(t, 2, sess.MessageCount)
 		assert.Equal(t, 1, sess.UserMessageCount)
-		assert.Equal(t, "/roborev-fix 450", sess.FirstMessage)
+		assert.Equal(t, "", sess.FirstMessage, "slash command with no follow-up yields empty first_message")
 		assert.Equal(t, RoleUser, msgs[0].Role)
 		assert.Equal(t, "/roborev-fix 450", msgs[0].Content)
 	})
@@ -1531,10 +1531,14 @@ func TestIsSkippablePreviewCommand(t *testing.T) {
 		{"/effortless", "/effortless", true},
 		{"/cleareffort", "/cleareffort", true},
 		{"arbitrary /unrelated", "/unrelated", true},
+		// Hyphenated and underscored command names are skipped.
+		{"/clear-xyz", "/clear-xyz", true},
+		{"/roborev-fix", "/roborev-fix", true},
+		{"/skill_name", "/skill_name", true},
+		{"/roborev-fix with args", "/roborev-fix some args", true},
 		// Non-commands are not skipped.
 		{"empty string", "", false},
 		{"prose containing /clear", "hello /clear", false},
-		{"/clear-xyz (hyphen terminates command word)", "/clear-xyz", false},
 		{"file path reference", "/usr/local/bin gives an error", false},
 		{"plain text", "Fix the login bug", false},
 	}
@@ -1598,7 +1602,7 @@ func TestParseClaudeSession_SkipClearEffortFirstMessage(t *testing.T) {
 		assert.Equal(t, 2, sess.UserMessageCount)
 	})
 
-	t.Run("non-skipped command still becomes first_message", func(t *testing.T) {
+	t.Run("hyphenated slash command is skipped, next message becomes first_message", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
 			testjsonl.ClaudeUserJSON(
 				"<command-message>roborev-fix</command-message>\n<command-name>/roborev-fix</command-name>\n<command-args>450</command-args>",
@@ -1607,6 +1611,6 @@ func TestParseClaudeSession_SkipClearEffortFirstMessage(t *testing.T) {
 			testjsonl.ClaudeUserJSON("follow-up", tsZeroS1),
 		)
 		sess, _ := runClaudeParserTest(t, "test.jsonl", content)
-		assert.Equal(t, "/roborev-fix 450", sess.FirstMessage)
+		assert.Equal(t, "follow-up", sess.FirstMessage)
 	})
 }


### PR DESCRIPTION
Fixes #487.

Session sidebar titles were set from the first user message without filtering slash commands, so sessions starting with `/login`, `/plan`, or similar showed those commands as the title instead of the first meaningful prompt.

Previously only `/clear` and `/effort` were excluded via an explicit allowlist. This replaces that list with generic slash command detection: any message that starts with `/` followed by one or more letters or digits (then end-of-string or whitespace) is treated as a command and skipped. File-path references like `/usr/local/bin gives an error` are not affected because the embedded `/` causes the check to return false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)