### PR TITLE
feat: support Google Antigravity IDE and CLI sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ html/
 
 # Visual verification scratch — per-task screenshot/HTML capture dirs.
 .test-data*/
+
+# Antigravity CLI session dir created when AGY runs inside this repo
+.antigravitycli/

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ agentsview auto-discovers sessions from all of these:
 | Piebald            | `~/.local/share/piebald/`                              |
 | Warp               | `~/.warp/` (platform-dependent)                        |
 | Positron Assistant | `~/Library/Application Support/Positron/User/` (macOS) |
+| Antigravity        | `~/.gemini/antigravity/`                               |
+| Antigravity CLI    | `~/.gemini/antigravity-cli/` (summary mode)            |
 
 Each directory can be overridden with an environment variable. See the
 [configuration docs](https://agentsview.io/configuration/) for details.

--- a/frontend/src/lib/components/settings/AgentDirSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentDirSettings.svelte
@@ -18,6 +18,8 @@
     openclaw: "OpenClaw",
     kimi: "Kimi",
     piebald: "Piebald",
+    antigravity: "Antigravity",
+    "antigravity-cli": "Antigravity CLI",
   };
 </script>
 

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -30,6 +30,8 @@ describe("KNOWN_AGENTS", () => {
       "kiro-ide",
       "cortex",
       "piebald",
+      "antigravity",
+      "antigravity-cli",
     ]);
   });
 

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -34,6 +34,16 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "kiro-ide", color: "var(--accent-lime)", label: "Kiro IDE" },
   { name: "cortex", color: "var(--accent-cyan)", label: "Cortex Code" },
   { name: "piebald", color: "var(--accent-orange)", label: "Piebald" },
+  {
+    name: "antigravity",
+    color: "var(--accent-violet)",
+    label: "Antigravity",
+  },
+  {
+    name: "antigravity-cli",
+    color: "var(--accent-violet)",
+    label: "Antigravity CLI",
+  },
 ];
 
 const agentColorMap = new Map(

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -1,0 +1,311 @@
+package parser
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Antigravity IDE sessions live under ~/.gemini/antigravity/:
+//
+//   conversations/<uuid>.db        SQLite, one per session
+//   annotations/<uuid>.pbtxt       last_user_view_time + flags
+//   brain/<uuid>/*.md(+.json)      plaintext task/plan artifacts
+//   implicit/<uuid>.pb             encrypted (handled like CLI)
+//
+// We treat the .db as the canonical session file (like Gemini's
+// per-session JSON). Each row of `steps` becomes one ParsedMessage.
+
+const antigravityIDPrefix = "antigravity:"
+
+// DiscoverAntigravitySessions returns one DiscoveredFile per
+// conversations/<uuid>.db under the IDE root.
+func DiscoverAntigravitySessions(root string) []DiscoveredFile {
+	if root == "" {
+		return nil
+	}
+	dir := filepath.Join(root, "conversations")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var files []DiscoveredFile
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".db") {
+			continue
+		}
+		id := strings.TrimSuffix(name, ".db")
+		if !IsValidSessionID(id) {
+			continue
+		}
+		files = append(files, DiscoveredFile{
+			Path:  filepath.Join(dir, name),
+			Agent: AgentAntigravity,
+		})
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+// FindAntigravitySourceFile locates a session DB by id.
+func FindAntigravitySourceFile(root, id string) string {
+	if root == "" || !IsValidSessionID(id) {
+		return ""
+	}
+	p := filepath.Join(root, "conversations", id+".db")
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	return ""
+}
+
+// ParseAntigravitySession parses one IDE session DB.
+func ParseAntigravitySession(
+	path, project, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	id := strings.TrimSuffix(filepath.Base(path), ".db")
+	if !IsValidSessionID(id) {
+		return nil, nil, fmt.Errorf(
+			"invalid Antigravity IDE session filename: %s", path,
+		)
+	}
+	root := filepath.Dir(filepath.Dir(path))
+
+	// Open read-only; SQLite session files have WAL/SHM
+	// sidecars that the driver expects in the same dir.
+	dsn := "file:" + path + "?mode=ro&immutable=0"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"open antigravity db %s: %w", path, err,
+		)
+	}
+	defer db.Close()
+
+	messages, err := loadAntigravitySteps(db)
+	if err != nil {
+		return nil, nil, err
+	}
+	messages = append(messages,
+		collectAntigravityBrainMessages(
+			filepath.Join(root, "brain", id),
+		)...,
+	)
+
+	sort.SliceStable(messages, func(i, j int) bool {
+		return messages[i].Timestamp.Before(messages[j].Timestamp)
+	})
+	for i := range messages {
+		messages[i].Ordinal = i
+	}
+
+	var firstMessage string
+	var userCount int
+	var startedAt, endedAt time.Time
+	for _, m := range messages {
+		if m.Role == RoleUser {
+			userCount++
+			if firstMessage == "" && m.Content != "" {
+				firstMessage = truncate(
+					strings.ReplaceAll(m.Content, "\n", " "),
+					300,
+				)
+			}
+		}
+		if !m.Timestamp.IsZero() {
+			if startedAt.IsZero() || m.Timestamp.Before(startedAt) {
+				startedAt = m.Timestamp
+			}
+			if m.Timestamp.After(endedAt) {
+				endedAt = m.Timestamp
+			}
+		}
+	}
+	if ann := readAntigravityAnnotation(
+		filepath.Join(root, "annotations", id+".pbtxt"),
+	); !ann.IsZero() && ann.After(endedAt) {
+		endedAt = ann
+	}
+	if startedAt.IsZero() {
+		startedAt = info.ModTime()
+	}
+	if endedAt.IsZero() {
+		endedAt = info.ModTime()
+	}
+
+	sess := &ParsedSession{
+		ID:               antigravityIDPrefix + id,
+		Project:          project,
+		Machine:          machine,
+		Agent:            AgentAntigravity,
+		FirstMessage:     firstMessage,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     len(messages),
+		UserMessageCount: userCount,
+		File: FileInfo{
+			Path:  path,
+			Size:  info.Size(),
+			Mtime: info.ModTime().UnixNano(),
+		},
+	}
+	if len(messages) == 0 {
+		return sess, nil, nil
+	}
+	return sess, messages, nil
+}
+
+func loadAntigravitySteps(db *sql.DB) ([]ParsedMessage, error) {
+	rows, err := db.Query(
+		`SELECT idx, step_type, step_payload FROM steps ` +
+			`ORDER BY idx`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query steps: %w", err)
+	}
+	defer rows.Close()
+	var out []ParsedMessage
+	for rows.Next() {
+		var (
+			idx      int
+			stepType int
+			payload  []byte
+		)
+		if err := rows.Scan(&idx, &stepType, &payload); err != nil {
+			return nil, fmt.Errorf("scan step: %w", err)
+		}
+		msg, ok := decodeAntigravityStep(idx, stepType, payload)
+		if !ok {
+			continue
+		}
+		out = append(out, msg)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate steps: %w", err)
+	}
+	return out, nil
+}
+
+// decodeAntigravityStep extracts a ParsedMessage from one step's
+// protobuf payload. Without an upstream .proto we use heuristics:
+//   - role: step_type 14 has been observed to carry user prompts.
+//     Every other type is rendered as assistant. (TODO: refine
+//     when more sample data is available.)
+//   - content: concatenation of every UTF-8 string >= 20 chars
+//     found anywhere in the payload tree, deduped.
+//   - timestamp: earliest google.protobuf.Timestamp-shaped field.
+func decodeAntigravityStep(
+	idx, stepType int, payload []byte,
+) (ParsedMessage, bool) {
+	if len(payload) == 0 {
+		return ParsedMessage{}, false
+	}
+	fields, err := agProtoParse(payload)
+	if err != nil || len(fields) == 0 {
+		return ParsedMessage{}, false
+	}
+	strs := dedupeStrings(agProtoCollectStrings(fields, 20))
+	ts := earliestAntigravityTimestamp(fields)
+	if len(strs) == 0 {
+		return ParsedMessage{}, false
+	}
+	role := RoleAssistant
+	if stepType == 14 {
+		role = RoleUser
+	}
+	header := fmt.Sprintf(
+		"[step %d · type %d]", idx, stepType,
+	)
+	content := header + "\n" + strings.Join(strs, "\n\n")
+	return ParsedMessage{
+		Role:          role,
+		Content:       content,
+		ContentLength: len(content),
+		Timestamp:     ts,
+	}, true
+}
+
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// earliestAntigravityTimestamp walks the field tree and returns
+// the earliest plausible google.protobuf.Timestamp value.
+// Plausible = seconds field in the year 2000..2100 range.
+func earliestAntigravityTimestamp(
+	fields []agProtoField,
+) time.Time {
+	var best time.Time
+	var walk func([]agProtoField)
+	walk = func(fs []agProtoField) {
+		for _, f := range fs {
+			if f.Nested != nil {
+				if sec, nanos, ok := agProtoTimestamp(f.Nested); ok {
+					if sec > 946_684_800 && sec < 4_102_444_800 {
+						t := time.Unix(sec, int64(nanos))
+						if best.IsZero() || t.Before(best) {
+							best = t
+						}
+					}
+				}
+				walk(f.Nested)
+			}
+		}
+	}
+	walk(fields)
+	return best
+}
+
+// readAntigravityAnnotation parses last_user_view_time from a
+// pbtxt annotation file. Returns zero time on any failure.
+func readAntigravityAnnotation(path string) time.Time {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return time.Time{}
+	}
+	// last_user_view_time:{seconds:1779326586 nanos:959000000}
+	i := strings.Index(string(data), "last_user_view_time")
+	if i < 0 {
+		return time.Time{}
+	}
+	rest := string(data[i:])
+	j := strings.Index(rest, "seconds:")
+	if j < 0 {
+		return time.Time{}
+	}
+	rest = rest[j+len("seconds:"):]
+	end := strings.IndexAny(rest, " \n\t}")
+	if end < 0 {
+		return time.Time{}
+	}
+	var sec int64
+	if _, err := fmt.Sscanf(rest[:end], "%d", &sec); err != nil {
+		return time.Time{}
+	}
+	return time.Unix(sec, 0)
+}

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -85,8 +85,7 @@ func FindAntigravityCLISourceFile(root, id string) string {
 	if root == "" {
 		return ""
 	}
-	if strings.HasPrefix(id, antigravityImplicitTag) {
-		uuid := strings.TrimPrefix(id, antigravityImplicitTag)
+	if uuid, ok := strings.CutPrefix(id, antigravityImplicitTag); ok {
 		if !IsValidSessionID(uuid) {
 			return ""
 		}

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -25,7 +25,16 @@ import (
 // rows. With the key we additionally append the decrypted transcript
 // preview (raw extracted strings) as a synthetic assistant message.
 
-const antigravityCLIIDPrefix = "antigravity-cli:"
+const (
+	antigravityCLIIDPrefix = "antigravity-cli:"
+
+	// antigravityImplicitTag distinguishes implicit/<uuid>.pb from
+	// conversations/<uuid>.pb in the storage ID. Both can exist for
+	// the same UUID; without a tag they collide as
+	// "antigravity-cli:<uuid>" and one record overwrites the other.
+	// Hyphen keeps the tag inside the IsValidSessionID charset.
+	antigravityImplicitTag = "implicit-"
+)
 
 // DiscoverAntigravityCLISessions enumerates conversations/*.pb and
 // implicit/*.pb under the CLI root and tags each with its workspace
@@ -70,17 +79,29 @@ func DiscoverAntigravityCLISessions(root string) []DiscoveredFile {
 }
 
 // FindAntigravityCLISourceFile locates the .pb file for a session
-// id (without the agent prefix). Checks conversations/ then
-// implicit/.
+// id (without the agent prefix). An "implicit-" prefix routes to
+// the implicit/ subdir; bare ids resolve under conversations/.
 func FindAntigravityCLISourceFile(root, id string) string {
-	if root == "" || !IsValidSessionID(id) {
+	if root == "" {
 		return ""
 	}
-	for _, sub := range []string{"conversations", "implicit"} {
-		p := filepath.Join(root, sub, id+".pb")
+	if strings.HasPrefix(id, antigravityImplicitTag) {
+		uuid := strings.TrimPrefix(id, antigravityImplicitTag)
+		if !IsValidSessionID(uuid) {
+			return ""
+		}
+		p := filepath.Join(root, "implicit", uuid+".pb")
 		if _, err := os.Stat(p); err == nil {
 			return p
 		}
+		return ""
+	}
+	if !IsValidSessionID(id) {
+		return ""
+	}
+	p := filepath.Join(root, "conversations", id+".pb")
+	if _, err := os.Stat(p); err == nil {
+		return p
 	}
 	return ""
 }
@@ -103,6 +124,12 @@ func ParseAntigravityCLISession(
 	// Root = two levels up from the .pb file
 	// (conversations/<id>.pb or implicit/<id>.pb).
 	root := filepath.Dir(filepath.Dir(path))
+	// Tag implicit/ sessions so they don't collide with the
+	// conversations/ entry that may share the same UUID.
+	storageID := id
+	if filepath.Base(filepath.Dir(path)) == "implicit" {
+		storageID = antigravityImplicitTag + id
+	}
 
 	messages := collectAntigravityHistoryMessages(
 		filepath.Join(root, "history.jsonl"), id,
@@ -162,7 +189,7 @@ func ParseAntigravityCLISession(
 	}
 
 	sess := &ParsedSession{
-		ID:               antigravityCLIIDPrefix + id,
+		ID:               antigravityCLIIDPrefix + storageID,
 		Project:          project,
 		Machine:          machine,
 		Agent:            AgentAntigravityCLI,

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -1,0 +1,353 @@
+package parser
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+// Antigravity CLI sessions live under ~/.gemini/antigravity-cli/:
+//
+//   conversations/<uuid>.pb      AES-encrypted conversation stream
+//   implicit/<uuid>.pb           AES-encrypted implicit conversation
+//   brain/<uuid>/*.md(+.json)    plaintext task/plan/walkthrough docs
+//   history.jsonl                user-prompt log (one row per turn)
+//   cache/last_conversations.json   workspace -> conversationId
+//
+// Without the AES key (ANTIGRAVITY_KEY) we still produce a useful
+// session from the brain/ artifacts and the matching history.jsonl
+// rows. With the key we additionally append the decrypted transcript
+// preview (raw extracted strings) as a synthetic assistant message.
+
+const antigravityCLIIDPrefix = "antigravity-cli:"
+
+// DiscoverAntigravityCLISessions enumerates conversations/*.pb and
+// implicit/*.pb under the CLI root and tags each with its workspace
+// (resolved via history.jsonl).
+func DiscoverAntigravityCLISessions(root string) []DiscoveredFile {
+	if root == "" {
+		return nil
+	}
+	projects := buildAntigravityProjectMap(
+		filepath.Join(root, "history.jsonl"),
+	)
+	var files []DiscoveredFile
+	for _, sub := range []string{"conversations", "implicit"} {
+		dir := filepath.Join(root, sub)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if !strings.HasSuffix(name, ".pb") {
+				continue
+			}
+			id := strings.TrimSuffix(name, ".pb")
+			if !IsValidSessionID(id) {
+				continue
+			}
+			files = append(files, DiscoveredFile{
+				Path:    filepath.Join(dir, name),
+				Project: projects[id],
+				Agent:   AgentAntigravityCLI,
+			})
+		}
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+// FindAntigravityCLISourceFile locates the .pb file for a session
+// id (without the agent prefix). Checks conversations/ then
+// implicit/.
+func FindAntigravityCLISourceFile(root, id string) string {
+	if root == "" || !IsValidSessionID(id) {
+		return ""
+	}
+	for _, sub := range []string{"conversations", "implicit"} {
+		p := filepath.Join(root, sub, id+".pb")
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// ParseAntigravityCLISession parses one CLI session into the
+// canonical ParsedSession + messages shape.
+func ParseAntigravityCLISession(
+	path, project, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	id := strings.TrimSuffix(filepath.Base(path), ".pb")
+	if !IsValidSessionID(id) {
+		return nil, nil, fmt.Errorf(
+			"invalid Antigravity CLI session filename: %s", path,
+		)
+	}
+	// Root = two levels up from the .pb file
+	// (conversations/<id>.pb or implicit/<id>.pb).
+	root := filepath.Dir(filepath.Dir(path))
+
+	messages := collectAntigravityHistoryMessages(
+		filepath.Join(root, "history.jsonl"), id,
+	)
+	messages = append(messages,
+		collectAntigravityBrainMessages(
+			filepath.Join(root, "brain", id),
+		)...,
+	)
+
+	if hasAntigravityKey() {
+		if extra, ok := decryptAntigravityCLITranscript(path); ok {
+			messages = append(messages, extra)
+		}
+	}
+
+	sort.SliceStable(messages, func(i, j int) bool {
+		return messages[i].Timestamp.Before(messages[j].Timestamp)
+	})
+	for i := range messages {
+		messages[i].Ordinal = i
+	}
+
+	if project == "" {
+		project = inferAntigravityProject(
+			filepath.Join(root, "history.jsonl"), id,
+		)
+	}
+
+	var firstMessage string
+	var userCount int
+	var startedAt, endedAt time.Time
+	for _, m := range messages {
+		if m.Role == RoleUser {
+			userCount++
+			if firstMessage == "" && m.Content != "" {
+				firstMessage = truncate(
+					strings.ReplaceAll(m.Content, "\n", " "),
+					300,
+				)
+			}
+		}
+		if !m.Timestamp.IsZero() {
+			if startedAt.IsZero() || m.Timestamp.Before(startedAt) {
+				startedAt = m.Timestamp
+			}
+			if m.Timestamp.After(endedAt) {
+				endedAt = m.Timestamp
+			}
+		}
+	}
+	if startedAt.IsZero() {
+		startedAt = info.ModTime()
+	}
+	if endedAt.IsZero() {
+		endedAt = info.ModTime()
+	}
+
+	sess := &ParsedSession{
+		ID:               antigravityCLIIDPrefix + id,
+		Project:          project,
+		Machine:          machine,
+		Agent:            AgentAntigravityCLI,
+		FirstMessage:     firstMessage,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     len(messages),
+		UserMessageCount: userCount,
+		File: FileInfo{
+			Path:  path,
+			Size:  info.Size(),
+			Mtime: info.ModTime().UnixNano(),
+		},
+	}
+	if len(messages) == 0 {
+		return sess, nil, nil
+	}
+	return sess, messages, nil
+}
+
+// buildAntigravityProjectMap reads history.jsonl and returns a
+// map of conversationId -> workspace path.
+func buildAntigravityProjectMap(path string) map[string]string {
+	out := make(map[string]string)
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		id := gjson.GetBytes(line, "conversationId").Str
+		ws := gjson.GetBytes(line, "workspace").Str
+		if id != "" && ws != "" {
+			out[id] = ws
+		}
+	}
+	return out
+}
+
+func inferAntigravityProject(path, id string) string {
+	m := buildAntigravityProjectMap(path)
+	return m[id]
+}
+
+// collectAntigravityHistoryMessages returns one user ParsedMessage
+// per history.jsonl row matching the conversationId.
+func collectAntigravityHistoryMessages(
+	path, id string,
+) []ParsedMessage {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	var out []ParsedMessage
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		cid := gjson.GetBytes(line, "conversationId").Str
+		if cid != id {
+			continue
+		}
+		display := gjson.GetBytes(line, "display").Str
+		if display == "" {
+			continue
+		}
+		tsMS := gjson.GetBytes(line, "timestamp").Int()
+		out = append(out, ParsedMessage{
+			Role:          RoleUser,
+			Content:       display,
+			ContentLength: len(display),
+			Timestamp:     time.UnixMilli(tsMS),
+		})
+	}
+	return out
+}
+
+// collectAntigravityBrainMessages reads brain/<id>/*.md plus
+// sibling .metadata.json files and emits one assistant message
+// per artifact.
+func collectAntigravityBrainMessages(dir string) []ParsedMessage {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []ParsedMessage
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		ts, summary, artifactType := readAntigravityArtifactMeta(
+			filepath.Join(dir, name+".metadata.json"),
+		)
+		header := "[" + name + "]"
+		if artifactType != "" {
+			header = "[" + artifactType + " — " + name + "]"
+		}
+		var content string
+		if summary != "" {
+			content = header + "\n" + summary + "\n\n" +
+				string(body)
+		} else {
+			content = header + "\n" + string(body)
+		}
+		out = append(out, ParsedMessage{
+			Role:          RoleAssistant,
+			Content:       content,
+			ContentLength: len(content),
+			Timestamp:     ts,
+		})
+	}
+	return out
+}
+
+func readAntigravityArtifactMeta(
+	path string,
+) (ts time.Time, summary, artifactType string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return time.Time{}, "", ""
+	}
+	summary = gjson.GetBytes(data, "summary").Str
+	artifactType = gjson.GetBytes(data, "artifactType").Str
+	if s := gjson.GetBytes(data, "updatedAt").Str; s != "" {
+		if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+			ts = t
+		}
+	}
+	return ts, summary, artifactType
+}
+
+// decryptAntigravityCLITranscript attempts to decrypt a .pb file
+// and returns a single assistant ParsedMessage holding the raw
+// strings extracted from the plaintext. Returns ok=false when
+// decryption fails or yields no usable text.
+func decryptAntigravityCLITranscript(
+	path string,
+) (ParsedMessage, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ParsedMessage{}, false
+	}
+	plain, err := decryptAntigravity(data)
+	if err != nil || plain == nil {
+		return ParsedMessage{}, false
+	}
+	fields, err := agProtoParse(plain)
+	if err != nil || len(fields) == 0 {
+		return ParsedMessage{}, false
+	}
+	strs := agProtoCollectStrings(fields, 40)
+	if len(strs) == 0 {
+		return ParsedMessage{}, false
+	}
+	body := strings.Join(strs, "\n\n---\n\n")
+	header := "[Antigravity CLI: decrypted transcript preview]\n" +
+		"(field schema unknown; strings extracted by wire walker)\n\n"
+	content := header + body
+	info, statErr := os.Stat(path)
+	var ts time.Time
+	if statErr == nil {
+		ts = info.ModTime()
+	}
+	return ParsedMessage{
+		Role:          RoleAssistant,
+		Content:       content,
+		ContentLength: len(content),
+		Timestamp:     ts,
+	}, true
+}

--- a/internal/parser/antigravity_crypto.go
+++ b/internal/parser/antigravity_crypto.go
@@ -1,0 +1,200 @@
+package parser
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"errors"
+	"os"
+	"sync"
+)
+
+// Antigravity CLI conversations are AES-encrypted on disk.
+// The Python decryptor (github.com/arashz/antigravity_decryptor)
+// tries CTR (primary) then CBC / GCM with various skip offsets.
+// We mirror that strategy with Go stdlib primitives.
+//
+// Key sources (v1, in order):
+//  1. ANTIGRAVITY_KEY env var, base64-encoded (matches the
+//     Python tool's env-var fallback).
+//
+// Follow-up: probe libsecret / KWallet on Linux and the macOS
+// Keychain via `security find-generic-password`. Tracked.
+
+var (
+	agKeyOnce sync.Once
+	agKeyVal  []byte
+	agKeyErr  error
+)
+
+// loadAntigravityKey returns the AES key (16, 24, or 32 bytes)
+// or an error explaining why no key was found. Cached for the
+// life of the process — agents only re-resolve the key on
+// restart.
+func loadAntigravityKey() ([]byte, error) {
+	agKeyOnce.Do(func() {
+		raw := os.Getenv("ANTIGRAVITY_KEY")
+		if raw == "" {
+			agKeyErr = errors.New(
+				"ANTIGRAVITY_KEY env var not set; set it " +
+					"to the base64-encoded key to decrypt " +
+					"Antigravity CLI conversations",
+			)
+			return
+		}
+		key, err := base64.StdEncoding.DecodeString(raw)
+		if err != nil {
+			agKeyErr = errors.New(
+				"ANTIGRAVITY_KEY is not valid base64",
+			)
+			return
+		}
+		switch len(key) {
+		case 16, 24, 32:
+			agKeyVal = key
+		default:
+			agKeyErr = errors.New(
+				"ANTIGRAVITY_KEY decodes to an unsupported " +
+					"AES key length (need 16/24/32 bytes)",
+			)
+		}
+	})
+	if agKeyErr != nil {
+		return nil, agKeyErr
+	}
+	return agKeyVal, nil
+}
+
+// hasAntigravityKey reports whether decryption is currently
+// possible. Callers use this to decide between full transcript
+// mode and the brain/+history.jsonl fallback.
+func hasAntigravityKey() bool {
+	_, err := loadAntigravityKey()
+	return err == nil
+}
+
+// decryptAntigravity tries each (mode, skip, post-skip)
+// combination from the Python decryptor and returns the first
+// plaintext that walks as protobuf with at least one field.
+// Returns nil, nil when none worked (caller should treat as a
+// non-decryptable session rather than an error).
+func decryptAntigravity(data []byte) ([]byte, error) {
+	key, err := loadAntigravityKey()
+	if err != nil {
+		return nil, err
+	}
+	type modeFn func([]byte, []byte, int) []byte
+	modes := []modeFn{
+		decryptAesCTR,
+		decryptAesCBC,
+		decryptAesGCM,
+	}
+	skips := []int{0, 1, 2, 4, 8}
+	for _, fn := range modes {
+		for _, skip := range skips {
+			plain := fn(data, key, skip)
+			if plain == nil {
+				continue
+			}
+			for _, post := range skips {
+				if post >= len(plain) {
+					continue
+				}
+				cand := plain[post:]
+				if isLikelyAntigravityProto(cand) {
+					return cand, nil
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+func decryptAesCTR(data, key []byte, skip int) []byte {
+	if len(data) < skip+16 {
+		return nil
+	}
+	data = data[skip:]
+	nonce := data[:16]
+	ct := data[16:]
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil
+	}
+	out := make([]byte, len(ct))
+	cipher.NewCTR(block, nonce).XORKeyStream(out, ct)
+	return out
+}
+
+func decryptAesCBC(data, key []byte, skip int) []byte {
+	if len(data) < skip+16 {
+		return nil
+	}
+	data = data[skip:]
+	iv := data[:16]
+	ct := data[16:]
+	if len(ct) == 0 || len(ct)%aes.BlockSize != 0 {
+		return nil
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil
+	}
+	out := make([]byte, len(ct))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(out, ct)
+	return stripPKCS7(out)
+}
+
+func decryptAesGCM(data, key []byte, skip int) []byte {
+	if len(data) < skip+12+16 {
+		return nil
+	}
+	data = data[skip:]
+	nonce := data[:12]
+	ct := data[12:]
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil
+	}
+	plain, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return nil
+	}
+	return plain
+}
+
+func stripPKCS7(data []byte) []byte {
+	if len(data) == 0 {
+		return data
+	}
+	pad := int(data[len(data)-1])
+	if pad == 0 || pad > aes.BlockSize || pad > len(data) {
+		return data
+	}
+	for _, b := range data[len(data)-pad:] {
+		if int(b) != pad {
+			return data
+		}
+	}
+	return data[:len(data)-pad]
+}
+
+// isLikelyAntigravityProto runs the wire walker over the first
+// chunk of a candidate plaintext and reports whether it looks
+// like a well-formed message. Caps work at 4KB to keep the
+// retry loop cheap.
+func isLikelyAntigravityProto(data []byte) bool {
+	head := data
+	if len(head) > 4096 {
+		head = head[:4096]
+	}
+	fields, err := agProtoParse(head)
+	if err != nil || len(fields) == 0 {
+		return false
+	}
+	return agProtoLooksLikeMessage(fields)
+}

--- a/internal/parser/antigravity_crypto.go
+++ b/internal/parser/antigravity_crypto.go
@@ -186,15 +186,13 @@ func stripPKCS7(data []byte) []byte {
 // isLikelyAntigravityProto runs the wire walker over the first
 // chunk of a candidate plaintext and reports whether it looks
 // like a well-formed message. Caps work at 4KB to keep the
-// retry loop cheap.
+// retry loop cheap. Uses the prefix-tolerant validator so that
+// large valid transcripts whose 4KB sniff falls mid-field still
+// pass.
 func isLikelyAntigravityProto(data []byte) bool {
 	head := data
 	if len(head) > 4096 {
 		head = head[:4096]
 	}
-	fields, err := agProtoParse(head)
-	if err != nil || len(fields) == 0 {
-		return false
-	}
-	return agProtoLooksLikeMessage(fields)
+	return agProtoLooksLikePrefix(head)
 }

--- a/internal/parser/antigravity_proto.go
+++ b/internal/parser/antigravity_proto.go
@@ -1,0 +1,237 @@
+package parser
+
+import (
+	"encoding/binary"
+	"errors"
+	"unicode/utf8"
+)
+
+// Generic protobuf wire-format walker used by both Antigravity
+// agents. We do not have the official .proto schema, so the
+// walker extracts a permissive field tree and exposes helpers
+// for pulling out strings and Timestamp-like (seconds, nanos)
+// values by field number.
+
+const (
+	pbWireVarint     = 0
+	pbWireFixed64    = 1
+	pbWireBytes      = 2
+	pbWireStartGroup = 3 // deprecated, ignored
+	pbWireEndGroup   = 4 // deprecated, ignored
+	pbWireFixed32    = 5
+
+	// agProtoMaxDepth caps nested-message recursion to keep
+	// malformed payloads from exploding the call stack.
+	agProtoMaxDepth = 32
+)
+
+// agProtoField is one wire-format field decoded from a payload.
+// For length-delimited fields, Bytes holds the raw payload and
+// Nested holds the recursively-decoded sub-fields when the
+// payload looks like a well-formed message; Nested is nil when
+// the payload is opaque (likely a string or binary blob).
+type agProtoField struct {
+	Number int
+	Wire   int
+	// Varint holds the value when Wire == pbWireVarint.
+	Varint uint64
+	// Fixed holds the raw 4 or 8 bytes when Wire is fixed32/64.
+	Fixed []byte
+	// Bytes holds the length-delimited payload as-is.
+	Bytes []byte
+	// Nested is set when Bytes was successfully reparsed as a
+	// nested message. Nil if the payload is not a message.
+	Nested []agProtoField
+}
+
+// agProtoParse decodes a protobuf payload into a flat slice of
+// fields at the top level. Length-delimited sub-payloads are
+// speculatively re-parsed as nested messages.
+func agProtoParse(data []byte) ([]agProtoField, error) {
+	return agProtoParseDepth(data, 0)
+}
+
+func agProtoParseDepth(
+	data []byte, depth int,
+) ([]agProtoField, error) {
+	if depth > agProtoMaxDepth {
+		return nil, errors.New("antigravity proto: max depth")
+	}
+	var out []agProtoField
+	pos := 0
+	for pos < len(data) {
+		tag, n := binary.Uvarint(data[pos:])
+		if n <= 0 {
+			return nil, errors.New("antigravity proto: bad tag")
+		}
+		pos += n
+		number := int(tag >> 3)
+		wire := int(tag & 0x7)
+		if number <= 0 {
+			return nil, errors.New("antigravity proto: zero field")
+		}
+		f := agProtoField{Number: number, Wire: wire}
+		switch wire {
+		case pbWireVarint:
+			v, m := binary.Uvarint(data[pos:])
+			if m <= 0 {
+				return nil, errors.New(
+					"antigravity proto: bad varint",
+				)
+			}
+			f.Varint = v
+			pos += m
+		case pbWireFixed64:
+			if pos+8 > len(data) {
+				return nil, errors.New(
+					"antigravity proto: short fixed64",
+				)
+			}
+			f.Fixed = data[pos : pos+8]
+			pos += 8
+		case pbWireFixed32:
+			if pos+4 > len(data) {
+				return nil, errors.New(
+					"antigravity proto: short fixed32",
+				)
+			}
+			f.Fixed = data[pos : pos+4]
+			pos += 4
+		case pbWireBytes:
+			ln, m := binary.Uvarint(data[pos:])
+			if m <= 0 {
+				return nil, errors.New(
+					"antigravity proto: bad length",
+				)
+			}
+			pos += m
+			if uint64(pos)+ln > uint64(len(data)) {
+				return nil, errors.New(
+					"antigravity proto: short bytes",
+				)
+			}
+			f.Bytes = data[pos : pos+int(ln)]
+			pos += int(ln)
+			if nested, err := agProtoParseDepth(
+				f.Bytes, depth+1,
+			); err == nil && agProtoLooksLikeMessage(nested) {
+				f.Nested = nested
+			}
+		case pbWireStartGroup, pbWireEndGroup:
+			// Skip; deprecated and not used by Antigravity.
+		default:
+			return nil, errors.New(
+				"antigravity proto: unknown wire type",
+			)
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// agProtoLooksLikeMessage returns true when the decoded fields
+// look more like a nested message than coincidentally-parseable
+// random bytes (e.g. UTF-8 strings whose first byte happens to
+// decode as a valid tag). The heuristic: at least one field and
+// every field's number is in a reasonable range.
+func agProtoLooksLikeMessage(fields []agProtoField) bool {
+	if len(fields) == 0 {
+		return false
+	}
+	for _, f := range fields {
+		if f.Number < 1 || f.Number > 100000 {
+			return false
+		}
+	}
+	return true
+}
+
+// agProtoString returns the payload of f as a UTF-8 string when
+// f is length-delimited and the bytes parse as valid UTF-8.
+func agProtoString(f agProtoField) (string, bool) {
+	if f.Wire != pbWireBytes {
+		return "", false
+	}
+	if !utf8.Valid(f.Bytes) {
+		return "", false
+	}
+	return string(f.Bytes), true
+}
+
+// agProtoFind returns the first sub-field with the given field
+// number, descending into Nested messages.
+func agProtoFind(
+	fields []agProtoField, number int,
+) (agProtoField, bool) {
+	for _, f := range fields {
+		if f.Number == number {
+			return f, true
+		}
+	}
+	return agProtoField{}, false
+}
+
+// agProtoFindAll returns all sub-fields at the top level with
+// the given field number.
+func agProtoFindAll(
+	fields []agProtoField, number int,
+) []agProtoField {
+	var out []agProtoField
+	for _, f := range fields {
+		if f.Number == number {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// agProtoCollectStrings walks the field tree and returns every
+// UTF-8 string with at least minLen runes. Returned in encounter
+// order. Duplicates are preserved (callers can dedupe).
+func agProtoCollectStrings(
+	fields []agProtoField, minLen int,
+) []string {
+	var out []string
+	var walk func([]agProtoField)
+	walk = func(fs []agProtoField) {
+		for _, f := range fs {
+			if f.Wire == pbWireBytes && f.Nested == nil {
+				if s, ok := agProtoString(f); ok &&
+					utf8.RuneCountInString(s) >= minLen {
+					out = append(out, s)
+				}
+			}
+			if f.Nested != nil {
+				walk(f.Nested)
+			}
+		}
+	}
+	walk(fields)
+	return out
+}
+
+// agProtoTimestamp returns (seconds, nanos, ok) when fields
+// match the google.protobuf.Timestamp shape: field 1 varint
+// seconds, optional field 2 varint nanos, and no other fields.
+func agProtoTimestamp(
+	fields []agProtoField,
+) (int64, int32, bool) {
+	var sec int64
+	var nanos int32
+	sawSec := false
+	for _, f := range fields {
+		if f.Wire != pbWireVarint {
+			return 0, 0, false
+		}
+		switch f.Number {
+		case 1:
+			sec = int64(f.Varint)
+			sawSec = true
+		case 2:
+			nanos = int32(f.Varint)
+		default:
+			return 0, 0, false
+		}
+	}
+	return sec, nanos, sawSec
+}

--- a/internal/parser/antigravity_proto.go
+++ b/internal/parser/antigravity_proto.go
@@ -171,20 +171,6 @@ func agProtoFind(
 	return agProtoField{}, false
 }
 
-// agProtoFindAll returns all sub-fields at the top level with
-// the given field number.
-func agProtoFindAll(
-	fields []agProtoField, number int,
-) []agProtoField {
-	var out []agProtoField
-	for _, f := range fields {
-		if f.Number == number {
-			out = append(out, f)
-		}
-	}
-	return out
-}
-
 // agProtoCollectStrings walks the field tree and returns every
 // UTF-8 string with at least minLen runes. Returned in encounter
 // order. Duplicates are preserved (callers can dedupe).

--- a/internal/parser/antigravity_proto.go
+++ b/internal/parser/antigravity_proto.go
@@ -105,7 +105,11 @@ func agProtoParseDepth(
 				)
 			}
 			pos += m
-			if uint64(pos)+ln > uint64(len(data)) {
+			// Overflow-safe: pos <= len(data) is invariant (Uvarint
+			// caps m), so len(data)-pos is non-negative. Comparing
+			// against ln without addition avoids uint64 wrap on a
+			// malformed huge length varint.
+			if ln > uint64(len(data)-pos) {
 				return nil, errors.New(
 					"antigravity proto: short bytes",
 				)
@@ -194,6 +198,65 @@ func agProtoCollectStrings(
 	}
 	walk(fields)
 	return out
+}
+
+// agProtoLooksLikePrefix returns true when data starts with a
+// well-formed protobuf field sequence — even if the final field
+// runs off the end of data. Used to validate decryption
+// candidates against a fixed-size sniff (e.g. the first 4KB):
+// agProtoParse would reject a buffer truncated mid-field, which
+// can throw away valid large transcripts. This validator accepts
+// any clean prefix of fields plus a partially-read tail, as long
+// as at least one full field decoded cleanly first.
+func agProtoLooksLikePrefix(data []byte) bool {
+	pos := 0
+	parsed := 0
+	for pos < len(data) {
+		tag, n := binary.Uvarint(data[pos:])
+		if n <= 0 {
+			return parsed > 0
+		}
+		pos += n
+		number := int(tag >> 3)
+		wire := int(tag & 0x7)
+		if number < 1 || number > 100000 {
+			return false
+		}
+		switch wire {
+		case pbWireVarint:
+			_, m := binary.Uvarint(data[pos:])
+			if m <= 0 {
+				return parsed > 0
+			}
+			pos += m
+		case pbWireFixed64:
+			if pos+8 > len(data) {
+				return parsed > 0
+			}
+			pos += 8
+		case pbWireFixed32:
+			if pos+4 > len(data) {
+				return parsed > 0
+			}
+			pos += 4
+		case pbWireBytes:
+			ln, m := binary.Uvarint(data[pos:])
+			if m <= 0 {
+				return parsed > 0
+			}
+			pos += m
+			if ln > uint64(len(data)-pos) {
+				return parsed > 0
+			}
+			pos += int(ln)
+		case pbWireStartGroup, pbWireEndGroup:
+			// deprecated; skip
+		default:
+			return false
+		}
+		parsed++
+	}
+	return parsed > 0
 }
 
 // agProtoTimestamp returns (seconds, nanos, ok) when fields

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -1,6 +1,9 @@
 package parser
 
 import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
 	"database/sql"
 	"encoding/binary"
 	"os"
@@ -297,6 +300,189 @@ func TestAntigravityKeyMissing(t *testing.T) {
 	// Cannot reset sync.Once without restructuring the source.
 	// At minimum verify hasAntigravityKey doesn't panic.
 	_ = hasAntigravityKey()
+}
+
+// ---- crypto: cipher round-trips -------------------------------
+
+// TestDecryptAesGCMRoundTrip encrypts a payload with stdlib AES-GCM
+// in the same layout decryptAesGCM expects (12-byte nonce prefix +
+// ciphertext-with-tag) and confirms recovery. GCM is Antigravity's
+// primary cipher per the handoff.
+func TestDecryptAesGCMRoundTrip(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, 32)
+	plaintext := []byte("hello antigravity gcm world")
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("new gcm: %v", err)
+	}
+	nonce := bytes.Repeat([]byte{0x01}, 12)
+	ct := gcm.Seal(nil, nonce, plaintext, nil)
+	data := append(append([]byte{}, nonce...), ct...)
+
+	got := decryptAesGCM(data, key, 0)
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("decrypt: got %q want %q", got, plaintext)
+	}
+
+	// Wrong key → nil (auth tag fails).
+	bad := bytes.Repeat([]byte{0x43}, 32)
+	if out := decryptAesGCM(data, bad, 0); out != nil {
+		t.Fatalf("wrong key should fail, got %q", out)
+	}
+
+	// Too-short input → nil, not panic.
+	if out := decryptAesGCM([]byte{0x00}, key, 0); out != nil {
+		t.Fatalf("short input should return nil, got %q", out)
+	}
+}
+
+// TestDecryptAesGCMSkip confirms the leading-bytes skip works as
+// documented (the brute-forcer tries 0/1/2/4/8 byte prefixes).
+func TestDecryptAesGCMSkip(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, 32)
+	plaintext := []byte("with leading junk bytes")
+
+	block, _ := aes.NewCipher(key)
+	gcm, _ := cipher.NewGCM(block)
+	nonce := bytes.Repeat([]byte{0x02}, 12)
+	ct := gcm.Seal(nil, nonce, plaintext, nil)
+
+	prefix := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	data := append(append([]byte{}, prefix...), nonce...)
+	data = append(data, ct...)
+
+	got := decryptAesGCM(data, key, len(prefix))
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("decrypt with skip: got %q want %q", got, plaintext)
+	}
+}
+
+func TestStripPKCS7(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+		want []byte
+	}{
+		{
+			name: "valid one-byte pad",
+			in:   []byte{0x41, 0x42, 0x43, 0x01},
+			want: []byte{0x41, 0x42, 0x43},
+		},
+		{
+			name: "valid four-byte pad",
+			in: []byte{
+				0x41, 0x42, 0x43, 0x44,
+				0x04, 0x04, 0x04, 0x04,
+			},
+			want: []byte{0x41, 0x42, 0x43, 0x44},
+		},
+		{
+			name: "empty input passes through",
+			in:   []byte{},
+			want: []byte{},
+		},
+		{
+			name: "pad byte zero is invalid → unchanged",
+			in:   []byte{0x41, 0x00},
+			want: []byte{0x41, 0x00},
+		},
+		{
+			name: "pad larger than block size → unchanged",
+			in:   []byte{0x41, 0x42, 0xFF},
+			want: []byte{0x41, 0x42, 0xFF},
+		},
+		{
+			name: "inconsistent pad bytes → unchanged",
+			in:   []byte{0x41, 0x02, 0x03},
+			want: []byte{0x41, 0x02, 0x03},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripPKCS7(tc.in); !bytes.Equal(got, tc.want) {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---- CLI parser: discovery edges ------------------------------
+
+// TestAntigravityCLIDiscoverImplicit confirms .pb files under
+// implicit/ are discovered alongside conversations/.
+func TestAntigravityCLIDiscoverImplicit(t *testing.T) {
+	root := t.TempDir()
+	convID := "aaaaaaaa-1111-2222-3333-444444444444"
+	implID := "bbbbbbbb-5555-6666-7777-888888888888"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustMkdir(t, filepath.Join(root, "implicit"))
+	mustWrite(t,
+		filepath.Join(root, "conversations", convID+".pb"),
+		[]byte("x"))
+	mustWrite(t,
+		filepath.Join(root, "implicit", implID+".pb"),
+		[]byte("x"))
+
+	files := DiscoverAntigravityCLISessions(root)
+	if len(files) != 2 {
+		t.Fatalf("got %d files, want 2 (one per subdir)", len(files))
+	}
+	var sawConv, sawImpl bool
+	for _, f := range files {
+		if strings.Contains(f.Path, "/conversations/") {
+			sawConv = true
+		}
+		if strings.Contains(f.Path, "/implicit/") {
+			sawImpl = true
+		}
+	}
+	if !sawConv || !sawImpl {
+		t.Fatalf("missing subdir: conv=%v impl=%v",
+			sawConv, sawImpl)
+	}
+
+	// FindAntigravityCLISourceFile resolves either id.
+	if got := FindAntigravityCLISourceFile(root, implID); got == "" ||
+		!strings.HasSuffix(got, "implicit/"+implID+".pb") {
+		t.Fatalf("find implicit: %q", got)
+	}
+}
+
+func TestBuildAntigravityProjectMapRobust(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "history.jsonl")
+
+	// Missing file → empty map, no error.
+	if m := buildAntigravityProjectMap(path); len(m) != 0 {
+		t.Fatalf("missing file: got %d entries", len(m))
+	}
+
+	// Mix of valid rows, blank lines, garbage, and rows missing
+	// one of the two required fields. Only the valid rows survive.
+	mustWrite(t, path, []byte(
+		`{"conversationId":"id-1","workspace":"/tmp/a"}`+"\n"+
+			""+"\n"+
+			`not json at all`+"\n"+
+			`{"conversationId":"id-2"}`+"\n"+
+			`{"workspace":"/tmp/orphan"}`+"\n"+
+			`{"conversationId":"id-3","workspace":"/tmp/c"}`+"\n",
+	))
+	m := buildAntigravityProjectMap(path)
+	if len(m) != 2 {
+		t.Fatalf("got %d entries, want 2: %#v", len(m), m)
+	}
+	if m["id-1"] != "/tmp/a" || m["id-3"] != "/tmp/c" {
+		t.Fatalf("unexpected map: %#v", m)
+	}
+	if _, ok := m["id-2"]; ok {
+		t.Fatalf("id-2 had no workspace, should be absent")
+	}
 }
 
 // ---- helpers --------------------------------------------------

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -435,10 +435,10 @@ func TestAntigravityCLIDiscoverImplicit(t *testing.T) {
 	}
 	var sawConv, sawImpl bool
 	for _, f := range files {
-		if strings.Contains(f.Path, "/conversations/") {
+		switch filepath.Base(filepath.Dir(f.Path)) {
+		case "conversations":
 			sawConv = true
-		}
-		if strings.Contains(f.Path, "/implicit/") {
+		case "implicit":
 			sawImpl = true
 		}
 	}
@@ -448,8 +448,9 @@ func TestAntigravityCLIDiscoverImplicit(t *testing.T) {
 	}
 
 	// FindAntigravityCLISourceFile resolves either id.
+	wantImpl := filepath.Join("implicit", implID+".pb")
 	if got := FindAntigravityCLISourceFile(root, implID); got == "" ||
-		!strings.HasSuffix(got, "implicit/"+implID+".pb") {
+		!strings.HasSuffix(got, wantImpl) {
 		t.Fatalf("find implicit: %q", got)
 	}
 }

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -106,7 +106,7 @@ func TestAgProtoLengthOverflow(t *testing.T) {
 	tag := []byte{0x0A}
 	// Encode the largest uvarint (10 bytes, value 2^64-1).
 	huge := make([]byte, 10)
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		huge[i] = 0xFF
 	}
 	huge[9] = 0x01

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -96,6 +96,72 @@ func TestAgProtoParseAndExtract(t *testing.T) {
 	}
 }
 
+// TestAgProtoLengthOverflow feeds a length-delimited field whose
+// declared length is near uint64-max. The pre-fix code computed
+// pos+ln in uint64 and wrapped, then sliced with int(ln) which
+// panicked. The fix compares ln against (len(data)-pos) without
+// addition.
+func TestAgProtoLengthOverflow(t *testing.T) {
+	// Tag for field 1, wire 2 (length-delimited).
+	tag := []byte{0x0A}
+	// Encode the largest uvarint (10 bytes, value 2^64-1).
+	huge := make([]byte, 10)
+	for i := 0; i < 9; i++ {
+		huge[i] = 0xFF
+	}
+	huge[9] = 0x01
+	payload := append(append([]byte{}, tag...), huge...)
+	payload = append(payload, []byte("only-a-few-bytes")...)
+
+	// Must return an error rather than panicking or returning a
+	// bogus slice.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("agProtoParse panicked: %v", r)
+		}
+	}()
+	if _, err := agProtoParse(payload); err == nil {
+		t.Fatalf("expected error for oversized length, got nil")
+	}
+}
+
+// TestAgProtoLooksLikePrefix exercises the prefix-tolerant
+// validator used by the decryption retry loop. It must accept a
+// well-formed prefix followed by a truncated final field, but
+// reject random bytes.
+func TestAgProtoLooksLikePrefix(t *testing.T) {
+	complete := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 42},
+		{num: 2, wire: pbWireBytes, bytes: []byte("hello there")},
+	})
+	if !agProtoLooksLikePrefix(complete) {
+		t.Fatalf("complete message rejected")
+	}
+
+	// Append a length-delimited field whose declared length runs
+	// past the end of the buffer — agProtoParse rejects this, but
+	// the prefix-tolerant check should accept since at least one
+	// full field decoded cleanly first.
+	truncated := append(append([]byte{}, complete...),
+		// tag for field 3, wire 2; length 100; only 3 actual bytes
+		0x1A, 0x64, 0x41, 0x42, 0x43,
+	)
+	if agProtoLooksLikePrefix(truncated) != true {
+		t.Fatalf("truncated tail rejected; want accepted")
+	}
+	if _, err := agProtoParse(truncated); err == nil {
+		t.Fatalf("agProtoParse should still reject truncated tail")
+	}
+
+	// Pure garbage with zero clean fields → reject.
+	if agProtoLooksLikePrefix([]byte{0x00, 0x00, 0x00}) {
+		t.Fatalf("zero-field-number garbage accepted")
+	}
+	if agProtoLooksLikePrefix(nil) {
+		t.Fatalf("empty input accepted")
+	}
+}
+
 func TestEarliestAntigravityTimestamp(t *testing.T) {
 	older := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: 1700000000},
@@ -447,11 +513,66 @@ func TestAntigravityCLIDiscoverImplicit(t *testing.T) {
 			sawConv, sawImpl)
 	}
 
-	// FindAntigravityCLISourceFile resolves either id.
+	// FindAntigravityCLISourceFile routes implicit-tagged ids to
+	// the implicit/ subdir; bare ids resolve under conversations/.
 	wantImpl := filepath.Join("implicit", implID+".pb")
-	if got := FindAntigravityCLISourceFile(root, implID); got == "" ||
-		!strings.HasSuffix(got, wantImpl) {
+	if got := FindAntigravityCLISourceFile(
+		root, "implicit-"+implID,
+	); got == "" || !strings.HasSuffix(got, wantImpl) {
 		t.Fatalf("find implicit: %q", got)
+	}
+	wantConv := filepath.Join("conversations", convID+".pb")
+	if got := FindAntigravityCLISourceFile(root, convID); got == "" ||
+		!strings.HasSuffix(got, wantConv) {
+		t.Fatalf("find conv: %q", got)
+	}
+	// A bare implicit-only UUID must NOT resolve under conversations/.
+	if got := FindAntigravityCLISourceFile(root, implID); got != "" {
+		t.Fatalf("bare implicit id should not resolve: %q", got)
+	}
+}
+
+// TestAntigravityCLIImplicitSessionIDDistinct ensures a UUID that
+// appears under both conversations/ and implicit/ produces two
+// distinct storage IDs, so one record doesn't overwrite the other.
+func TestAntigravityCLIImplicitSessionIDDistinct(t *testing.T) {
+	root := t.TempDir()
+	id := "cccccccc-9999-aaaa-bbbb-dddddddddddd"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustMkdir(t, filepath.Join(root, "implicit"))
+	convPath := filepath.Join(root, "conversations", id+".pb")
+	implPath := filepath.Join(root, "implicit", id+".pb")
+	mustWrite(t, convPath, []byte("x"))
+	mustWrite(t, implPath, []byte("x"))
+
+	convSess, _, err := ParseAntigravityCLISession(convPath, "", "m")
+	if err != nil {
+		t.Fatalf("parse conv: %v", err)
+	}
+	implSess, _, err := ParseAntigravityCLISession(implPath, "", "m")
+	if err != nil {
+		t.Fatalf("parse impl: %v", err)
+	}
+	if convSess.ID == implSess.ID {
+		t.Fatalf("session ids collide: conv=%q impl=%q",
+			convSess.ID, implSess.ID)
+	}
+	if convSess.ID != "antigravity-cli:"+id {
+		t.Fatalf("conv id: %q", convSess.ID)
+	}
+	if implSess.ID != "antigravity-cli:implicit-"+id {
+		t.Fatalf("impl id: %q", implSess.ID)
+	}
+
+	// Round-trip: each storage id resolves back to its own file.
+	if got := FindAntigravityCLISourceFile(root, id); got != convPath {
+		t.Fatalf("round-trip conv: %q", got)
+	}
+	if got := FindAntigravityCLISourceFile(
+		root, "implicit-"+id,
+	); got != implPath {
+		t.Fatalf("round-trip impl: %q", got)
 	}
 }
 

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -1,0 +1,386 @@
+package parser
+
+import (
+	"database/sql"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// ---- protobuf wire walker -------------------------------------
+
+// agProtoEncode is a tiny test-only encoder used to hand-craft
+// payloads for the wire walker. It supports varint, length-
+// delimited bytes, and nested messages (re-encoded recursively).
+type pbField struct {
+	num    int
+	wire   int
+	varint uint64
+	bytes  []byte
+}
+
+func encodeVarint(v uint64) []byte {
+	buf := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(buf, v)
+	return buf[:n]
+}
+
+func encodePB(fields []pbField) []byte {
+	var out []byte
+	for _, f := range fields {
+		tag := uint64(f.num<<3) | uint64(f.wire)
+		out = append(out, encodeVarint(tag)...)
+		switch f.wire {
+		case pbWireVarint:
+			out = append(out, encodeVarint(f.varint)...)
+		case pbWireBytes:
+			out = append(out, encodeVarint(uint64(len(f.bytes)))...)
+			out = append(out, f.bytes...)
+		}
+	}
+	return out
+}
+
+func TestAgProtoParseAndExtract(t *testing.T) {
+	inner := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779326586},
+		{num: 2, wire: pbWireVarint, varint: 12345},
+	})
+	payload := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 7},
+		{
+			num:   17,
+			wire:  pbWireBytes,
+			bytes: []byte("Hi, what's up next?"),
+		},
+		{num: 5, wire: pbWireBytes, bytes: inner},
+	})
+
+	fields, err := agProtoParse(payload)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(fields) != 3 {
+		t.Fatalf("got %d fields, want 3", len(fields))
+	}
+
+	// Field 17 should be a UTF-8 string with no nested decoding.
+	got, _ := agProtoFind(fields, 17)
+	s, ok := agProtoString(got)
+	if !ok || s != "Hi, what's up next?" {
+		t.Fatalf("field 17: got %q ok=%v", s, ok)
+	}
+
+	// Field 5 should have nested fields parsed as a Timestamp.
+	tsf, _ := agProtoFind(fields, 5)
+	if tsf.Nested == nil {
+		t.Fatalf("field 5 not parsed as nested")
+	}
+	sec, nanos, ok := agProtoTimestamp(tsf.Nested)
+	if !ok || sec != 1779326586 || nanos != 12345 {
+		t.Fatalf("timestamp: sec=%d nanos=%d ok=%v",
+			sec, nanos, ok)
+	}
+
+	strs := agProtoCollectStrings(fields, 5)
+	if len(strs) != 1 || strs[0] != "Hi, what's up next?" {
+		t.Fatalf("collect strings: %#v", strs)
+	}
+}
+
+func TestEarliestAntigravityTimestamp(t *testing.T) {
+	older := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1700000000},
+		{num: 2, wire: pbWireVarint, varint: 0},
+	})
+	newer := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779326586},
+	})
+	payload := encodePB([]pbField{
+		{num: 3, wire: pbWireBytes, bytes: newer},
+		{num: 4, wire: pbWireBytes, bytes: older},
+	})
+	fields, err := agProtoParse(payload)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := earliestAntigravityTimestamp(fields)
+	if got.Unix() != 1700000000 {
+		t.Fatalf("got %d, want 1700000000", got.Unix())
+	}
+}
+
+// ---- CLI parser -----------------------------------------------
+
+func TestAntigravityCLIDiscoverAndParse(t *testing.T) {
+	root := t.TempDir()
+	id := "11111111-2222-3333-4444-555555555555"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustMkdir(t, filepath.Join(root, "implicit"))
+	mustMkdir(t, filepath.Join(root, "brain", id))
+
+	// Encrypted .pb stub (content does not matter without a key)
+	mustWrite(t, filepath.Join(root, "conversations", id+".pb"),
+		[]byte("encrypted-placeholder"))
+
+	// brain artifact + metadata
+	mustWrite(t, filepath.Join(root, "brain", id, "task.md"),
+		[]byte("# Task\n\n- step one"))
+	mustWrite(t,
+		filepath.Join(root, "brain", id, "task.md.metadata.json"),
+		[]byte(`{
+			"artifactType": "ARTIFACT_TYPE_TASK",
+			"summary": "Top task summary",
+			"updatedAt": "2026-05-20T22:47:27.078Z"
+		}`))
+
+	// history.jsonl: one row for our session, one for another
+	mustWrite(t, filepath.Join(root, "history.jsonl"),
+		[]byte(`{"display":"hello world","timestamp":1779000000000,`+
+			`"workspace":"/tmp/proj","conversationId":"`+id+`"}
+{"display":"other","timestamp":1779000001000,"workspace":"/tmp/x","conversationId":"other-id"}`))
+
+	// Discovery should return the .pb with the right project.
+	files := DiscoverAntigravityCLISessions(root)
+	if len(files) != 1 {
+		t.Fatalf("discover: got %d files, want 1", len(files))
+	}
+	if files[0].Project != "/tmp/proj" {
+		t.Fatalf("project: got %q want /tmp/proj", files[0].Project)
+	}
+
+	// Find by id should locate the same .pb.
+	if got := FindAntigravityCLISourceFile(root, id); got !=
+		files[0].Path {
+		t.Fatalf("find: got %q want %q", got, files[0].Path)
+	}
+
+	sess, msgs, err := ParseAntigravityCLISession(
+		files[0].Path, files[0].Project, "test-machine",
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if sess.ID != "antigravity-cli:"+id {
+		t.Fatalf("session id: %q", sess.ID)
+	}
+	// One user message from history + one assistant from brain.
+	if len(msgs) != 2 {
+		t.Fatalf("msgs: got %d want 2", len(msgs))
+	}
+	if msgs[0].Role != RoleUser ||
+		!strings.Contains(msgs[0].Content, "hello world") {
+		t.Fatalf("msg0: %+v", msgs[0])
+	}
+	if msgs[1].Role != RoleAssistant ||
+		!strings.Contains(msgs[1].Content, "step one") ||
+		!strings.Contains(msgs[1].Content, "Top task summary") {
+		t.Fatalf("msg1: %+v", msgs[1])
+	}
+	if sess.MessageCount != 2 || sess.UserMessageCount != 1 {
+		t.Fatalf(
+			"counts: msg=%d user=%d",
+			sess.MessageCount, sess.UserMessageCount,
+		)
+	}
+	if sess.FirstMessage != "hello world" {
+		t.Fatalf("first message: %q", sess.FirstMessage)
+	}
+	// StartedAt is the user message timestamp (epoch ms).
+	if sess.StartedAt.UnixMilli() != 1779000000000 {
+		t.Fatalf(
+			"startedAt: %d want 1779000000000",
+			sess.StartedAt.UnixMilli(),
+		)
+	}
+}
+
+func TestAntigravityCLIDiscoverIgnoresJunk(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	// Non-.pb files in the conversations dir are ignored.
+	mustWrite(t,
+		filepath.Join(root, "conversations", "README.txt"),
+		[]byte("x"))
+	// .pb files whose stem isn't a valid session id (contains
+	// characters outside [A-Za-z0-9_-]) are skipped.
+	mustWrite(t,
+		filepath.Join(root, "conversations", "bad.name.pb"),
+		[]byte("x"))
+	if files := DiscoverAntigravityCLISessions(root); len(files) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(files))
+	}
+}
+
+// ---- IDE parser -----------------------------------------------
+
+func TestAntigravityIDEDiscoverAndParse(t *testing.T) {
+	root := t.TempDir()
+	id := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustMkdir(t, filepath.Join(root, "annotations"))
+	mustMkdir(t, filepath.Join(root, "brain", id))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath)
+
+	mustWrite(t,
+		filepath.Join(root, "annotations", id+".pbtxt"),
+		[]byte("last_user_view_time:{seconds:1779326586 nanos:0}\n"))
+	mustWrite(t,
+		filepath.Join(root, "brain", id, "plan.md"),
+		[]byte("# Plan"))
+	mustWrite(t,
+		filepath.Join(root, "brain", id, "plan.md.metadata.json"),
+		[]byte(`{"summary":"Plan summary","updatedAt":"2026-05-20T22:47:27Z"}`))
+
+	files := DiscoverAntigravitySessions(root)
+	if len(files) != 1 || files[0].Path != dbPath {
+		t.Fatalf("discover: %#v", files)
+	}
+	if got := FindAntigravitySourceFile(root, id); got != dbPath {
+		t.Fatalf("find: got %q want %q", got, dbPath)
+	}
+
+	sess, msgs, err := ParseAntigravitySession(
+		dbPath, "", "test-machine",
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if sess.ID != "antigravity:"+id {
+		t.Fatalf("session id: %q", sess.ID)
+	}
+	// 2 step rows + 1 brain artifact = 3 messages
+	if len(msgs) != 3 {
+		t.Fatalf("msgs: %d", len(msgs))
+	}
+	// step_type=14 should be flagged as user
+	var sawUser, sawAssistant bool
+	for _, m := range msgs {
+		if m.Role == RoleUser {
+			sawUser = true
+			if !strings.Contains(m.Content, "user prompt text") {
+				t.Fatalf("user msg content: %q", m.Content)
+			}
+		}
+		if m.Role == RoleAssistant &&
+			strings.Contains(m.Content, "Plan summary") {
+			sawAssistant = true
+		}
+	}
+	if !sawUser || !sawAssistant {
+		t.Fatalf("missing role(s): user=%v assistant=%v",
+			sawUser, sawAssistant)
+	}
+	// Annotation overrides endedAt to 2026-05-20T... =
+	// 1779326586
+	if sess.EndedAt.Unix() != 1779326586 {
+		t.Fatalf("endedAt: %d", sess.EndedAt.Unix())
+	}
+}
+
+// ---- crypto: key loading --------------------------------------
+
+func TestAntigravityKeyMissing(t *testing.T) {
+	// loadAntigravityKey memoizes via sync.Once, so we test the
+	// observable behavior via hasAntigravityKey on a process
+	// without the env var. Set+unset to be explicit.
+	t.Setenv("ANTIGRAVITY_KEY", "")
+	// Cannot reset sync.Once without restructuring the source.
+	// At minimum verify hasAntigravityKey doesn't panic.
+	_ = hasAntigravityKey()
+}
+
+// ---- helpers --------------------------------------------------
+
+func mustMkdir(t *testing.T, p string) {
+	t.Helper()
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", p, err)
+	}
+}
+
+func mustWrite(t *testing.T, p string, b []byte) {
+	t.Helper()
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+}
+
+// createAntigravityTestDB writes a minimal antigravity IDE
+// SQLite database with two synthetic steps: a user prompt
+// (step_type=14) and an assistant step (step_type=17).
+func createAntigravityTestDB(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	mustExec(t, db, `CREATE TABLE trajectory_meta (
+		trajectory_id text, cascade_id text,
+		trajectory_type integer, source integer,
+		PRIMARY KEY (trajectory_id))`)
+	mustExec(t, db, `CREATE TABLE steps (
+		idx integer, step_type integer NOT NULL DEFAULT 0,
+		status integer NOT NULL DEFAULT 0,
+		has_subtrajectory numeric NOT NULL DEFAULT false,
+		metadata blob, error_details blob,
+		permissions blob, task_details blob,
+		render_info blob, step_payload blob,
+		step_format integer NOT NULL DEFAULT 0,
+		PRIMARY KEY (idx))`)
+
+	tsEarly := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000000},
+	})
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsEarly},
+		{
+			num:   17,
+			wire:  pbWireBytes,
+			bytes: []byte("user prompt text goes here"),
+		},
+	})
+	tsLate := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000100},
+	})
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsLate},
+		{
+			num:   17,
+			wire:  pbWireBytes,
+			bytes: []byte("assistant reply content body"),
+		},
+	})
+
+	mustExec(t, db,
+		`INSERT INTO steps (idx, step_type, step_payload) `+
+			`VALUES (?, ?, ?)`,
+		0, 14, userPayload)
+	mustExec(t, db,
+		`INSERT INTO steps (idx, step_type, step_payload) `+
+			`VALUES (?, ?, ?)`,
+		1, 17, asstPayload)
+}
+
+func mustExec(
+	t *testing.T, db *sql.DB, q string, args ...any,
+) {
+	t.Helper()
+	if _, err := db.Exec(q, args...); err != nil {
+		t.Fatalf("exec %q: %v", q, err)
+	}
+}
+
+// silence unused warning on time import in case the file is
+// trimmed in the future.
+var _ = time.Time{}

--- a/internal/parser/taxonomy.go
+++ b/internal/parser/taxonomy.go
@@ -46,6 +46,20 @@ func NormalizeToolCategory(rawName string) string {
 	case "search_files", "grep", "grep_search":
 		return "Grep"
 
+	// Antigravity tools
+	case "view_file", "read_url_content":
+		return "Read"
+	case "replace_file_content", "multi_replace_file_content":
+		return "Edit"
+	case "write_to_file":
+		return "Write"
+	case "define_subagent", "invoke_subagent", "manage_subagents",
+		"send_message", "manage_task":
+		return "Task"
+	case "ask_permission", "ask_question", "schedule", "search_web",
+		"generate_image":
+		return "Tool"
+
 	// OpenCode tools (lowercase variants)
 	// Note: "grep" is handled above in the Gemini section.
 	case "read":

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -27,14 +27,16 @@ const (
 	AgentKimi          AgentType = "kimi"
 	AgentClaudeAI      AgentType = "claude-ai"
 	AgentChatGPT       AgentType = "chatgpt"
-	AgentKiro          AgentType = "kiro"
-	AgentKiroIDE       AgentType = "kiro-ide"
-	AgentCortex        AgentType = "cortex"
-	AgentHermes        AgentType = "hermes"
-	AgentForge         AgentType = "forge"
-	AgentPiebald       AgentType = "piebald"
-	AgentWarp          AgentType = "warp"
-	AgentPositron      AgentType = "positron"
+	AgentKiro           AgentType = "kiro"
+	AgentKiroIDE        AgentType = "kiro-ide"
+	AgentCortex         AgentType = "cortex"
+	AgentHermes         AgentType = "hermes"
+	AgentForge          AgentType = "forge"
+	AgentPiebald        AgentType = "piebald"
+	AgentWarp           AgentType = "warp"
+	AgentPositron       AgentType = "positron"
+	AgentAntigravity    AgentType = "antigravity"
+	AgentAntigravityCLI AgentType = "antigravity-cli"
 )
 
 // AgentDef describes a supported coding agent's filesystem
@@ -367,6 +369,30 @@ var Registry = []AgentDef{
 		FileBased:      true,
 		DiscoverFunc:   DiscoverPositronSessions,
 		FindSourceFunc: FindPositronSourceFile,
+	},
+	{
+		Type:           AgentAntigravity,
+		DisplayName:    "Antigravity",
+		EnvVar:         "ANTIGRAVITY_DIR",
+		ConfigKey:      "antigravity_dirs",
+		DefaultDirs:    []string{".gemini/antigravity"},
+		IDPrefix:       "antigravity:",
+		WatchSubdirs:   []string{"brain"},
+		FileBased:      true,
+		DiscoverFunc:   DiscoverAntigravitySessions,
+		FindSourceFunc: FindAntigravitySourceFile,
+	},
+	{
+		Type:           AgentAntigravityCLI,
+		DisplayName:    "Antigravity CLI",
+		EnvVar:         "ANTIGRAVITY_CLI_DIR",
+		ConfigKey:      "antigravity_cli_dirs",
+		DefaultDirs:    []string{".gemini/antigravity-cli"},
+		IDPrefix:       "antigravity-cli:",
+		WatchSubdirs:   []string{"brain"},
+		FileBased:      true,
+		DiscoverFunc:   DiscoverAntigravityCLISessions,
+		FindSourceFunc: FindAntigravityCLISourceFile,
 	},
 }
 

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -10,23 +10,23 @@ import (
 type AgentType string
 
 const (
-	AgentClaude        AgentType = "claude"
-	AgentCodex         AgentType = "codex"
-	AgentCopilot       AgentType = "copilot"
-	AgentGemini        AgentType = "gemini"
-	AgentOpenCode      AgentType = "opencode"
-	AgentOpenHands     AgentType = "openhands"
-	AgentCursor        AgentType = "cursor"
-	AgentIflow         AgentType = "iflow"
-	AgentAmp           AgentType = "amp"
-	AgentZencoder      AgentType = "zencoder"
-	AgentVSCodeCopilot AgentType = "vscode-copilot"
-	AgentPi            AgentType = "pi"
-	AgentQwen          AgentType = "qwen"
-	AgentOpenClaw      AgentType = "openclaw"
-	AgentKimi          AgentType = "kimi"
-	AgentClaudeAI      AgentType = "claude-ai"
-	AgentChatGPT       AgentType = "chatgpt"
+	AgentClaude         AgentType = "claude"
+	AgentCodex          AgentType = "codex"
+	AgentCopilot        AgentType = "copilot"
+	AgentGemini         AgentType = "gemini"
+	AgentOpenCode       AgentType = "opencode"
+	AgentOpenHands      AgentType = "openhands"
+	AgentCursor         AgentType = "cursor"
+	AgentIflow          AgentType = "iflow"
+	AgentAmp            AgentType = "amp"
+	AgentZencoder       AgentType = "zencoder"
+	AgentVSCodeCopilot  AgentType = "vscode-copilot"
+	AgentPi             AgentType = "pi"
+	AgentQwen           AgentType = "qwen"
+	AgentOpenClaw       AgentType = "openclaw"
+	AgentKimi           AgentType = "kimi"
+	AgentClaudeAI       AgentType = "claude-ai"
+	AgentChatGPT        AgentType = "chatgpt"
 	AgentKiro           AgentType = "kiro"
 	AgentKiroIDE        AgentType = "kiro-ide"
 	AgentCortex         AgentType = "cortex"
@@ -371,25 +371,33 @@ var Registry = []AgentDef{
 		FindSourceFunc: FindPositronSourceFile,
 	},
 	{
-		Type:           AgentAntigravity,
-		DisplayName:    "Antigravity",
-		EnvVar:         "ANTIGRAVITY_DIR",
-		ConfigKey:      "antigravity_dirs",
-		DefaultDirs:    []string{".gemini/antigravity"},
-		IDPrefix:       "antigravity:",
-		WatchSubdirs:   []string{"brain"},
+		Type:        AgentAntigravity,
+		DisplayName: "Antigravity",
+		EnvVar:      "ANTIGRAVITY_DIR",
+		ConfigKey:   "antigravity_dirs",
+		DefaultDirs: []string{".gemini/antigravity"},
+		IDPrefix:    "antigravity:",
+		WatchSubdirs: []string{
+			"conversations",
+			"brain",
+			"annotations",
+		},
 		FileBased:      true,
 		DiscoverFunc:   DiscoverAntigravitySessions,
 		FindSourceFunc: FindAntigravitySourceFile,
 	},
 	{
-		Type:           AgentAntigravityCLI,
-		DisplayName:    "Antigravity CLI",
-		EnvVar:         "ANTIGRAVITY_CLI_DIR",
-		ConfigKey:      "antigravity_cli_dirs",
-		DefaultDirs:    []string{".gemini/antigravity-cli"},
-		IDPrefix:       "antigravity-cli:",
-		WatchSubdirs:   []string{"brain"},
+		Type:        AgentAntigravityCLI,
+		DisplayName: "Antigravity CLI",
+		EnvVar:      "ANTIGRAVITY_CLI_DIR",
+		ConfigKey:   "antigravity_cli_dirs",
+		DefaultDirs: []string{".gemini/antigravity-cli"},
+		IDPrefix:    "antigravity-cli:",
+		WatchSubdirs: []string{
+			"conversations",
+			"implicit",
+			"brain",
+		},
 		FileBased:      true,
 		DiscoverFunc:   DiscoverAntigravityCLISessions,
 		FindSourceFunc: FindAntigravityCLISourceFile,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -910,6 +910,62 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
+	// Antigravity IDE: <root>/conversations/<uuid>.db (+ -wal, -shm)
+	for _, agDir := range e.agentDirs[parser.AgentAntigravity] {
+		if agDir == "" {
+			continue
+		}
+		if rel, ok := isUnder(agDir, path); ok {
+			parts := strings.Split(rel, sep)
+			if len(parts) != 2 || parts[0] != "conversations" {
+				continue
+			}
+			name := parts[1]
+			name = strings.TrimSuffix(name, "-wal")
+			name = strings.TrimSuffix(name, "-shm")
+			if !strings.HasSuffix(name, ".db") {
+				continue
+			}
+			id := strings.TrimSuffix(name, ".db")
+			if !parser.IsValidSessionID(id) {
+				continue
+			}
+			return parser.DiscoveredFile{
+				Path: filepath.Join(
+					agDir, "conversations", name,
+				),
+				Agent: parser.AgentAntigravity,
+			}, true
+		}
+	}
+
+	// Antigravity CLI: <root>/conversations|implicit/<uuid>.pb
+	for _, agDir := range e.agentDirs[parser.AgentAntigravityCLI] {
+		if agDir == "" {
+			continue
+		}
+		if rel, ok := isUnder(agDir, path); ok {
+			parts := strings.Split(rel, sep)
+			if len(parts) != 2 ||
+				(parts[0] != "conversations" &&
+					parts[0] != "implicit") {
+				continue
+			}
+			name := parts[1]
+			if !strings.HasSuffix(name, ".pb") {
+				continue
+			}
+			id := strings.TrimSuffix(name, ".pb")
+			if !parser.IsValidSessionID(id) {
+				continue
+			}
+			return parser.DiscoveredFile{
+				Path:  path,
+				Agent: parser.AgentAntigravityCLI,
+			}, true
+		}
+	}
+
 	return parser.DiscoveredFile{}, false
 }
 
@@ -2687,6 +2743,10 @@ func (e *Engine) processFile(
 		res = e.processHermes(file, info)
 	case parser.AgentPositron:
 		res = e.processPositron(file, info)
+	case parser.AgentAntigravity:
+		res = e.processAntigravity(file, info)
+	case parser.AgentAntigravityCLI:
+		res = e.processAntigravityCLI(file, info)
 	default:
 		res = processResult{
 			err: fmt.Errorf(
@@ -3747,6 +3807,64 @@ func (e *Engine) processPositron(
 	}
 
 	sess, msgs, err := parser.ParsePositronSession(
+		file.Path, file.Project, e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if sess == nil {
+		return processResult{}
+	}
+
+	hash, err := ComputeFileHash(file.Path)
+	if err == nil {
+		sess.File.Hash = hash
+	}
+
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: *sess, Messages: msgs},
+		},
+	}
+}
+
+func (e *Engine) processAntigravity(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	if e.shouldSkipByPath(file.Path, info) {
+		return processResult{skip: true}
+	}
+
+	sess, msgs, err := parser.ParseAntigravitySession(
+		file.Path, file.Project, e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if sess == nil {
+		return processResult{}
+	}
+
+	hash, err := ComputeFileHash(file.Path)
+	if err == nil {
+		sess.File.Hash = hash
+	}
+
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: *sess, Messages: msgs},
+		},
+	}
+}
+
+func (e *Engine) processAntigravityCLI(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	if e.shouldSkipByPath(file.Path, info) {
+		return processResult{skip: true}
+	}
+
+	sess, msgs, err := parser.ParseAntigravityCLISession(
 		file.Path, file.Project, e.machine,
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds two new agents to agentsview's session registry:

- **Antigravity** (IDE) — `~/.gemini/antigravity/`. Per-session SQLite
  database; unencrypted. Parsed in full: messages, timestamps, brain
  artifacts.
- **Antigravity CLI** — `~/.gemini/antigravity-cli/`. Per-session
  protobuf streams under AES-GCM. Parsed in summary mode by default
  (user prompts from `history.jsonl` + plaintext `brain/` artifacts),
  with an optional decrypted-strings preview when `ANTIGRAVITY_KEY`
  is set.

The IDE side is feature-complete. The CLI side ships summary mode now
and falls back gracefully when the AES key is unavailable; full
transcript decryption requires HKDF parameters baked into the
Antigravity binary and has been deferred to a separate, dedicated
tool.

## What's in the diff

- `internal/parser/antigravity.go` — IDE SQLite parser
- `internal/parser/antigravity_cli.go` — CLI parser (summary + optional
  decrypted preview)
- `internal/parser/antigravity_crypto.go` — AES-CTR/CBC/GCM helpers,
  env-var key loader, brute-force-skip retry loop mirroring the
  reference Python decryptor
- `internal/parser/antigravity_proto.go` — stdlib-only protobuf wire
  walker (no third-party deps)
- `internal/parser/types.go`, `taxonomy.go`, `sync/engine.go` — registry
  entries, tool-name mapping, file-watcher classifiers
- `frontend/src/lib/utils/agents.ts` + `AgentDirSettings.svelte` — UI
  labels and violet accent color for both agents
- `internal/parser/antigravity_test.go` — wire-walker round-trip,
  IDE SQLite fixture, CLI discovery+parse (conversations/ and
  implicit/), AES-GCM round-trip, PKCS7 edge cases,
  `history.jsonl` robustness against malformed lines

## Known limitations

- **CLI full decryption requires `ANTIGRAVITY_KEY` to be set manually.**
  The on-disk key is HKDF-derived from the OAuth refresh token in the
  OS keyring, using salt/info baked into the Antigravity binary. The
  binary-RE work to extract those parameters and the keyring probing
  logic are out of scope here and tracked for a separate standalone
  tool.
- **IDE role inference is heuristic** (`step_type==14 → user`, else
  `assistant`). The full `CORTEX_STEP_TYPE_*` taxonomy is available
  via the Antigravity daemon's `GetCascadeTrajectory` RPC and can be
  ported in once the standalone tool's translator code is mature.

## Notes for review

- All new code uses stdlib only — no protobuf or HKDF dependencies
  added.
- `go fmt`, `go vet`, parser tests, and frontend tests all green
  locally and in CI on this branch (Linux + Windows).
- README's supported-agents table updated.
- `.antigravitycli/` (the agent's session directory, created if
  Antigravity CLI is run inside this repo) added to `.gitignore`.