### PR TITLE
Use go.kenn.io vanity module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ powershell -ExecutionPolicy ByPass -c "irm https://agentsview.io/install.ps1 | i
 ```
 
 Or download the **desktop app** (macOS / Windows) from
-[GitHub Releases](https://github.com/wesm/agentsview/releases) or via homebrew: `brew install --cask agentsview`
+[GitHub Releases](https://github.com/wesm/agentsview/releases) or via homebrew:
+`brew install --cask agentsview`
 
 Or run the published Docker image:
 
@@ -55,10 +56,10 @@ docker compose -f docker-compose.prod.yaml up -d
 ```
 
 The included compose file persists the agentsview data directory in a named
-volume and mounts Claude, Codex, Forge, and OpenCode session roots read-only. The
-container runs as root, so prefer a named volume for `/data` over a host bind
-mount; if you do bind-mount, pre-create the directory with the desired ownership
-to avoid root-owned files in your home directory.
+volume and mounts Claude, Codex, Forge, and OpenCode session roots read-only.
+The container runs as root, so prefer a named volume for `/data` over a host
+bind mount; if you do bind-mount, pre-create the directory with the desired
+ownership to avoid root-owned files in your home directory.
 
 The examples publish the UI on loopback only (`127.0.0.1`). If you need to
 expose it beyond localhost, enable `--require-auth` and publish the port
@@ -181,7 +182,7 @@ agentsview auto-discovers sessions from all of these:
 | Qwen Code          | `~/.qwen/projects/`                                    |
 | OpenClaw           | `~/.openclaw/agents/`                                  |
 | Kimi               | `~/.kimi/sessions/`                                    |
-| Kiro CLI           | `~/.kiro/sessions/cli/`, `~/.local/share/kiro-cli/`     |
+| Kiro CLI           | `~/.kiro/sessions/cli/`, `~/.local/share/kiro-cli/`    |
 | Kiro IDE           | `~/Library/Application Support/Kiro/` (macOS)          |
 | Cortex Code        | `~/.snowflake/cortex/conversations/`                   |
 | Hermes Agent       | `~/.hermes/sessions/`                                  |
@@ -220,7 +221,7 @@ Full docs at **[agentsview.io](https://agentsview.io)**:
 [Configuration](https://agentsview.io/configuration/) --
 [Architecture](https://agentsview.io/architecture/)
 
----
+______________________________________________________________________
 
 ## Development
 

--- a/cmd/agentsview/classifier.go
+++ b/cmd/agentsview/classifier.go
@@ -13,9 +13,9 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/postgres"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/postgres"
 )
 
 func newClassifierCommand() *cobra.Command {

--- a/cmd/agentsview/classifier_test.go
+++ b/cmd/agentsview/classifier_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // classifierTestEnv prepares a temp data dir and writes a

--- a/cmd/agentsview/classifier_wiring.go
+++ b/cmd/agentsview/classifier_wiring.go
@@ -3,8 +3,8 @@
 package main
 
 import (
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // applyClassifierConfig installs user-defined classifier

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 	"golang.org/x/term"
 )
 

--- a/cmd/agentsview/health.go
+++ b/cmd/agentsview/health.go
@@ -10,8 +10,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // HealthConfig configures the `health` command.

--- a/cmd/agentsview/health_test.go
+++ b/cmd/agentsview/health_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestGradeCell(t *testing.T) {

--- a/cmd/agentsview/import.go
+++ b/cmd/agentsview/import.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/importer"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/importer"
 )
 
 type ImportConfig struct {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -14,12 +14,12 @@ import (
 	_ "time/tzdata"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/server"
-	"github.com/wesm/agentsview/internal/signals"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/signals"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 var (

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 func TestMustLoadConfig(t *testing.T) {

--- a/cmd/agentsview/managed_caddy.go
+++ b/cmd/agentsview/managed_caddy.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/config"
 )
 
 const managedCaddyStartGrace = 300 * time.Millisecond

--- a/cmd/agentsview/managed_caddy_test.go
+++ b/cmd/agentsview/managed_caddy_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/config"
 )
 
 func TestBrowserURLUsesPublicURL(t *testing.T) {

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/postgres"
-	"github.com/wesm/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/postgres"
+	"go.kenn.io/agentsview/internal/server"
 )
 
 type PGPushConfig struct {

--- a/cmd/agentsview/pg_test.go
+++ b/cmd/agentsview/pg_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/config"
 )
 
 func loadPGServeConfigForTest(t *testing.T, args ...string) (config.Config, string, error) {

--- a/cmd/agentsview/projects.go
+++ b/cmd/agentsview/projects.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func runProjects(jsonOutput bool) {

--- a/cmd/agentsview/prune.go
+++ b/cmd/agentsview/prune.go
@@ -11,8 +11,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // PruneConfig holds parsed CLI options for the prune command.

--- a/cmd/agentsview/prune_test.go
+++ b/cmd/agentsview/prune_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
 )
 
 func TestParsePruneFlags(t *testing.T) {

--- a/cmd/agentsview/serve_runtime.go
+++ b/cmd/agentsview/serve_runtime.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/server"
 )
 
 type serveRuntimeOptions struct {

--- a/cmd/agentsview/session.go
+++ b/cmd/agentsview/session.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func newSessionCommand() *cobra.Command {

--- a/cmd/agentsview/session_export.go
+++ b/cmd/agentsview/session_export.go
@@ -9,8 +9,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func newSessionExportCommand() *cobra.Command {

--- a/cmd/agentsview/session_get.go
+++ b/cmd/agentsview/session_get.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func newSessionGetCommand() *cobra.Command {

--- a/cmd/agentsview/session_list.go
+++ b/cmd/agentsview/session_list.go
@@ -8,8 +8,8 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func newSessionListCommand() *cobra.Command {

--- a/cmd/agentsview/session_messages.go
+++ b/cmd/agentsview/session_messages.go
@@ -8,7 +8,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func newSessionMessagesCommand() *cobra.Command {

--- a/cmd/agentsview/session_sync.go
+++ b/cmd/agentsview/session_sync.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/service"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 func newSessionSyncCommand() *cobra.Command {

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/server"
 )
 
 func TestSessionHelp_ShowsSubcommands(t *testing.T) {

--- a/cmd/agentsview/session_tool_calls.go
+++ b/cmd/agentsview/session_tool_calls.go
@@ -10,7 +10,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func newSessionToolCallsCommand() *cobra.Command {

--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func newStatsCommand() *cobra.Command {

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // TestPrintStatsHuman_Populated exercises the happy path with

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -9,11 +9,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/ssh"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/ssh"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 // SyncConfig holds parsed CLI options for the sync command.

--- a/cmd/agentsview/token_use.go
+++ b/cmd/agentsview/token_use.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/server"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 // Exit codes for the token-use subcommand.

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // newTestDB opens a fresh SQLite DB in a temp dir for a single test.

--- a/cmd/agentsview/transport.go
+++ b/cmd/agentsview/transport.go
@@ -10,10 +10,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/server"
-	"github.com/wesm/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 type transportMode int

--- a/cmd/agentsview/transport_test.go
+++ b/cmd/agentsview/transport_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/server"
 )
 
 // freeTCPListener binds to a free loopback port and returns the

--- a/cmd/agentsview/update.go
+++ b/cmd/agentsview/update.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/update"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/update"
 )
 
 type UpdateConfig struct {

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -11,11 +11,11 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/pricing"
-	"github.com/wesm/agentsview/internal/server"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/pricing"
+	"go.kenn.io/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 // quickSyncMargin pads the mtime cutoff backward from the

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestFmtCost(t *testing.T) {

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 type sessionSpec struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wesm/agentsview
+module go.kenn.io/agentsview
 
 go 1.26.2
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/pflag"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // TerminalConfig holds terminal launch preferences.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/pflag"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 const configFileName = "config.toml"

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1873,8 +1873,8 @@ func TestAnalyticsTerminationFilter(t *testing.T) {
 
 		insert := func(id string, term *string) {
 			insertSession(t, d, id, "p", func(s *Session) {
-				s.StartedAt = Ptr("2024-06-02T09:00:00Z")
-				s.EndedAt = Ptr("2024-06-02T10:00:00Z")
+				s.StartedAt = new(string("2024-06-02T09:00:00Z"))
+				s.EndedAt = new(string("2024-06-02T10:00:00Z"))
 				s.MessageCount = 5
 				s.UserMessageCount = 2
 				s.TerminationStatus = term

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -16,8 +16,8 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // dataVersion tracks parser changes that require a full

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 const (

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -63,7 +63,7 @@ func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
 				Project:          "proj",
 				Machine:          defaultMachine,
 				Agent:            defaultAgent,
-				FirstMessage:     Ptr("hello"),
+				FirstMessage:     new(string("hello")),
 				MessageCount:     2,
 				UserMessageCount: 1,
 			},

--- a/internal/db/remote_skipped_test.go
+++ b/internal/db/remote_skipped_test.go
@@ -4,7 +4,7 @@ import (
 	"maps"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/dbtest"
 )
 
 func TestRemoteSkippedFiles_InitiallyEmpty(t *testing.T) {

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/tidwall/gjson"
-	"github.com/wesm/agentsview/internal/db/git"
+	"go.kenn.io/agentsview/internal/db/git"
 )
 
 // StatsFilter mirrors the service-layer StatsFilter but lives in db

--- a/internal/db/skipped_test.go
+++ b/internal/db/skipped_test.go
@@ -4,7 +4,7 @@ import (
 	"maps"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/dbtest"
 )
 
 func TestSkippedFiles_RoundTrip(t *testing.T) {

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // Stats holds database-wide statistics.

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/config"
 )
 
 func TestGetDailyUsageEmpty(t *testing.T) {

--- a/internal/db/worktree_mappings.go
+++ b/internal/db/worktree_mappings.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-sqlite3"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 var ErrWorktreeMappingDuplicate = errors.New("worktree mapping already exists")

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // Ptr returns a pointer to v.

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // ImportStats reports the outcome of an import operation.

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 const testConversationsJSON = `[

--- a/internal/insight/prompt.go
+++ b/internal/insight/prompt.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 const maxSessions = 50

--- a/internal/insight/prompt_test.go
+++ b/internal/insight/prompt_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
 )
 
 func TestBuildPrompt(t *testing.T) {

--- a/internal/parser/amp.go
+++ b/internal/parser/amp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -62,8 +63,8 @@ func ParseAmpSession(
 	traces := root.Get("meta.traces")
 	if traces.IsArray() {
 		traceList := traces.Array()
-		for i := len(traceList) - 1; i >= 0; i-- {
-			t := parseTimestamp(traceList[i].Get("endTime").Str)
+		for _, v := range slices.Backward(traceList) {
+			t := parseTimestamp(v.Get("endTime").Str)
 			if !t.IsZero() {
 				endTime = t
 				break

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 	"unicode"
@@ -313,9 +314,9 @@ func ParseClaudeSession(
 // none. Used by Classify to decide between awaiting_user and
 // clean for sessions that ended without an orphan tool_use.
 func lastAssistantStopReason(messages []ParsedMessage) string {
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role == RoleAssistant {
-			return messages[i].StopReason
+	for _, v := range slices.Backward(messages) {
+		if v.Role == RoleAssistant {
+			return v.StopReason
 		}
 	}
 	return ""

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 func runClaudeParserTest(t *testing.T, fileName, content string) (ParsedSession, []ParsedMessage) {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -203,12 +204,12 @@ func (b *codexSessionBuilder) handleTokenCountEvent(
 	// Find last assistant message without usage in the current
 	// turn. Stop at user message boundary so we don't cross
 	// turns.
-	for i := len(b.messages) - 1; i >= 0; i-- {
-		if b.messages[i].Role == RoleUser {
+	for i, v := range slices.Backward(b.messages) {
+		if v.Role == RoleUser {
 			break
 		}
-		if b.messages[i].Role == RoleAssistant &&
-			b.messages[i].TokenUsage == nil {
+		if v.Role == RoleAssistant &&
+			v.TokenUsage == nil {
 			b.applyCodexTokenUsage(&b.messages[i], raw)
 			return
 		}

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 func runCodexParserTest(t *testing.T, fileName, content string, includeExec bool) (*ParsedSession, []ParsedMessage) {

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -221,8 +222,8 @@ func (b *copilotSessionBuilder) handleToolComplete(
 func (b *copilotSessionBuilder) handleAssistantReasoning() {
 	// Mark the most recent assistant message as having
 	// thinking, if one exists.
-	for i := len(b.messages) - 1; i >= 0; i-- {
-		if b.messages[i].Role == RoleAssistant {
+	for i, v := range slices.Backward(b.messages) {
+		if v.Role == RoleAssistant {
 			b.messages[i].HasThinking = true
 			return
 		}

--- a/internal/parser/fork_test.go
+++ b/internal/parser/fork_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 func parseTestContent(t *testing.T, name, content string, expectedLen int) []ParseResult {

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 func runGeminiParserTest(t *testing.T, content string) (*ParsedSession, []ParsedMessage) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/tidwall/gjson"
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 func TestGetProjectName(t *testing.T) {

--- a/internal/parser/piebald.go
+++ b/internal/parser/piebald.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 )
@@ -459,8 +460,8 @@ func splitPiebaldBranches(rows []piebaldMessageRow) []piebaldBranch {
 			}
 
 			mainIdx := len(kids) - 1
-			for i := len(kids) - 1; i >= 0; i-- {
-				if kids[i].enabled() {
+			for i, v := range slices.Backward(kids) {
+				if v.enabled() {
 					mainIdx = i
 					break
 				}

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -60,8 +61,8 @@ func GetProjectName(dirName string) string {
 	}
 
 	// Strategy 2: use last non-system-directory component
-	for i := len(parts) - 1; i >= 0; i-- {
-		if p := parts[i]; p != "" && !ignoredSystemDirs[strings.ToLower(p)] {
+	for _, v := range slices.Backward(parts) {
+		if p := v; p != "" && !ignoredSystemDirs[strings.ToLower(p)] {
 			return NormalizeName(p)
 		}
 	}

--- a/internal/parser/termination.go
+++ b/internal/parser/termination.go
@@ -1,5 +1,7 @@
 package parser
 
+import "slices"
+
 // TerminationStatus describes how a parsed session appears to have
 // ended. The empty string means "unknown" — caller should leave the
 // stored column NULL.
@@ -89,8 +91,8 @@ func isAwaitingUserStopReason(stopReason string) bool {
 // mark the final unresolved call as resolved.
 func hasOrphanedToolCall(messages []ParsedMessage) bool {
 	lastAssistantIdx := -1
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role == RoleAssistant {
+	for i, v := range slices.Backward(messages) {
+		if v.Role == RoleAssistant {
 			lastAssistantIdx = i
 			break
 		}

--- a/internal/postgres/activity.go
+++ b/internal/postgres/activity.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // GetSessionActivity returns time-bucketed message counts for a

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // maxPGVars is the maximum bind variables per IN clause.

--- a/internal/postgres/analytics_autonomy_pgtest_test.go
+++ b/internal/postgres/analytics_autonomy_pgtest_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // TestStoreGetAnalyticsSessionShape_AutonomyExcludesSystemUsers

--- a/internal/postgres/analytics_pgtest_test.go
+++ b/internal/postgres/analytics_pgtest_test.go
@@ -3,7 +3,7 @@ package postgres
 import (
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestRankTopSessions_DurationSort(t *testing.T) {

--- a/internal/postgres/analytics_signals_pgtest_test.go
+++ b/internal/postgres/analytics_signals_pgtest_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // TestStoreGetAnalyticsSignals exercises the PG implementation

--- a/internal/postgres/automated_pgtest_test.go
+++ b/internal/postgres/automated_pgtest_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // TestPushSessionTrustsLocalIsAutomated verifies that

--- a/internal/postgres/integration_test.go
+++ b/internal/postgres/integration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestPGConnectivity(t *testing.T) {

--- a/internal/postgres/messages.go
+++ b/internal/postgres/messages.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 const attachToolCallBatchSize = 500

--- a/internal/postgres/messages_pgtest_test.go
+++ b/internal/postgres/messages_pgtest_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestStoreSearchILIKE(t *testing.T) {

--- a/internal/postgres/pricing.go
+++ b/internal/postgres/pricing.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/pricing"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/pricing"
 )
 
 type modelRates struct {

--- a/internal/postgres/pricing_pgtest_test.go
+++ b/internal/postgres/pricing_pgtest_test.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/config"
 )
 
 // TestLoadPricingMapAppliesCustomWhenTableMissing covers the fresh-PG

--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -4,8 +4,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestCustomPricingOverridesPricingMap(t *testing.T) {

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 const lastPushBoundaryStateKey = "last_push_boundary_state"

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // TestPushSystemFingerprintCollisionRegression verifies that the fast-path

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 type syncStateReaderStub struct {

--- a/internal/postgres/push_thinking_pgtest_test.go
+++ b/internal/postgres/push_thinking_pgtest_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // TestPushThinkingText_SanitizesNullAndInvalidUTF8 verifies that

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 const tokenCoverageRepairMetadataKey = "token_coverage_repair_v1"

--- a/internal/postgres/session_timing.go
+++ b/internal/postgres/session_timing.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // GetSessionTiming computes the per-session timing summary on the PG

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // Store wraps a PostgreSQL connection for read-only session

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // Compile-time check: *Store satisfies db.Store.

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 const testSchema = "agentsview_store_test"

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // isUndefinedTable returns true when the error indicates the

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func testDB(t *testing.T) *db.DB {

--- a/internal/postgres/time_test.go
+++ b/internal/postgres/time_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestParseSQLiteTimestamp(t *testing.T) {

--- a/internal/postgres/token_usage_pgtest_test.go
+++ b/internal/postgres/token_usage_pgtest_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestStoreSessionAndMessageTokenUsage(t *testing.T) {

--- a/internal/postgres/trends.go
+++ b/internal/postgres/trends.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func (s *Store) GetTrendsTerms(

--- a/internal/postgres/trends_pgtest_test.go
+++ b/internal/postgres/trends_pgtest_test.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestStoreGetTrendsTerms(t *testing.T) {

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/tidwall/gjson"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 const pgUsageMessageEligibility = `

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func prepareUsageSchema(

--- a/internal/server/activity_test.go
+++ b/internal/server/activity_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestGetSessionActivity(t *testing.T) {

--- a/internal/server/agent_config_internal_test.go
+++ b/internal/server/agent_config_internal_test.go
@@ -3,7 +3,7 @@ package server
 import (
 	"testing"
 
-	"github.com/wesm/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/config"
 )
 
 func TestInsightAgentConfigMapsBinaryOverrides(t *testing.T) {

--- a/internal/server/analytics.go
+++ b/internal/server/analytics.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/timeutil"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 // defaultDateRange returns (from, to) defaulting to the last

--- a/internal/server/analytics_test.go
+++ b/internal/server/analytics_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 const basePath = "/api/v1/analytics/"

--- a/internal/server/deadline_internal_test.go
+++ b/internal/server/deadline_internal_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestHandlers_Internal_DeadlineExceeded(t *testing.T) {

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/wesm/agentsview/internal/sessionwatch"
-	syncpkg "github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/sessionwatch"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
 )
 
 // sessionMonitor returns a channel that ticks whenever the

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // getSessionWithMessages fetches a session and its messages by ID,

--- a/internal/server/export_markdown.go
+++ b/internal/server/export_markdown.go
@@ -11,8 +11,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 type exportMarkdownOptions struct {

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // testSession returns a *db.Session with sensible defaults.

--- a/internal/server/helpers_internal_test.go
+++ b/internal/server/helpers_internal_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 // testServer creates a Server for internal tests with the given

--- a/internal/server/import.go
+++ b/internal/server/import.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/importer"
+	"go.kenn.io/agentsview/internal/importer"
 )
 
 // wantsSSE checks if the client opted into streaming via

--- a/internal/server/import_test.go
+++ b/internal/server/import_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/importer"
+	"go.kenn.io/agentsview/internal/importer"
 )
 
 func TestHandleImportClaudeAI(t *testing.T) {

--- a/internal/server/insights.go
+++ b/internal/server/insights.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/insight"
-	"github.com/wesm/agentsview/internal/timeutil"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/insight"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 var validInsightTypes = map[string]bool{

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/insight"
-	"github.com/wesm/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/insight"
+	"go.kenn.io/agentsview/internal/server"
 )
 
 type listInsightsResponse struct {

--- a/internal/server/messages.go
+++ b/internal/server/messages.go
@@ -3,8 +3,8 @@ package server
 import (
 	"net/http"
 
-	dbpkg "github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/service"
+	dbpkg "go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func (s *Server) handleGetMessages(

--- a/internal/server/pins.go
+++ b/internal/server/pins.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 type pinRequest struct {

--- a/internal/server/pins_test.go
+++ b/internal/server/pins_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // pinSessionMessage pins the first message of a session via the DB

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // writeJSON writes v as JSON with the given HTTP status code.

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/google/shlex"
 	"github.com/tidwall/gjson"
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // resumeRequest is the JSON body for POST /api/v1/sessions/{id}/resume.

--- a/internal/server/resume_handler_test.go
+++ b/internal/server/resume_handler_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func canonicalTestPath(path string) string {

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func canonicalTestDir(path string) string {

--- a/internal/server/search.go
+++ b/internal/server/search.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 type searchResponse struct {

--- a/internal/server/search_test.go
+++ b/internal/server/search_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestValidateSort(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,12 +14,12 @@ import (
 	gosync "sync"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/insight"
-	"github.com/wesm/agentsview/internal/service"
-	"github.com/wesm/agentsview/internal/sync"
-	"github.com/wesm/agentsview/internal/web"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/insight"
+	"go.kenn.io/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/web"
 )
 
 // VersionInfo holds build-time version metadata.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,14 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/server"
-	"github.com/wesm/agentsview/internal/service"
-	"github.com/wesm/agentsview/internal/sync"
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 // Timestamp constants for test data.

--- a/internal/server/session_search_test.go
+++ b/internal/server/session_search_test.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestHandleSearchSession(t *testing.T) {

--- a/internal/server/session_timing_test.go
+++ b/internal/server/session_timing_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
 )
 
 func TestHandleSessionTiming_OK(t *testing.T) {
@@ -57,8 +57,8 @@ func seedTimingFixture(t *testing.T, d *db.DB, sessionID string) {
 		func(s *db.Session) {
 			s.MessageCount = 3
 			s.UserMessageCount = 2
-			s.StartedAt = dbtest.Ptr(startedAt)
-			s.EndedAt = dbtest.Ptr(endedAt)
+			s.StartedAt = new(string(startedAt))
+			s.EndedAt = new(string(endedAt))
 		})
 
 	msgs := []db.Message{

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/service"
-	"github.com/wesm/agentsview/internal/timeutil"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 func (s *Server) handleListSessions(

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // settingsResponse is the JSON shape returned by GET /api/v1/settings.

--- a/internal/server/sync_route.go
+++ b/internal/server/sync_route.go
@@ -8,8 +8,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func (s *Server) handleSyncSession(

--- a/internal/server/timeout_test.go
+++ b/internal/server/timeout_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 // TestServerTimeouts starts a real HTTP server and verifies that

--- a/internal/server/trends.go
+++ b/internal/server/trends.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func (s *Server) handleTrendsTerms(

--- a/internal/server/trends_test.go
+++ b/internal/server/trends_test.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestTrendsTermsEndpoint(t *testing.T) {

--- a/internal/server/update.go
+++ b/internal/server/update.go
@@ -3,7 +3,7 @@ package server
 import (
 	"net/http"
 
-	"github.com/wesm/agentsview/internal/update"
+	"go.kenn.io/agentsview/internal/update"
 )
 
 // UpdateCheckFunc is the signature for functions that check for

--- a/internal/server/update_test.go
+++ b/internal/server/update_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/server"
-	"github.com/wesm/agentsview/internal/update"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/update"
 )
 
 func stubChecker(

--- a/internal/server/upload.go
+++ b/internal/server/upload.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/timeutil"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 type uploadRequest struct {

--- a/internal/server/upload_failure_test.go
+++ b/internal/server/upload_failure_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/server"
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 type uploadCommitFailStore struct {

--- a/internal/server/usage.go
+++ b/internal/server/usage.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/timeutil"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 // ProjectTotal holds range-wide token and cost totals per project.

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // approxEqual returns true if a and b are within eps (for

--- a/internal/server/usage_readonly_internal_test.go
+++ b/internal/server/usage_readonly_internal_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // readOnlyUsageSpy stubs the Store interface and returns

--- a/internal/server/usage_test.go
+++ b/internal/server/usage_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/server"
 )
 
 // tokenUsageJSON is a valid token_usage blob for test messages.

--- a/internal/server/worktree_mappings.go
+++ b/internal/server/worktree_mappings.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 type worktreeMappingsResponse struct {

--- a/internal/server/worktree_mappings_test.go
+++ b/internal/server/worktree_mappings_test.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestWorktreeMappingsAPIUsesCurrentMachine(t *testing.T) {

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/sessionwatch"
-	"github.com/wesm/agentsview/internal/signals"
-	"github.com/wesm/agentsview/internal/sync"
-	"github.com/wesm/agentsview/internal/timeutil"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/sessionwatch"
+	"go.kenn.io/agentsview/internal/signals"
+	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 // directBackend implements SessionService by wrapping a db.Store

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
-	"github.com/wesm/agentsview/internal/service"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 // directTestEnv is a lightweight environment helper for testing

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // errHTTPNotFound is returned by getJSON for 404 responses so callers

--- a/internal/service/http_test.go
+++ b/internal/service/http_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wesm/agentsview/internal/config"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
-	"github.com/wesm/agentsview/internal/server"
-	"github.com/wesm/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/server"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 // newHTTPTestServer builds an in-memory SQLite DB, constructs a

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // SessionService is the canonical per-session operation interface.

--- a/internal/service/stats_types.go
+++ b/internal/service/stats_types.go
@@ -1,7 +1,7 @@
 // internal/service/stats_types.go
 package service
 
-import "github.com/wesm/agentsview/internal/db"
+import "go.kenn.io/agentsview/internal/db"
 
 // StatsFilter mirrors the session-stats CLI flag set.
 type StatsFilter struct {

--- a/internal/sessionwatch/watcher.go
+++ b/internal/sessionwatch/watcher.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 const (

--- a/internal/sessionwatch/watcher_test.go
+++ b/internal/sessionwatch/watcher_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 // testWatcher creates a Watcher backed by a fresh SQLite database

--- a/internal/ssh/helpers_sshtest_test.go
+++ b/internal/ssh/helpers_sshtest_test.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func testSSHHost(t *testing.T) string {

--- a/internal/ssh/integration_sshtest_test.go
+++ b/internal/ssh/integration_sshtest_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestSSHSyncEndToEnd(t *testing.T) {

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // buildResolveScript generates a shell script that echoes each

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestBuildResolveScript(t *testing.T) {

--- a/internal/ssh/sync.go
+++ b/internal/ssh/sync.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 // SyncStats summarizes the outcome of a remote sync run.

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // buildTarCommand generates the remote tar command for the given

--- a/internal/ssh/transfer_test.go
+++ b/internal/ssh/transfer_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestBuildTarCommand(t *testing.T) {

--- a/internal/sync/classify_cortex_test.go
+++ b/internal/sync/classify_cortex_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestClassifyOnePath_Cortex(t *testing.T) {

--- a/internal/sync/classify_openhands_test.go
+++ b/internal/sync/classify_openhands_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestClassifyOnePath_OpenHands(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10,14 +10,15 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	gosync "sync"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/signals"
-	"github.com/wesm/agentsview/internal/timeutil"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/signals"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 const (
@@ -3995,8 +3996,8 @@ func (e *Engine) processIflow(
 // from the end of the tool call list.
 func computeFinalStreak(calls []signals.ToolCallRow) int {
 	streak := 0
-	for i := len(calls) - 1; i >= 0; i-- {
-		if signals.IsFailure(calls[i]) {
+	for _, v := range slices.Backward(calls) {
+		if signals.IsFailure(v) {
 			streak++
 		} else {
 			break

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -13,11 +13,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/dbtest"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/sync"
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 type testEnv struct {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/parser"
-	"github.com/wesm/agentsview/internal/testjsonl"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 func openTestDB(t *testing.T) *db.DB {

--- a/internal/sync/forge_integration_test.go
+++ b/internal/sync/forge_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 type forgeTestDB struct {

--- a/internal/sync/iflow_discovery_test.go
+++ b/internal/sync/iflow_discovery_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestDiscoverIflowProjects(t *testing.T) {

--- a/internal/sync/openhands_retry_test.go
+++ b/internal/sync/openhands_retry_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/agentsview/internal/dbtest"
-	"github.com/wesm/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestProcessFileOpenHandsUsesSnapshotMtimeForRetryCache(t *testing.T) {

--- a/internal/sync/piebald_integration_test.go
+++ b/internal/sync/piebald_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 type piebaldTestDB struct {

--- a/internal/sync/signal_compute.go
+++ b/internal/sync/signal_compute.go
@@ -1,10 +1,11 @@
 package sync
 
 import (
+	"slices"
 	"time"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/signals"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/signals"
 )
 
 // computeSignalsFromMessages produces a SessionSignalUpdate from
@@ -220,9 +221,9 @@ func extractLastMessageRole(
 	if msgs == nil {
 		return "", ""
 	}
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if !msgs[i].IsSystem {
-			return msgs[i].Role, msgs[i].Content
+	for _, v := range slices.Backward(msgs) {
+		if !v.IsSystem {
+			return v.Role, v.Content
 		}
 	}
 	return "", ""

--- a/internal/sync/signal_compute_test.go
+++ b/internal/sync/signal_compute_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/signals"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/signals"
 )
 
 func TestExtractToolCallRows(t *testing.T) {

--- a/internal/sync/test_helpers_test.go
+++ b/internal/sync/test_helpers_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/wesm/agentsview/internal/db"
-	"github.com/wesm/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/sync"
 )
 
 // Timestamp constants for test data.


### PR DESCRIPTION
## Summary
- change the Go module path to go.kenn.io/agentsview
- rewrite internal imports to use the vanity module path
- keep hook-applied Go 1.26 lint fixes passing after the path rewrite

## Validation
- make vet
- make test
- mise exec -- prek run --all-files
- git diff --check