### PR TITLE
pg push service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,7 @@ html/
 
 # Antigravity CLI session dir created when AGY runs inside this repo
 .antigravitycli/
+
+# graphify knowledge-graph output (local analysis)
+graphify-out/
 .kata.local.toml

--- a/README.md
+++ b/README.md
@@ -283,6 +283,45 @@ agentsview pg push       # push local data to PG
 agentsview pg serve      # serve web UI from PG (read-only)
 ```
 
+### Automatic push (background service)
+
+To keep a shared PostgreSQL database current without running `pg push` by
+hand, run the auto-push daemon. It watches your session directories and
+pushes shortly after new sessions are recorded, with a periodic floor as a
+safety net:
+
+```bash
+agentsview pg push --watch                 # foreground, Ctrl-C to stop
+agentsview pg push --watch --debounce 1m   # custom coalesce window
+agentsview pg push --watch --interval 5m   # custom floor interval
+```
+
+The daemon reads the same `[pg]` config as `pg push`, so the PostgreSQL
+DSN must be set in your config file (or an environment variable it
+expands). Protect the config file, since it holds credentials:
+
+```bash
+chmod 600 ~/.agentsview/config.toml
+```
+
+To run it unattended as an OS service (launchd on macOS,
+`systemd --user` on Linux):
+
+```bash
+agentsview pg service install     # generate the unit, enable + start it
+agentsview pg service status      # show manager status
+agentsview pg service logs -f     # follow the service log
+agentsview pg service uninstall   # stop and remove
+```
+
+**Linux headless machines:** systemd `--user` services stop at logout and
+do not start at boot unless lingering is enabled for your user. `install`
+detects this and prints the command; you can also run it yourself:
+
+```bash
+loginctl enable-linger "$USER"
+```
+
 See [PostgreSQL docs](https://agentsview.io/postgresql/) for setup and
 configuration.
 

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -350,6 +350,7 @@ func newPGCommand() *cobra.Command {
 	cmd.AddCommand(newPGPushCommand())
 	cmd.AddCommand(newPGStatusCommand())
 	cmd.AddCommand(newPGServeCommand())
+	cmd.AddCommand(newPGServiceCommand())
 	return cmd
 }
 
@@ -361,6 +362,14 @@ func newPGPushCommand() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			if cfg.Watch {
+				runPGPushWatch(cfg)
+				return
+			}
+			if cmd.Flags().Changed("debounce") || cmd.Flags().Changed("interval") {
+				fmt.Fprintln(os.Stderr,
+					"warning: --debounce and --interval have no effect without --watch")
+			}
 			runPGPush(cfg)
 		},
 	}
@@ -368,6 +377,9 @@ func newPGPushCommand() *cobra.Command {
 	cmd.Flags().StringVar(&cfg.ProjectsFlag, "projects", "", "Comma-separated list of projects to push (inclusive)")
 	cmd.Flags().StringVar(&cfg.ExcludeProjects, "exclude-projects", "", "Comma-separated list of projects to exclude from push")
 	cmd.Flags().BoolVar(&cfg.AllProjects, "all-projects", false, "Ignore configured project filters for this run")
+	cmd.Flags().BoolVar(&cfg.Watch, "watch", false, "Run continuously, pushing on change plus a periodic floor")
+	cmd.Flags().DurationVar(&cfg.Debounce, "debounce", defaultWatchDebounce, "Coalesce window after a change before pushing (--watch only)")
+	cmd.Flags().DurationVar(&cfg.Interval, "interval", defaultWatchInterval, "Periodic floor push interval (--watch only)")
 	return cmd
 }
 

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -253,7 +253,11 @@ func runServe(cfg config.Config) {
 	fmt.Printf("Database: %s\n", cfg.DBPath)
 
 	if engine != nil {
-		stopWatcher, unwatchedDirs := startFileWatcher(cfg, engine)
+		stopWatcher, unwatchedDirs := startFileWatcher(
+			cfg, engine, func(paths []string) {
+				engine.SyncPaths(paths)
+			},
+		)
 		defer stopWatcher()
 		if len(unwatchedDirs) > 0 {
 			go startUnwatchedPoll(engine)
@@ -281,7 +285,13 @@ func mustLoadConfig(cmd *cobra.Command) config.Config {
 const maxLogSize = 10 * 1024 * 1024 // 10 MB
 
 func setupLogFile(dataDir string) {
-	logPath := filepath.Join(dataDir, "debug.log")
+	setupLogFileNamed(dataDir, "debug.log")
+}
+
+// setupLogFileNamed redirects the standard logger to the named file
+// in dataDir, truncating it first if it exceeds maxLogSize.
+func setupLogFileNamed(dataDir, name string) {
+	logPath := filepath.Join(dataDir, name)
 	truncateLogFile(logPath, maxLogSize)
 	f, err := os.OpenFile(
 		logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644,
@@ -443,12 +453,9 @@ func printSyncProgress(p sync.Progress) {
 }
 
 func startFileWatcher(
-	cfg config.Config, engine *sync.Engine,
+	cfg config.Config, engine *sync.Engine, onChange func(paths []string),
 ) (stopWatcher func(), unwatchedDirs []string) {
 	t := time.Now()
-	onChange := func(paths []string) {
-		engine.SyncPaths(paths)
-	}
 	watcher, err := sync.NewWatcher(watcherDebounce, onChange, cfg.WatchExcludePatterns)
 	if err != nil {
 		log.Printf(

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -24,19 +24,12 @@ type PGPushConfig struct {
 	ProjectsFlag    string
 	ExcludeProjects string
 	AllProjects     bool
+	Watch           bool
+	Debounce        time.Duration
+	Interval        time.Duration
 }
 
 func runPGPush(cfg PGPushConfig) {
-	if cfg.ProjectsFlag != "" && cfg.ExcludeProjects != "" {
-		fatal("pg push: --projects and --exclude-projects " +
-			"are mutually exclusive")
-	}
-	if cfg.AllProjects &&
-		(cfg.ProjectsFlag != "" || cfg.ExcludeProjects != "") {
-		fatal("pg push: --all-projects cannot be combined " +
-			"with --projects or --exclude-projects")
-	}
-
 	appCfg, err := config.LoadMinimal()
 	if err != nil {
 		log.Fatalf("loading config: %v", err)
@@ -54,28 +47,9 @@ func runPGPush(cfg PGPushConfig) {
 		fatal("pg push: url not configured")
 	}
 
-	// CLI flags override config values entirely. When either
-	// flag is set, clear both config-derived lists so a CLI
-	// include can override a config exclude (and vice versa).
-	// --all-projects clears both lists for an unfiltered push.
-	projects := pgCfg.Projects
-	excludeProjects := pgCfg.ExcludeProjects
-	if cfg.AllProjects {
-		projects = nil
-		excludeProjects = nil
-	}
-	if cfg.ProjectsFlag != "" {
-		projects = splitProjectList(cfg.ProjectsFlag)
-		excludeProjects = nil
-	}
-	if cfg.ExcludeProjects != "" {
-		excludeProjects = splitProjectList(cfg.ExcludeProjects)
-		projects = nil
-	}
-
-	if len(projects) > 0 && len(excludeProjects) > 0 {
-		fatal("pg push: projects and exclude_projects " +
-			"are mutually exclusive")
+	projects, excludeProjects, err := resolvePushProjects(pgCfg, cfg)
+	if err != nil {
+		fatal("pg push: %v", err)
 	}
 
 	applyClassifierConfig(appCfg)
@@ -361,6 +335,47 @@ func runPGServe(appCfg config.Config, basePath string) {
 	if err := waitForServerRuntime(ctx, srv, rt); err != nil {
 		fatal("pg serve: %v", err)
 	}
+}
+
+// resolvePushProjects merges configured project filters with CLI
+// flag overrides. A CLI include or exclude flag fully replaces the
+// configured lists; --all-projects clears both. Include and exclude
+// are mutually exclusive.
+func resolvePushProjects(
+	pgCfg config.PGConfig, cfg PGPushConfig,
+) (projects, exclude []string, err error) {
+	if cfg.ProjectsFlag != "" && cfg.ExcludeProjects != "" {
+		return nil, nil, fmt.Errorf(
+			"--projects and --exclude-projects are mutually exclusive",
+		)
+	}
+	if cfg.AllProjects &&
+		(cfg.ProjectsFlag != "" || cfg.ExcludeProjects != "") {
+		return nil, nil, fmt.Errorf(
+			"--all-projects cannot be combined with " +
+				"--projects or --exclude-projects",
+		)
+	}
+	projects = pgCfg.Projects
+	exclude = pgCfg.ExcludeProjects
+	if cfg.AllProjects {
+		projects = nil
+		exclude = nil
+	}
+	if cfg.ProjectsFlag != "" {
+		projects = splitProjectList(cfg.ProjectsFlag)
+		exclude = nil
+	}
+	if cfg.ExcludeProjects != "" {
+		exclude = splitProjectList(cfg.ExcludeProjects)
+		projects = nil
+	}
+	if len(projects) > 0 && len(exclude) > 0 {
+		return nil, nil, fmt.Errorf(
+			"projects and exclude_projects are mutually exclusive",
+		)
+	}
+	return projects, exclude, nil
 }
 
 // splitProjectList splits a comma-separated string into trimmed,

--- a/cmd/agentsview/pg_service.go
+++ b/cmd/agentsview/pg_service.go
@@ -1,0 +1,301 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/agentsview/internal/config"
+)
+
+func newPGServiceCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "service",
+		Short:        "Install and manage the pg push --watch background service",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newPGServiceInstallCommand())
+	cmd.AddCommand(newPGServiceUninstallCommand())
+	cmd.AddCommand(newPGServiceStatusCommand())
+	cmd.AddCommand(newPGServiceStartCommand())
+	cmd.AddCommand(newPGServiceStopCommand())
+	cmd.AddCommand(newPGServiceLogsCommand())
+	return cmd
+}
+
+func newPGServiceInstallCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "install",
+		Short:        "Install and start the auto-push service",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServiceInstall()
+		},
+	}
+}
+
+func newPGServiceUninstallCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "uninstall",
+		Short:        "Stop and remove the auto-push service",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServiceSimple("uninstall")
+		},
+	}
+}
+
+func newPGServiceStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "status",
+		Short:        "Show the auto-push service status",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServiceStatus()
+		},
+	}
+}
+
+func newPGServiceStartCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "start",
+		Short:        "Start the auto-push service",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServiceSimple("start")
+		},
+	}
+}
+
+func newPGServiceStopCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "stop",
+		Short:        "Stop the auto-push service",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServiceSimple("stop")
+		},
+	}
+}
+
+func newPGServiceLogsCommand() *cobra.Command {
+	var follow bool
+	cmd := &cobra.Command{
+		Use:          "logs",
+		Short:        "Show the auto-push service log",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServiceLogs(follow)
+		},
+	}
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow the log output")
+	return cmd
+}
+
+// loadServiceConfig loads minimal config and ensures the data dir.
+func loadServiceConfig() config.Config {
+	appCfg, err := config.LoadMinimal()
+	if err != nil {
+		fatal("pg service: loading config: %v", err)
+	}
+	if err := os.MkdirAll(appCfg.DataDir, 0o755); err != nil {
+		fatal("pg service: creating data dir: %v", err)
+	}
+	return appCfg
+}
+
+func runServiceInstall() {
+	appCfg := loadServiceConfig()
+	spec, err := buildServiceSpec(appCfg)
+	if err != nil {
+		fatal("pg service install: %v", err)
+	}
+	warnUninheritedServiceEnv(
+		os.Stdout, setEnvVarsAffectingService(os.LookupEnv),
+	)
+	mgr, err := newServiceManager()
+	if err != nil {
+		fatal("pg service install: %v", err)
+	}
+	ctx := context.Background()
+
+	if err := mgr.install(ctx, spec); err != nil {
+		fatal("pg service install: %v", err)
+	}
+	fmt.Printf("Installed service unit at %s\n", mgr.unitPath())
+
+	// Surface the linger requirement for systemd headless boxes.
+	if lc, ok := mgr.(lingerChecker); ok && !lc.lingerEnabled(ctx) {
+		fmt.Println()
+		fmt.Println(
+			"WARNING: user lingering is not enabled. Without it, the service " +
+				"stops when you log out and will not start at boot.",
+		)
+		fmt.Printf("Run this to enable it:\n  %s\n", lc.enableLingerCmd())
+		if promptYesNo(os.Stdin, "Enable lingering now?") {
+			parts := strings.Fields(lc.enableLingerCmd())
+			if out, lerr := defaultRunner(ctx, parts[0], parts[1:]...); lerr != nil {
+				fmt.Printf(
+					"Could not enable lingering (%v: %s).\n"+
+						"You may need elevated privileges: sudo %s\n",
+					lerr, strings.TrimSpace(out), lc.enableLingerCmd(),
+				)
+			} else {
+				fmt.Println("Lingering enabled.")
+			}
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Service installed and started.")
+	fmt.Println("View logs with: agentsview pg service logs -f")
+}
+
+func runServiceStatus() {
+	mgr, err := newServiceManager()
+	if err != nil {
+		fatal("pg service status: %v", err)
+	}
+	ctx := context.Background()
+	out, _ := mgr.status(ctx)
+	fmt.Print(out)
+	if out != "" && !strings.HasSuffix(out, "\n") {
+		fmt.Println()
+	}
+	// Show the last successful push time from local sync state.
+	appCfg := loadServiceConfig()
+	database, derr := openDB(appCfg)
+	if derr != nil {
+		return
+	}
+	defer database.Close()
+	lastPush, gerr := database.GetSyncState("last_push_at")
+	if gerr != nil {
+		return
+	}
+	fmt.Printf("Last push: %s\n", valueOrNever(lastPush))
+}
+
+func runServiceSimple(action string) {
+	mgr, err := newServiceManager()
+	if err != nil {
+		fatal("pg service %s: %v", action, err)
+	}
+	ctx := context.Background()
+	switch action {
+	case "uninstall":
+		if err := mgr.uninstall(ctx); err != nil {
+			fatal("pg service uninstall: %v", err)
+		}
+		fmt.Println("Service stopped and removed.")
+	case "start":
+		if err := mgr.start(ctx); err != nil {
+			fatal("pg service start: %v", err)
+		}
+		fmt.Println("Service started.")
+	case "stop":
+		if err := mgr.stop(ctx); err != nil {
+			fatal("pg service stop: %v", err)
+		}
+		fmt.Println("Service stopped.")
+	}
+}
+
+func runServiceLogs(follow bool) {
+	appCfg := loadServiceConfig()
+	logPath := filepath.Join(appCfg.DataDir, "pg-watch.log")
+	if err := tailFile(os.Stdout, logPath, follow); err != nil {
+		fatal("pg service logs: %v", err)
+	}
+}
+
+// tailFile prints the contents of path to w. When follow is true it
+// keeps printing appended data until the process is interrupted.
+func tailFile(w io.Writer, path string, follow bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf(
+				"no log yet at %s (has the service run?)", path,
+			)
+		}
+		return err
+	}
+	defer f.Close()
+	if _, err := io.Copy(w, f); err != nil {
+		return err
+	}
+	if !follow {
+		return nil
+	}
+	for {
+		time.Sleep(500 * time.Millisecond)
+		// If the file shrank (the daemon truncated the log on
+		// restart), our offset is now past EOF; seek back to the
+		// start so we keep streaming new output.
+		if info, serr := f.Stat(); serr == nil {
+			if pos, perr := f.Seek(0, io.SeekCurrent); perr == nil && info.Size() < pos {
+				if _, serr := f.Seek(0, io.SeekStart); serr != nil {
+					return serr
+				}
+			}
+		}
+		if _, err := io.Copy(w, f); err != nil {
+			return err
+		}
+	}
+}
+
+// warnUninheritedServiceEnv advises that environment variables set in the
+// installing shell affect runtime behavior but are not inherited by the
+// background service (which only receives AGENTSVIEW_DATA_DIR). It warns
+// rather than rejects: the service still runs using config.toml or
+// defaults, so this surfaces a potential divergence without overriding
+// the intended "environment overrides config" semantics.
+func warnUninheritedServiceEnv(w io.Writer, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w,
+		"WARNING: these environment variables affect how the service runs "+
+			"but are NOT inherited by it (the service only receives "+
+			"AGENTSVIEW_DATA_DIR):\n  %s\n",
+		strings.Join(names, ", "),
+	)
+	fmt.Fprintln(w,
+		"The background service reads these from config.toml or uses "+
+			"built-in defaults. Set them in config.toml if the service "+
+			"should match your shell.",
+	)
+}
+
+// promptYesNo asks a yes/no question, reading the answer from in and
+// defaulting to no. in is a parameter (rather than os.Stdin directly) so
+// tests can supply a reader without mutating global process state.
+func promptYesNo(in io.Reader, question string) bool {
+	fmt.Printf("%s [y/N]: ", question)
+	r := bufio.NewReader(in)
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
+}

--- a/cmd/agentsview/pg_service_launchd.go
+++ b/cmd/agentsview/pg_service_launchd.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Compile-time check that launchdManager implements serviceManager.
+var _ serviceManager = (*launchdManager)(nil)
+
+const launchdLabel = "agentsview.pg-watch"
+
+// launchdManager manages a per-user launchd LaunchAgent.
+type launchdManager struct {
+	uid  int
+	home string
+	run  cmdRunner
+}
+
+func (m *launchdManager) unitPath() string {
+	return filepath.Join(
+		m.home, "Library", "LaunchAgents", launchdLabel+".plist",
+	)
+}
+
+func (m *launchdManager) domain() string {
+	return fmt.Sprintf("gui/%d", m.uid)
+}
+
+func (m *launchdManager) target() string {
+	return fmt.Sprintf("gui/%d/%s", m.uid, launchdLabel)
+}
+
+func xmlEscape(s string) string {
+	var b strings.Builder
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}
+
+// KeepAlive restarts the daemon if it exits. install validates
+// the DSN up front and the daemon does not fatal on a transiently
+// unreachable database, so the narrow remaining fatal paths
+// (config removed, lock contention) will be retried ~every 10s by
+// launchd rather than staying down.
+func (m *launchdManager) render(spec serviceSpec) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>%s</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>%s</string>
+		<string>pg</string>
+		<string>push</string>
+		<string>--watch</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>AGENTSVIEW_DATA_DIR</key>
+		<string>%s</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>%s</string>
+	<key>StandardErrorPath</key>
+	<string>%s</string>
+</dict>
+</plist>
+`,
+		xmlEscape(launchdLabel),
+		xmlEscape(spec.BinPath),
+		xmlEscape(spec.DataDir),
+		xmlEscape(spec.LogPath),
+		xmlEscape(spec.LogPath),
+	)
+}
+
+func (m *launchdManager) install(
+	ctx context.Context, spec serviceSpec,
+) error {
+	if err := os.MkdirAll(filepath.Dir(m.unitPath()), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(
+		m.unitPath(), []byte(m.render(spec)), 0o644,
+	); err != nil {
+		return err
+	}
+	// Best-effort unload of any prior instance so bootstrap succeeds.
+	_, _ = m.run(ctx, "launchctl", "bootout", m.target())
+	if out, err := m.run(
+		ctx, "launchctl", "bootstrap", m.domain(), m.unitPath(),
+	); err != nil {
+		return fmt.Errorf("launchctl bootstrap: %v: %s", err, out)
+	}
+	return nil
+}
+
+func (m *launchdManager) uninstall(ctx context.Context) error {
+	_, _ = m.run(ctx, "launchctl", "bootout", m.target())
+	if err := os.Remove(m.unitPath()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (m *launchdManager) start(ctx context.Context) error {
+	// bootout any prior instance so bootstrap reloads cleanly;
+	// bootstrap fails if the job is already loaded.
+	_, _ = m.run(ctx, "launchctl", "bootout", m.target())
+	if out, err := m.run(
+		ctx, "launchctl", "bootstrap", m.domain(), m.unitPath(),
+	); err != nil {
+		return fmt.Errorf("launchctl bootstrap: %v: %s", err, out)
+	}
+	return nil
+}
+
+func (m *launchdManager) stop(ctx context.Context) error {
+	// bootout unloads the job so KeepAlive cannot restart it.
+	// A non-zero exit means the job was not loaded (already
+	// stopped), which we treat as success, so stop is idempotent.
+	_, _ = m.run(ctx, "launchctl", "bootout", m.target())
+	return nil
+}
+
+func (m *launchdManager) status(ctx context.Context) (string, error) {
+	// Errors are intentionally ignored: launchctl print exits
+	// non-zero when the job is not loaded, which is normal status
+	// output rather than a failure. The combined output is shown
+	// to the user verbatim. (The systemd manager swallows status
+	// errors for the same reason.)
+	out, _ := m.run(ctx, "launchctl", "print", m.target())
+	return out, nil
+}

--- a/cmd/agentsview/pg_service_manager.go
+++ b/cmd/agentsview/pg_service_manager.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unicode"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// serviceSpec is the resolved input for rendering a unit file.
+type serviceSpec struct {
+	BinPath string
+	DataDir string
+	LogPath string
+}
+
+func rejectEnvDependentServicePGURL(rawURL string) error {
+	if os.Getenv("AGENTSVIEW_PG_URL") != "" {
+		return fmt.Errorf(
+			"AGENTSVIEW_PG_URL is set; pg service install requires a " +
+				"literal pg.url in config.toml because background " +
+				"services do not inherit your shell environment",
+		)
+	}
+	// Reuse config's expansion check so the rejection rule cannot drift
+	// from how config.ResolvePG actually expands the URL at runtime.
+	if config.IsEnvDependentURL(rawURL) {
+		return fmt.Errorf(
+			"pg.url uses environment variable expansion; pg service " +
+				"install requires a literal pg.url in config.toml because " +
+				"background services do not inherit your shell environment",
+		)
+	}
+	return nil
+}
+
+// serviceRuntimeEnvVars are environment variables that influence how the
+// background pg push --watch service behaves at runtime but are NOT
+// rendered into the service unit (only AGENTSVIEW_DATA_DIR is). When any
+// are set at install time, the installed service will not see them and
+// falls back to config.toml or built-in defaults, so install warns about
+// the divergence. AGENTSVIEW_PG_URL is intentionally excluded: a
+// service that cannot resolve a URL is broken rather than merely
+// divergent, so it is a hard error (rejectEnvDependentServicePGURL), not
+// a warning.
+func serviceRuntimeEnvVars() []string {
+	vars := []string{"AGENTSVIEW_PG_SCHEMA", "AGENTSVIEW_PG_MACHINE"}
+	for _, def := range parser.Registry {
+		if def.EnvVar != "" {
+			vars = append(vars, def.EnvVar)
+		}
+	}
+	return vars
+}
+
+// setEnvVarsAffectingService returns, in declaration order, the names of
+// serviceRuntimeEnvVars currently set to a non-empty value. lookup is
+// injectable for testing; production callers pass os.LookupEnv.
+func setEnvVarsAffectingService(lookup func(string) (string, bool)) []string {
+	var set []string
+	for _, name := range serviceRuntimeEnvVars() {
+		if v, ok := lookup(name); ok && v != "" {
+			set = append(set, name)
+		}
+	}
+	return set
+}
+
+// validateServiceSpec rejects spec values containing characters that
+// could break out of a quoted value in a rendered service unit. systemd
+// unit files are not shell scripts and provide no escaping for the values
+// we interpolate (ExecStart, Environment), so a newline or double quote
+// in a path could terminate the directive and inject additional ones.
+// launchd plists likewise cannot represent NUL or most control characters
+// even when XML escaped. Rejecting these characters up front keeps both
+// renderers safe regardless of how each escapes its output.
+func validateServiceSpec(spec serviceSpec) error {
+	for _, f := range []struct{ name, val string }{
+		{"binary path", spec.BinPath},
+		{"data dir", spec.DataDir},
+		{"log path", spec.LogPath},
+	} {
+		if i := strings.IndexFunc(f.val, isUnsafeServiceRune); i >= 0 {
+			return fmt.Errorf(
+				"%s %q contains an unsafe character %q; refusing to write "+
+					"a service unit that could be malformed or inject "+
+					"directives",
+				f.name, f.val, f.val[i],
+			)
+		}
+	}
+	return nil
+}
+
+// isUnsafeServiceRune reports whether r must not appear in a rendered
+// service unit value. Control characters (newline, carriage return, NUL,
+// and friends) and the double quote can terminate or escape a quoted
+// value in a systemd unit.
+func isUnsafeServiceRune(r rune) bool {
+	return r == '"' || unicode.IsControl(r)
+}
+
+// buildServiceSpec validates PG config and resolves the binary path,
+// data dir, and log path for the installed service. It refuses to
+// build a spec when the PG URL is not resolvable so the service is
+// only ever created in a working state.
+func buildServiceSpec(appCfg config.Config) (serviceSpec, error) {
+	if err := rejectEnvDependentServicePGURL(appCfg.PG.URL); err != nil {
+		return serviceSpec{}, err
+	}
+	pgCfg, err := appCfg.ResolvePG()
+	if err != nil {
+		return serviceSpec{}, err
+	}
+	if pgCfg.URL == "" {
+		return serviceSpec{}, fmt.Errorf(
+			"pg.url not configured; set it before installing the service",
+		)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return serviceSpec{}, fmt.Errorf("resolving binary path: %w", err)
+	}
+	if resolved, rerr := filepath.EvalSymlinks(exe); rerr == nil {
+		exe = resolved
+	}
+	spec := serviceSpec{
+		BinPath: exe,
+		DataDir: appCfg.DataDir,
+		LogPath: filepath.Join(appCfg.DataDir, "pg-watch.log"),
+	}
+	if err := validateServiceSpec(spec); err != nil {
+		return serviceSpec{}, err
+	}
+	return spec, nil
+}
+
+// cmdRunner runs an external command and returns combined output.
+// Injectable so managers can be tested without invoking launchctl /
+// systemctl.
+type cmdRunner func(ctx context.Context, name string, args ...string) (string, error)
+
+func defaultRunner(
+	ctx context.Context, name string, args ...string,
+) (string, error) {
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	return string(out), err
+}
+
+// serviceManager installs and controls the pg push --watch OS service.
+type serviceManager interface {
+	unitPath() string
+	render(spec serviceSpec) string
+	install(ctx context.Context, spec serviceSpec) error
+	uninstall(ctx context.Context) error
+	start(ctx context.Context) error
+	stop(ctx context.Context) error
+	status(ctx context.Context) (string, error)
+}
+
+// lingerChecker is implemented by managers (systemd) where the
+// service needs an OS setting to run while logged out.
+type lingerChecker interface {
+	lingerEnabled(ctx context.Context) bool
+	enableLingerCmd() string
+}
+
+// newServiceManager returns the manager for the current platform.
+func newServiceManager() (serviceManager, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving home dir: %w", err)
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return &launchdManager{
+			uid: os.Getuid(), home: home, run: defaultRunner,
+		}, nil
+	case "linux":
+		u, uerr := user.Current()
+		if uerr != nil {
+			return nil, fmt.Errorf("resolving current user: %w", uerr)
+		}
+		return &systemdManager{
+			user: u.Username, home: home, run: defaultRunner,
+		}, nil
+	default:
+		return nil, fmt.Errorf(
+			"pg service: unsupported platform %q (supported: macOS, Linux)",
+			runtime.GOOS,
+		)
+	}
+}

--- a/cmd/agentsview/pg_service_systemd.go
+++ b/cmd/agentsview/pg_service_systemd.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Compile-time checks that systemdManager satisfies both interfaces.
+var (
+	_ serviceManager = (*systemdManager)(nil)
+	_ lingerChecker  = (*systemdManager)(nil)
+)
+
+const systemdUnitName = "agentsview-pg-watch.service"
+
+// systemdManager manages a per-user systemd unit (systemctl --user).
+type systemdManager struct {
+	user string
+	home string
+	run  cmdRunner
+}
+
+func (m *systemdManager) unitPath() string {
+	return filepath.Join(
+		m.home, ".config", "systemd", "user", systemdUnitName,
+	)
+}
+
+// StandardOutput/StandardError append to LogPath so the daemon's stdout
+// and stderr (notably the startup banner and fatal-exit messages, which
+// bypass the log file) land where "pg service logs" tails. This mirrors
+// the launchd plist's StandardOutPath/StandardErrorPath; without it those
+// messages would go to journald and the tailed file would omit the very
+// crash reason a user runs "logs" to find.
+func (m *systemdManager) render(spec serviceSpec) string {
+	return fmt.Sprintf(`[Unit]
+Description=agentsview PostgreSQL auto-push
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart="%s" pg push --watch
+Environment=AGENTSVIEW_DATA_DIR="%s"
+StandardOutput=append:%s
+StandardError=append:%s
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+`, spec.BinPath, spec.DataDir, spec.LogPath, spec.LogPath)
+}
+
+func (m *systemdManager) lingerEnabled(ctx context.Context) bool {
+	out, err := m.run(
+		ctx, "loginctl", "show-user", m.user, "--property=Linger",
+	)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) == "Linger=yes"
+}
+
+func (m *systemdManager) enableLingerCmd() string {
+	return fmt.Sprintf("loginctl enable-linger %s", m.user)
+}
+
+func (m *systemdManager) install(
+	ctx context.Context, spec serviceSpec,
+) error {
+	if err := os.MkdirAll(filepath.Dir(m.unitPath()), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(
+		m.unitPath(), []byte(m.render(spec)), 0o644,
+	); err != nil {
+		return err
+	}
+	if out, err := m.run(
+		ctx, "systemctl", "--user", "daemon-reload",
+	); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %v: %s", err, out)
+	}
+	if out, err := m.run(
+		ctx, "systemctl", "--user", "enable", "--now", systemdUnitName,
+	); err != nil {
+		return fmt.Errorf("systemctl enable: %v: %s", err, out)
+	}
+	return nil
+}
+
+func (m *systemdManager) uninstall(ctx context.Context) error {
+	_, _ = m.run(
+		ctx, "systemctl", "--user", "disable", "--now", systemdUnitName,
+	)
+	if err := os.Remove(m.unitPath()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	_, _ = m.run(ctx, "systemctl", "--user", "daemon-reload")
+	return nil
+}
+
+func (m *systemdManager) start(ctx context.Context) error {
+	if out, err := m.run(
+		ctx, "systemctl", "--user", "start", systemdUnitName,
+	); err != nil {
+		return fmt.Errorf("systemctl start: %v: %s", err, out)
+	}
+	return nil
+}
+
+func (m *systemdManager) stop(ctx context.Context) error {
+	if out, err := m.run(
+		ctx, "systemctl", "--user", "stop", systemdUnitName,
+	); err != nil {
+		return fmt.Errorf("systemctl stop: %v: %s", err, out)
+	}
+	return nil
+}
+
+func (m *systemdManager) status(ctx context.Context) (string, error) {
+	out, _ := m.run(ctx, "systemctl", "--user", "status", systemdUnitName)
+	return out, nil
+}

--- a/cmd/agentsview/pg_service_test.go
+++ b/cmd/agentsview/pg_service_test.go
@@ -1,0 +1,505 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+)
+
+func TestBuildServiceSpec_RequiresURL(t *testing.T) {
+	t.Setenv("AGENTSVIEW_PG_URL", "")
+	_, err := buildServiceSpec(config.Config{})
+	require.Error(t, err, "expected error when pg.url is not configured")
+}
+
+func TestBuildServiceSpec_PopulatesFields(t *testing.T) {
+	t.Setenv("AGENTSVIEW_PG_URL", "")
+	dataDir := t.TempDir()
+	spec, err := buildServiceSpec(config.Config{
+		DataDir: dataDir,
+		PG: config.PGConfig{
+			URL:         "postgres://u:p@localhost/db?sslmode=disable",
+			MachineName: "box1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildServiceSpec: %v", err)
+	}
+	if spec.BinPath == "" {
+		t.Error("BinPath should be set")
+	}
+	if spec.DataDir != dataDir {
+		t.Errorf("DataDir = %q, want %q", spec.DataDir, dataDir)
+	}
+	if spec.LogPath != filepath.Join(dataDir, "pg-watch.log") {
+		t.Errorf("LogPath = %q", spec.LogPath)
+	}
+}
+
+func TestBuildServiceSpec_RejectsEnvPGURL(t *testing.T) {
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://from-env")
+	_, err := buildServiceSpec(config.Config{
+		DataDir: t.TempDir(),
+		PG: config.PGConfig{
+			URL:         "postgres://from-env",
+			MachineName: "box1",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AGENTSVIEW_PG_URL")
+	assert.Contains(t, err.Error(), "literal pg.url")
+}
+
+func TestBuildServiceSpec_RejectsExpandedPGURL(t *testing.T) {
+	t.Setenv("AGENTSVIEW_PG_URL", "")
+	t.Setenv("PGURL", "postgres://from-var")
+	_, err := buildServiceSpec(config.Config{
+		DataDir: t.TempDir(),
+		PG: config.PGConfig{
+			URL:         "${PGURL}",
+			MachineName: "box1",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment variable expansion")
+
+	_, err = buildServiceSpec(config.Config{
+		DataDir: t.TempDir(),
+		PG: config.PGConfig{
+			URL:         "$PGURL",
+			MachineName: "box1",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment variable expansion")
+}
+
+func TestValidateServiceSpec_RejectsUnsafeChars(t *testing.T) {
+	const clean = "/usr/local/bin/agentsview"
+	cleanSpec := serviceSpec{
+		BinPath: clean,
+		DataDir: "/home/me/.agentsview",
+		LogPath: "/home/me/.agentsview/pg-watch.log",
+	}
+	require.NoError(t, validateServiceSpec(cleanSpec),
+		"clean spec should pass validation")
+
+	// A path containing a space is unusual but legal and must not be
+	// rejected (only control characters and double quotes are unsafe).
+	spaced := cleanSpec
+	spaced.DataDir = "/home/me/App Support/agentsview"
+	require.NoError(t, validateServiceSpec(spaced),
+		"a space in a path is legal and should pass")
+
+	unsafe := []struct {
+		name string
+		bad  string
+	}{
+		{"newline", "/bin/x\nExecStart=/evil"},
+		{"carriage return", "/bin/x\rExecStart=/evil"},
+		{"double quote", `/bin/x" "/evil`},
+		{"nul byte", "/bin/x\x00/evil"},
+		{"control byte", "/bin/x\x07/evil"},
+	}
+	for _, u := range unsafe {
+		// ExecStart is rendered from BinPath; Environment from DataDir.
+		// Cover both interpolation sites.
+		t.Run("execstart_"+u.name, func(t *testing.T) {
+			s := cleanSpec
+			s.BinPath = u.bad
+			err := validateServiceSpec(s)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "binary path")
+			assert.Contains(t, err.Error(), "unsafe character")
+		})
+		t.Run("environment_"+u.name, func(t *testing.T) {
+			s := cleanSpec
+			s.DataDir = u.bad
+			err := validateServiceSpec(s)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "data dir")
+			assert.Contains(t, err.Error(), "unsafe character")
+		})
+	}
+}
+
+func TestBuildServiceSpec_RejectsUnsafeDataDir(t *testing.T) {
+	t.Setenv("AGENTSVIEW_PG_URL", "")
+	_, err := buildServiceSpec(config.Config{
+		DataDir: "/home/me/.agentsview\nExecStart=/evil",
+		PG: config.PGConfig{
+			URL:         "postgres://u:p@localhost/db?sslmode=disable",
+			MachineName: "box1",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe character")
+}
+
+func TestSetEnvVarsAffectingService(t *testing.T) {
+	// AGENTSVIEW_PG_URL is a hard error elsewhere, not a warning, so it
+	// must never appear here even when set.
+	env := map[string]string{
+		"AGENTSVIEW_PG_SCHEMA":  "staging",
+		"CLAUDE_PROJECTS_DIR":   "/tmp/claude",
+		"AGENTSVIEW_PG_URL":     "postgres://from-env",
+		"AGENTSVIEW_PG_MACHINE": "", // set-but-empty should be ignored
+	}
+	lookup := func(name string) (string, bool) {
+		v, ok := env[name]
+		return v, ok
+	}
+	got := setEnvVarsAffectingService(lookup)
+	assert.Contains(t, got, "AGENTSVIEW_PG_SCHEMA")
+	assert.Contains(t, got, "CLAUDE_PROJECTS_DIR")
+	assert.NotContains(t, got, "AGENTSVIEW_PG_URL")
+	assert.NotContains(t, got, "AGENTSVIEW_PG_MACHINE",
+		"set-but-empty env vars should not be reported")
+
+	// Nothing set -> empty result.
+	none := setEnvVarsAffectingService(func(string) (string, bool) {
+		return "", false
+	})
+	assert.Empty(t, none)
+}
+
+func TestWarnUninheritedServiceEnv(t *testing.T) {
+	var buf strings.Builder
+	warnUninheritedServiceEnv(&buf, nil)
+	assert.Empty(t, buf.String(), "no warning when nothing is set")
+
+	buf.Reset()
+	warnUninheritedServiceEnv(&buf, []string{"AGENTSVIEW_PG_SCHEMA", "CLAUDE_PROJECTS_DIR"})
+	out := buf.String()
+	assert.Contains(t, out, "WARNING")
+	assert.Contains(t, out, "AGENTSVIEW_PG_SCHEMA")
+	assert.Contains(t, out, "CLAUDE_PROJECTS_DIR")
+	assert.Contains(t, out, "config.toml")
+}
+
+// recordingRunner captures shell-out calls for assertions.
+type recordingRunner struct {
+	calls   [][]string
+	outputs map[string]string // keyed by joined args; optional
+}
+
+func (r *recordingRunner) run(
+	_ context.Context, name string, args ...string,
+) (string, error) {
+	full := append([]string{name}, args...)
+	r.calls = append(r.calls, full)
+	if r.outputs != nil {
+		if out, ok := r.outputs[strings.Join(full, " ")]; ok {
+			return out, nil
+		}
+	}
+	return "", nil
+}
+
+func (r *recordingRunner) sawContains(sub string) bool {
+	for _, c := range r.calls {
+		if strings.Contains(strings.Join(c, " "), sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLaunchdRender(t *testing.T) {
+	m := &launchdManager{uid: 501, home: "/Users/me", run: nil}
+	spec := serviceSpec{
+		BinPath: "/usr/local/bin/agentsview",
+		DataDir: "/Users/me/.agentsview",
+		LogPath: "/Users/me/.agentsview/pg-watch.log",
+	}
+	got := m.render(spec)
+	// Substring assertions avoid brittleness over plist indentation.
+	wants := []string{
+		`<string>agentsview.pg-watch</string>`,
+		`<string>/usr/local/bin/agentsview</string>`,
+		`<string>pg</string>`,
+		`<string>push</string>`,
+		`<string>--watch</string>`,
+		`<key>AGENTSVIEW_DATA_DIR</key>`,
+		`<string>/Users/me/.agentsview</string>`,
+		`<key>RunAtLoad</key>`,
+		`<key>KeepAlive</key>`,
+		`<string>/Users/me/.agentsview/pg-watch.log</string>`,
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("render missing %q\n--- got ---\n%s", w, got)
+		}
+	}
+	if !strings.HasPrefix(got, `<?xml version="1.0"`) {
+		t.Errorf("render should start with the XML prolog, got:\n%s", got)
+	}
+	if strings.Contains(got, "<false/>") {
+		t.Errorf("render should not contain any <false/> value:\n%s", got)
+	}
+}
+
+func TestLaunchdUnitPath(t *testing.T) {
+	m := &launchdManager{uid: 501, home: "/Users/me"}
+	want := filepath.Join(
+		"/Users/me", "Library", "LaunchAgents", "agentsview.pg-watch.plist",
+	)
+	if m.unitPath() != want {
+		t.Errorf("unitPath = %q, want %q", m.unitPath(), want)
+	}
+}
+
+func TestLaunchdInstall_WritesAndBootstraps(t *testing.T) {
+	home := t.TempDir()
+	rr := &recordingRunner{}
+	m := &launchdManager{uid: 501, home: home, run: rr.run}
+	spec := serviceSpec{
+		BinPath: "/usr/local/bin/agentsview",
+		DataDir: home,
+		LogPath: filepath.Join(home, "pg-watch.log"),
+	}
+	if err := m.install(context.Background(), spec); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := os.Stat(m.unitPath()); err != nil {
+		t.Fatalf("plist not written: %v", err)
+	}
+	if !rr.sawContains("launchctl bootstrap gui/501 " + m.unitPath()) {
+		t.Errorf("expected bootstrap with plist path, calls=%v", rr.calls)
+	}
+}
+
+func TestLaunchdStart_BootstrapsAfterBootout(t *testing.T) {
+	rr := &recordingRunner{}
+	m := &launchdManager{uid: 501, home: t.TempDir(), run: rr.run}
+	if err := m.start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !rr.sawContains("launchctl bootstrap gui/501 " + m.unitPath()) {
+		t.Errorf("expected bootstrap, calls=%v", rr.calls)
+	}
+}
+
+func TestLaunchdStop_BootsOut(t *testing.T) {
+	rr := &recordingRunner{}
+	m := &launchdManager{uid: 501, home: t.TempDir(), run: rr.run}
+	if err := m.stop(context.Background()); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !rr.sawContains("launchctl bootout gui/501/agentsview.pg-watch") {
+		t.Errorf("expected bootout, calls=%v", rr.calls)
+	}
+}
+
+func TestLaunchdUninstall_RemovesPlist(t *testing.T) {
+	home := t.TempDir()
+	rr := &recordingRunner{}
+	m := &launchdManager{uid: 501, home: home, run: rr.run}
+	spec := serviceSpec{
+		BinPath: "/usr/local/bin/agentsview",
+		DataDir: home,
+		LogPath: filepath.Join(home, "pg-watch.log"),
+	}
+	if err := m.install(context.Background(), spec); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := m.uninstall(context.Background()); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if _, err := os.Stat(m.unitPath()); !os.IsNotExist(err) {
+		t.Errorf("plist should be removed, stat err=%v", err)
+	}
+	if !rr.sawContains("launchctl bootout gui/501/agentsview.pg-watch") {
+		t.Errorf("expected bootout on uninstall, calls=%v", rr.calls)
+	}
+}
+
+func TestSystemdRender_Golden(t *testing.T) {
+	m := &systemdManager{user: "me", home: "/home/me"}
+	spec := serviceSpec{
+		BinPath: "/usr/local/bin/agentsview",
+		DataDir: "/home/me/.agentsview",
+		LogPath: "/home/me/.agentsview/pg-watch.log",
+	}
+	got := m.render(spec)
+	want := `[Unit]
+Description=agentsview PostgreSQL auto-push
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart="/usr/local/bin/agentsview" pg push --watch
+Environment=AGENTSVIEW_DATA_DIR="/home/me/.agentsview"
+StandardOutput=append:/home/me/.agentsview/pg-watch.log
+StandardError=append:/home/me/.agentsview/pg-watch.log
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+`
+	if got != want {
+		t.Errorf("render mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestSystemdUnitPath(t *testing.T) {
+	m := &systemdManager{user: "me", home: "/home/me"}
+	want := filepath.Join(
+		"/home/me", ".config", "systemd", "user", "agentsview-pg-watch.service",
+	)
+	if m.unitPath() != want {
+		t.Errorf("unitPath = %q, want %q", m.unitPath(), want)
+	}
+}
+
+func TestSystemdLingerDetection(t *testing.T) {
+	yes := &recordingRunner{outputs: map[string]string{
+		"loginctl show-user me --property=Linger": "Linger=yes\n",
+	}}
+	m := &systemdManager{user: "me", home: "/home/me", run: yes.run}
+	if !m.lingerEnabled(context.Background()) {
+		t.Error("expected linger enabled")
+	}
+	no := &recordingRunner{outputs: map[string]string{
+		"loginctl show-user me --property=Linger": "Linger=no\n",
+	}}
+	m2 := &systemdManager{user: "me", home: "/home/me", run: no.run}
+	if m2.lingerEnabled(context.Background()) {
+		t.Error("expected linger disabled")
+	}
+}
+
+func TestSystemdInstall_ReloadsAndEnables(t *testing.T) {
+	home := t.TempDir()
+	rr := &recordingRunner{}
+	m := &systemdManager{user: "me", home: home, run: rr.run}
+	spec := serviceSpec{
+		BinPath: "/usr/local/bin/agentsview",
+		DataDir: home,
+		LogPath: filepath.Join(home, "pg-watch.log"),
+	}
+	if err := m.install(context.Background(), spec); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := os.Stat(m.unitPath()); err != nil {
+		t.Fatalf("unit not written: %v", err)
+	}
+	if !rr.sawContains("systemctl --user daemon-reload") {
+		t.Errorf("expected daemon-reload, calls=%v", rr.calls)
+	}
+	if !rr.sawContains("systemctl --user enable --now agentsview-pg-watch.service") {
+		t.Errorf("expected enable --now, calls=%v", rr.calls)
+	}
+}
+
+func TestSystemdStart_CallsStart(t *testing.T) {
+	rr := &recordingRunner{}
+	m := &systemdManager{user: "me", home: t.TempDir(), run: rr.run}
+	if err := m.start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !rr.sawContains("systemctl --user start agentsview-pg-watch.service") {
+		t.Errorf("expected start, calls=%v", rr.calls)
+	}
+}
+
+func TestSystemdStop_CallsStop(t *testing.T) {
+	rr := &recordingRunner{}
+	m := &systemdManager{user: "me", home: t.TempDir(), run: rr.run}
+	if err := m.stop(context.Background()); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if !rr.sawContains("systemctl --user stop agentsview-pg-watch.service") {
+		t.Errorf("expected stop, calls=%v", rr.calls)
+	}
+}
+
+func TestSystemdUninstall_DisablesAndRemoves(t *testing.T) {
+	home := t.TempDir()
+	rr := &recordingRunner{}
+	m := &systemdManager{user: "me", home: home, run: rr.run}
+	spec := serviceSpec{
+		BinPath: "/usr/local/bin/agentsview",
+		DataDir: home,
+		LogPath: filepath.Join(home, "pg-watch.log"),
+	}
+	if err := m.install(context.Background(), spec); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := m.uninstall(context.Background()); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if _, err := os.Stat(m.unitPath()); !os.IsNotExist(err) {
+		t.Errorf("unit should be removed, stat err=%v", err)
+	}
+	if !rr.sawContains("systemctl --user disable --now agentsview-pg-watch.service") {
+		t.Errorf("expected disable --now, calls=%v", rr.calls)
+	}
+}
+
+func TestPGServiceCommandTree(t *testing.T) {
+	cmd := newPGServiceCommand()
+	want := map[string]bool{
+		"install": false, "uninstall": false, "status": false,
+		"start": false, "stop": false, "logs": false,
+	}
+	for _, c := range cmd.Commands() {
+		want[c.Name()] = true
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestTailFile_ReadsContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pg-watch.log")
+	if err := os.WriteFile(path, []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var buf strings.Builder
+	if err := tailFile(&buf, path, false); err != nil {
+		t.Fatalf("tailFile: %v", err)
+	}
+	if buf.String() != "hello\nworld\n" {
+		t.Errorf("tailFile content = %q, want %q", buf.String(), "hello\nworld\n")
+	}
+}
+
+func TestTailFile_MissingFileErrors(t *testing.T) {
+	var buf strings.Builder
+	err := tailFile(&buf, filepath.Join(t.TempDir(), "nope.log"), false)
+	if err == nil {
+		t.Fatal("expected an error for a missing log file")
+	}
+}
+
+func TestPromptYesNo(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"y\n", true},
+		{"yes\n", true},
+		{"Y\n", true},
+		{"n\n", false},
+		{"\n", false},
+		{"", false}, // EOF
+		{"garbage\n", false},
+	}
+	for _, c := range cases {
+		got := promptYesNo(strings.NewReader(c.in), "Continue?")
+		if got != c.want {
+			t.Errorf("promptYesNo(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/cmd/agentsview/pg_watch.go
+++ b/cmd/agentsview/pg_watch.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/pidlock"
+	"go.kenn.io/agentsview/internal/postgres"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// pgTarget is the subset of *postgres.Sync the pusher needs. It is an
+// interface so the pusher can be tested without a live database.
+type pgTarget interface {
+	EnsureSchema(ctx context.Context) error
+	Push(
+		ctx context.Context, full bool,
+		onProgress func(postgres.PushProgress),
+	) (postgres.PushResult, error)
+	Close() error
+}
+
+// pgPusher runs a local sync then pushes to PostgreSQL, lazily
+// connecting and reconnecting after errors so a transiently
+// unreachable database never crashes the daemon.
+type pgPusher struct {
+	localSync func(context.Context) error
+	connect   func() (pgTarget, error)
+	target    pgTarget
+}
+
+// push performs one local-sync-then-push cycle. On any PG error it
+// drops the cached connection so the next call reconnects.
+func (p *pgPusher) push(
+	ctx context.Context, reason pushReason, full bool,
+) error {
+	if err := p.localSync(ctx); err != nil {
+		return fmt.Errorf("local sync: %w", err)
+	}
+	if p.target == nil {
+		t, err := p.connect()
+		if err != nil {
+			return fmt.Errorf("connect: %w", err)
+		}
+		p.target = t
+	}
+	// EnsureSchema is idempotent and memoized inside *postgres.Sync,
+	// so calling it every cycle is cheap after the first success.
+	if err := p.target.EnsureSchema(ctx); err != nil {
+		p.reset()
+		return fmt.Errorf("ensure schema: %w", err)
+	}
+	res, err := p.target.Push(ctx, full, nil)
+	if err != nil {
+		p.reset()
+		return fmt.Errorf("push: %w", err)
+	}
+	if res.Errors > 0 {
+		log.Printf(
+			"pg watch: pushed %d sessions, %d messages, %d errors (%s)",
+			res.SessionsPushed, res.MessagesPushed, res.Errors, reason,
+		)
+		log.Printf(
+			"pg watch: %d session(s) failed to push; will retry",
+			res.Errors,
+		)
+		return nil
+	}
+	log.Printf(
+		"pg watch: pushed %d sessions, %d messages (%s)",
+		res.SessionsPushed, res.MessagesPushed, reason,
+	)
+	return nil
+}
+
+func (p *pgPusher) reset() {
+	if p.target != nil {
+		_ = p.target.Close()
+		p.target = nil
+	}
+}
+
+// resolveWatchTargets validates PG config and resolves the project
+// filters for a watch run.
+func resolveWatchTargets(
+	appCfg config.Config, cfg PGPushConfig,
+) (pgCfg config.PGConfig, projects, exclude []string, err error) {
+	pgCfg, err = appCfg.ResolvePG()
+	if err != nil {
+		return config.PGConfig{}, nil, nil, err
+	}
+	if pgCfg.URL == "" {
+		return config.PGConfig{}, nil, nil,
+			fmt.Errorf("url not configured")
+	}
+	projects, exclude, err = resolvePushProjects(pgCfg, cfg)
+	if err != nil {
+		return config.PGConfig{}, nil, nil, err
+	}
+	return pgCfg, projects, exclude, nil
+}
+
+const (
+	defaultWatchDebounce = 30 * time.Second
+	defaultWatchInterval = 15 * time.Minute
+)
+
+// runPGPushWatch runs the long-lived auto-push daemon: an initial
+// catch-up push, then pushes triggered by file changes (debounced)
+// and a periodic floor tick, until interrupted.
+func runPGPushWatch(cfg PGPushConfig) {
+	appCfg, err := config.LoadMinimal()
+	if err != nil {
+		log.Fatalf("loading config: %v", err)
+	}
+	if err := os.MkdirAll(appCfg.DataDir, 0o755); err != nil {
+		log.Fatalf("creating data dir: %v", err)
+	}
+	setupLogFileNamed(appCfg.DataDir, "pg-watch.log")
+
+	pgCfg, projects, exclude, err := resolveWatchTargets(appCfg, cfg)
+	if err != nil {
+		fatal("pg push --watch: %v", err)
+	}
+
+	debounce := cfg.Debounce
+	if debounce <= 0 {
+		debounce = defaultWatchDebounce
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = defaultWatchInterval
+	}
+
+	// Single-instance guard: only one watcher per data dir.
+	lockPath := filepath.Join(appCfg.DataDir, "pg-watch.lock")
+	lock, err := pidlock.Acquire(lockPath)
+	if err != nil {
+		fatal("pg push --watch: %v", err)
+	}
+	defer func() {
+		if rerr := lock.Release(); rerr != nil {
+			log.Printf("pg watch: releasing lock: %v", rerr)
+		}
+	}()
+
+	applyClassifierConfig(appCfg)
+	database := mustOpenDB(appCfg)
+	defer database.Close()
+
+	for _, def := range parser.Registry {
+		if !appCfg.IsUserConfigured(def.Type) {
+			continue
+		}
+		warnMissingDirs(appCfg.ResolveDirs(def.Type), string(def.Type))
+	}
+	cleanResyncTemp(appCfg.DBPath)
+
+	ctx, stop := signal.NotifyContext(
+		context.Background(), os.Interrupt, syscall.SIGTERM,
+	)
+	defer stop()
+
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs:               appCfg.AgentDirs,
+		Machine:                 "local",
+		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
+	})
+
+	// Initial local sync. A data-version change forces a full push.
+	didResync := cfg.Full || database.NeedsResync()
+	if didResync {
+		engine.ResyncAll(ctx, nil)
+	} else {
+		engine.SyncAll(ctx, nil)
+	}
+	if ctx.Err() != nil {
+		return
+	}
+
+	pusher := &pgPusher{
+		localSync: func(c context.Context) error {
+			engine.SyncAll(c, nil)
+			return nil
+		},
+		connect: func() (pgTarget, error) {
+			// Repeated inside this closure (not only in the outer
+			// body) because TestEveryStoreOpenPathIsWired scans each
+			// function literal independently and requires a
+			// classifier-wiring call in the same body as postgres.New.
+			applyClassifierConfig(appCfg)
+			s, cErr := postgres.New(
+				pgCfg.URL, pgCfg.Schema, database,
+				pgCfg.MachineName, pgCfg.AllowInsecure,
+				postgres.SyncOptions{
+					Projects:        projects,
+					ExcludeProjects: exclude,
+				},
+			)
+			if cErr != nil {
+				return nil, cErr
+			}
+			return s, nil
+		},
+	}
+	defer pusher.reset()
+
+	log.Printf(
+		"pg watch: starting (machine=%q debounce=%s interval=%s)",
+		pgCfg.MachineName, debounce, interval,
+	)
+	fmt.Printf(
+		"agentsview pg watch: pushing to PostgreSQL as %q "+
+			"(debounce %s, floor %s)\n",
+		pgCfg.MachineName, debounce, interval,
+	)
+
+	// Initial catch-up push (full if a resync just happened).
+	if err := pusher.push(ctx, reasonStartup, didResync); err != nil {
+		log.Printf("pg watch: initial push failed: %v", err)
+	}
+
+	loop, ticker := newPushLoop(debounce, interval,
+		func(c context.Context, r pushReason) error {
+			return pusher.push(c, r, false)
+		},
+	)
+	defer ticker.Stop()
+
+	stopWatcher, unwatchedDirs := startFileWatcher(appCfg, engine,
+		func(paths []string) {
+			engine.SyncPaths(paths)
+			loop.NotifyDirty()
+		},
+	)
+	defer stopWatcher()
+	if len(unwatchedDirs) > 0 {
+		log.Printf(
+			"pg watch: %d root(s) not watched; relying on the %s floor for coverage",
+			len(unwatchedDirs), interval,
+		)
+	}
+
+	loop.Run(ctx)
+}

--- a/cmd/agentsview/pg_watch_loop.go
+++ b/cmd/agentsview/pg_watch_loop.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// pushReason labels why a push was triggered, for logging.
+type pushReason string
+
+const (
+	reasonStartup  pushReason = "startup"
+	reasonChange   pushReason = "change"
+	reasonInterval pushReason = "interval"
+	reasonShutdown pushReason = "shutdown"
+)
+
+// defaultFlushTimeout bounds the best-effort push performed when the
+// loop shuts down, so a stalled PostgreSQL connection cannot block
+// process exit indefinitely.
+const defaultFlushTimeout = 30 * time.Second
+
+// pushLoop coalesces file-change notifications and a periodic floor
+// tick into serialized pushes. A single goroutine (Run) performs all
+// pushes, so a push is never concurrent with another push.
+//
+// The after/floor fields are injectable so the loop is deterministic
+// under test. In production, after is time.After and floor is a
+// time.Ticker channel.
+type pushLoop struct {
+	debounce time.Duration
+	dirty    chan struct{}
+	floor    <-chan time.Time
+	after    func(time.Duration) <-chan time.Time
+	push     func(ctx context.Context, reason pushReason) error
+	// flushTimeout bounds the final shutdown-flush push. Zero means
+	// no bound (used in tests that inject a fake pusher).
+	flushTimeout time.Duration
+}
+
+// newPushLoop builds a production loop with a real debounce timer and
+// floor ticker. The caller must Stop the returned ticker.
+func newPushLoop(
+	debounce, interval time.Duration,
+	push func(context.Context, pushReason) error,
+) (*pushLoop, *time.Ticker) {
+	ticker := time.NewTicker(interval)
+	return &pushLoop{
+		debounce:     debounce,
+		dirty:        make(chan struct{}, 1),
+		floor:        ticker.C,
+		after:        time.After,
+		push:         push,
+		flushTimeout: defaultFlushTimeout,
+	}, ticker
+}
+
+// NotifyDirty signals that local data changed. Non-blocking: a burst
+// collapses into a single pending push.
+func (l *pushLoop) NotifyDirty() {
+	select {
+	case l.dirty <- struct{}{}:
+	default:
+	}
+}
+
+// Run blocks until ctx is cancelled, then performs a final flush push.
+func (l *pushLoop) Run(ctx context.Context) {
+	var armed bool
+	var fire <-chan time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			// Final best-effort flush with a fresh context so the
+			// push is not immediately cancelled.
+			flushCtx := context.Background()
+			if l.flushTimeout > 0 {
+				var cancel context.CancelFunc
+				flushCtx, cancel = context.WithTimeout(flushCtx, l.flushTimeout)
+				defer cancel()
+			}
+			l.doPush(flushCtx, reasonShutdown)
+			return
+		case <-l.dirty:
+			if !armed {
+				armed = true
+				fire = l.after(l.debounce)
+			}
+		case <-fire:
+			armed = false
+			fire = nil
+			l.doPush(ctx, reasonChange)
+		case <-l.floor:
+			// A floor tick supersedes any pending debounce.
+			armed = false
+			fire = nil
+			l.doPush(ctx, reasonInterval)
+		}
+	}
+}
+
+func (l *pushLoop) doPush(ctx context.Context, reason pushReason) {
+	if err := l.push(ctx, reason); err != nil {
+		log.Printf("pg watch: push (%s) failed: %v", reason, err)
+	}
+}

--- a/cmd/agentsview/pg_watch_loop_test.go
+++ b/cmd/agentsview/pg_watch_loop_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// newTestLoop wires a pushLoop with caller-controlled timers.
+func newTestLoop(push func(context.Context, pushReason) error) (
+	*pushLoop, chan time.Time, chan time.Time,
+) {
+	fire := make(chan time.Time, 1)
+	floor := make(chan time.Time, 1)
+	l := &pushLoop{
+		debounce: time.Minute, // irrelevant; after is stubbed
+		dirty:    make(chan struct{}, 1),
+		floor:    floor,
+		after:    func(time.Duration) <-chan time.Time { return fire },
+		push:     push,
+	}
+	return l, fire, floor
+}
+
+func TestPushLoop_DirtyTriggersOnePush(t *testing.T) {
+	pushed := make(chan pushReason, 4)
+	l, fire, _ := newTestLoop(func(_ context.Context, r pushReason) error {
+		pushed <- r
+		return nil
+	})
+	ctx := t.Context()
+	go l.Run(ctx)
+
+	l.NotifyDirty()
+	fire <- time.Now()
+
+	select {
+	case r := <-pushed:
+		if r != reasonChange {
+			t.Fatalf("reason = %q, want %q", r, reasonChange)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a push")
+	}
+}
+
+func TestPushLoop_BurstCoalesces(t *testing.T) {
+	pushed := make(chan pushReason, 8)
+	l, fire, _ := newTestLoop(func(_ context.Context, r pushReason) error {
+		pushed <- r
+		return nil
+	})
+	ctx := t.Context()
+	go l.Run(ctx)
+
+	// Many dirty signals before the timer fires -> one push.
+	for range 5 {
+		l.NotifyDirty()
+	}
+	fire <- time.Now()
+
+	select {
+	case <-pushed:
+	case <-time.After(time.Second):
+		t.Fatal("expected a push")
+	}
+	select {
+	case <-pushed:
+		t.Fatal("expected exactly one push for a burst")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestPushLoop_FloorPushesWithoutDirty(t *testing.T) {
+	pushed := make(chan pushReason, 4)
+	l, _, floor := newTestLoop(func(_ context.Context, r pushReason) error {
+		pushed <- r
+		return nil
+	})
+	ctx := t.Context()
+	go l.Run(ctx)
+
+	floor <- time.Now()
+
+	select {
+	case r := <-pushed:
+		if r != reasonInterval {
+			t.Fatalf("reason = %q, want %q", r, reasonInterval)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected an interval push")
+	}
+}
+
+func TestPushLoop_ErrorDoesNotStopLoop(t *testing.T) {
+	pushed := make(chan pushReason, 4)
+	calls := 0
+	l, fire, _ := newTestLoop(func(_ context.Context, r pushReason) error {
+		calls++
+		pushed <- r
+		if calls == 1 {
+			return errors.New("pg down")
+		}
+		return nil
+	})
+	ctx := t.Context()
+	go l.Run(ctx)
+
+	l.NotifyDirty()
+	fire <- time.Now()
+	<-pushed // first (errored); also synchronizes the loop draining fire before the next send
+
+	l.NotifyDirty()
+	fire <- time.Now()
+	select {
+	case <-pushed: // second succeeds -> loop survived the error
+	case <-time.After(time.Second):
+		t.Fatal("loop did not survive a push error")
+	}
+}
+
+func TestPushLoop_ShutdownFlushes(t *testing.T) {
+	pushed := make(chan pushReason, 4)
+	l, _, _ := newTestLoop(func(_ context.Context, r pushReason) error {
+		pushed <- r
+		return nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	go l.Run(ctx)
+
+	cancel()
+	select {
+	case r := <-pushed:
+		if r != reasonShutdown {
+			t.Fatalf("reason = %q, want %q", r, reasonShutdown)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a shutdown flush push")
+	}
+}
+
+func TestPushLoop_ShutdownFlushHonorsTimeout(t *testing.T) {
+	gotDeadline := make(chan bool, 1)
+	l, _, _ := newTestLoop(func(ctx context.Context, _ pushReason) error {
+		_, ok := ctx.Deadline()
+		gotDeadline <- ok
+		return nil
+	})
+	l.flushTimeout = 50 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	go l.Run(ctx)
+	cancel()
+
+	select {
+	case ok := <-gotDeadline:
+		if !ok {
+			t.Fatal("shutdown flush ctx should carry a deadline when flushTimeout > 0")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a shutdown flush push")
+	}
+}

--- a/cmd/agentsview/pg_watch_test.go
+++ b/cmd/agentsview/pg_watch_test.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/postgres"
+)
+
+func pgConfigForTest(projects, exclude []string) config.PGConfig {
+	return config.PGConfig{Projects: projects, ExcludeProjects: exclude}
+}
+
+func TestResolvePushProjects(t *testing.T) {
+	tests := []struct {
+		name        string
+		pgProjects  []string
+		pgExclude   []string
+		cfg         PGPushConfig
+		wantInclude []string
+		wantExclude []string
+		wantErr     bool
+	}{
+		{
+			name:        "config include used when no flags",
+			pgProjects:  []string{"a", "b"},
+			wantInclude: []string{"a", "b"},
+		},
+		{
+			name:        "flag include overrides config exclude",
+			pgExclude:   []string{"x"},
+			cfg:         PGPushConfig{ProjectsFlag: "a,b"},
+			wantInclude: []string{"a", "b"},
+		},
+		{
+			name:       "all-projects clears both",
+			pgProjects: []string{"a"},
+			cfg:        PGPushConfig{AllProjects: true},
+		},
+		{
+			name:    "both flags is an error",
+			cfg:     PGPushConfig{ProjectsFlag: "a", ExcludeProjects: "b"},
+			wantErr: true,
+		},
+		{
+			name:    "all-projects with include is an error",
+			cfg:     PGPushConfig{AllProjects: true, ProjectsFlag: "a"},
+			wantErr: true,
+		},
+		{
+			name:       "config has both projects and exclude is an error",
+			pgProjects: []string{"a"},
+			pgExclude:  []string{"x"},
+			wantErr:    true,
+		},
+		{
+			name:    "all-projects with exclude is an error",
+			cfg:     PGPushConfig{AllProjects: true, ExcludeProjects: "x"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pg := pgConfigForTest(tt.pgProjects, tt.pgExclude)
+			inc, exc, err := resolvePushProjects(pg, tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalStrings(inc, tt.wantInclude) {
+				t.Errorf("include = %v, want %v", inc, tt.wantInclude)
+			}
+			if !equalStrings(exc, tt.wantExclude) {
+				t.Errorf("exclude = %v, want %v", exc, tt.wantExclude)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// fakeTarget is a test double for pgTarget.
+type fakeTarget struct {
+	ensureErr  error
+	pushErr    error
+	pushResult postgres.PushResult
+	pushes     int
+	closed     int
+}
+
+func (f *fakeTarget) EnsureSchema(context.Context) error { return f.ensureErr }
+func (f *fakeTarget) Push(
+	context.Context, bool, func(postgres.PushProgress),
+) (postgres.PushResult, error) {
+	f.pushes++
+	return f.pushResult, f.pushErr
+}
+func (f *fakeTarget) Close() error { f.closed++; return nil }
+
+func TestPgPusher_ConnectsOnceAndReuses(t *testing.T) {
+	target := &fakeTarget{}
+	connects := 0
+	p := &pgPusher{
+		localSync: func(context.Context) error { return nil },
+		connect: func() (pgTarget, error) {
+			connects++
+			return target, nil
+		},
+	}
+	if err := p.push(context.Background(), reasonChange, false); err != nil {
+		t.Fatalf("push 1: %v", err)
+	}
+	if err := p.push(context.Background(), reasonChange, false); err != nil {
+		t.Fatalf("push 2: %v", err)
+	}
+	if connects != 1 {
+		t.Fatalf("connects = %d, want 1 (connection reused)", connects)
+	}
+	if target.pushes != 2 {
+		t.Fatalf("pushes = %d, want 2", target.pushes)
+	}
+}
+
+func TestPgPusher_ReconnectsAfterPushError(t *testing.T) {
+	connects := 0
+	targets := []*fakeTarget{{pushErr: errors.New("conn reset")}, {}}
+	p := &pgPusher{
+		localSync: func(context.Context) error { return nil },
+		connect: func() (pgTarget, error) {
+			t := targets[connects]
+			connects++
+			return t, nil
+		},
+	}
+	if err := p.push(context.Background(), reasonChange, false); err == nil {
+		t.Fatal("expected first push to error")
+	}
+	if targets[0].closed != 1 {
+		t.Fatal("errored target should have been closed")
+	}
+	if err := p.push(context.Background(), reasonChange, false); err != nil {
+		t.Fatalf("second push should reconnect and succeed: %v", err)
+	}
+	if connects != 2 {
+		t.Fatalf("connects = %d, want 2 (reconnect after error)", connects)
+	}
+}
+
+func TestPgPusher_ConnectErrorSurfaced(t *testing.T) {
+	p := &pgPusher{
+		localSync: func(context.Context) error { return nil },
+		connect: func() (pgTarget, error) {
+			return nil, errors.New("dial timeout")
+		},
+	}
+	if err := p.push(context.Background(), reasonChange, false); err == nil {
+		t.Fatal("expected connect error to surface")
+	}
+}
+
+func TestPgPusher_LocalSyncErrorSkipsConnect(t *testing.T) {
+	connects := 0
+	p := &pgPusher{
+		localSync: func(context.Context) error { return errors.New("disk") },
+		connect: func() (pgTarget, error) {
+			connects++
+			return &fakeTarget{}, nil
+		},
+	}
+	if err := p.push(context.Background(), reasonChange, false); err == nil {
+		t.Fatal("expected local sync error")
+	}
+	if connects != 0 {
+		t.Fatal("connect should not run when local sync fails")
+	}
+}
+
+func TestPgPusher_ReconnectsAfterEnsureSchemaError(t *testing.T) {
+	connects := 0
+	targets := []*fakeTarget{{ensureErr: errors.New("schema down")}, {}}
+	p := &pgPusher{
+		localSync: func(context.Context) error { return nil },
+		connect: func() (pgTarget, error) {
+			tgt := targets[connects]
+			connects++
+			return tgt, nil
+		},
+	}
+	if err := p.push(context.Background(), reasonChange, false); err == nil {
+		t.Fatal("expected first push to error on ensure schema")
+	}
+	if targets[0].closed != 1 {
+		t.Fatal("errored target should have been closed")
+	}
+	if err := p.push(context.Background(), reasonChange, false); err != nil {
+		t.Fatalf("second push should reconnect and succeed: %v", err)
+	}
+	if connects != 2 {
+		t.Fatalf("connects = %d, want 2 (reconnect after ensure schema error)", connects)
+	}
+}
+
+func TestPgPusher_LogsPartialPushErrors(t *testing.T) {
+	target := &fakeTarget{
+		pushResult: postgres.PushResult{
+			SessionsPushed: 3,
+			MessagesPushed: 9,
+			Errors:         2,
+		},
+	}
+	var logs bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	p := &pgPusher{
+		localSync: func(context.Context) error { return nil },
+		connect: func() (pgTarget, error) {
+			return target, nil
+		},
+	}
+	require.NoError(t, p.push(context.Background(), reasonChange, false))
+
+	got := logs.String()
+	assert.Contains(t, got, "pushed 3 sessions, 9 messages, 2 errors")
+	assert.Contains(t, got, "2 session(s) failed to push; will retry")
+	assert.Contains(t, got, "change")
+}
+
+func TestResolveWatchTargets_ErrorsOnEmptyURL(t *testing.T) {
+	appCfg := config.Config{} // no PG URL
+	_, _, _, err := resolveWatchTargets(appCfg, PGPushConfig{})
+	if err == nil {
+		t.Fatal("expected error when url not configured")
+	}
+}
+
+func TestResolveWatchTargets_ResolvesProjects(t *testing.T) {
+	appCfg := config.Config{
+		PG: config.PGConfig{
+			URL:         "postgres://u:p@localhost:5432/db?sslmode=disable",
+			MachineName: "box1",
+		},
+	}
+	pg, inc, _, err := resolveWatchTargets(
+		appCfg, PGPushConfig{ProjectsFlag: "a,b"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pg.URL == "" {
+		t.Fatal("expected resolved URL")
+	}
+	if !equalStrings(inc, []string{"a", "b"}) {
+		t.Fatalf("include = %v, want [a b]", inc)
+	}
+}

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -107,8 +107,9 @@ func runLocalSync(
 	cleanResyncTemp(appCfg.DBPath)
 
 	engine := sync.NewEngine(database, sync.EngineConfig{
-		AgentDirs: appCfg.AgentDirs,
-		Machine:   "local",
+		AgentDirs:               appCfg.AgentDirs,
+		Machine:                 "local",
+		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
 	})
 
 	didResync := full || database.NeedsResync()

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/tidwall/gjson v1.19.0
 	golang.org/x/mod v0.36.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.44.0
 	golang.org/x/term v0.43.0
 )
 
@@ -29,7 +30,6 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1119,6 +1119,20 @@ var (
 	partialBareEnvPattern = regexp.MustCompile(`\$([A-Za-z_][A-Za-z0-9_]*)`)
 )
 
+// IsEnvDependentURL reports whether s would have environment variables
+// expanded by expandBracedEnv: it contains any ${VAR} reference, or the
+// whole string is a single bare $VAR shortcut. Embedded bare $VAR
+// references (e.g. "postgres://$USER@host") are deliberately NOT expanded
+// and so do not count. Callers that must persist a literal URL into a
+// context without the shell environment (e.g. a background service) use
+// this to reject env-dependent values. It shares the exact patterns
+// expandBracedEnv uses so the rejection check cannot drift from the
+// expansion semantics.
+func IsEnvDependentURL(s string) bool {
+	return bracedEnvPattern.MatchString(s) ||
+		bareEnvPattern.MatchString(strings.TrimSpace(s))
+}
+
 // bareEnvWarned tracks which bare $VAR names have already been warned
 // about, so each distinct variable triggers a warning at most once.
 var bareEnvWarned sync.Map

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -809,6 +809,31 @@ func TestResolvePG_ErrorsOnMissingBareEnvVar(t *testing.T) {
 	assert.Contains(t, err.Error(), "NONEXISTENT_PG_BARE_VAR")
 }
 
+// TestIsEnvDependentURL locks the helper to the same expansion semantics
+// as expandBracedEnv: any ${VAR}, or a whole-string bare $VAR, is
+// env-dependent; an embedded bare $VAR or literal dollar sequence is not.
+func TestIsEnvDependentURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"braced var", "${PGURL}", true},
+		{"braced var embedded", "postgres://h/db?password=${PGPASS}", true},
+		{"whole-string bare var", "$PGURL", true},
+		{"whole-string bare var with surrounding space", "  $PGURL  ", true},
+		{"embedded bare var not expanded", "postgres://$USER@host/db", false},
+		{"literal dollar sequence", "postgres://user:pa$word@host/db", false},
+		{"plain literal", "postgres://user:pass@localhost/db?sslmode=disable", false},
+		{"empty", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, IsEnvDependentURL(c.in))
+		})
+	}
+}
+
 // ResolvePG must not reject configs with both filter lists —
 // that's a push-specific concern validated in runPGPush after
 // CLI flags are merged. status and serve use ResolvePG too and

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,11 +28,18 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 29: secret findings now record tool_result_event
+// Bumped to 30: Hermes parser no longer treats cost_status
+// "included" as a confident $0 when cost_source is "none"/empty (its
+// default for models it does not price, e.g. gpt-5.5). Such rows now
+// leave cost_usd nil so they are catalog-priced. Existing Hermes rows
+// need re-parsing so their usage cost reflects the catalog instead of a
+// baked-in $0.
+//
+// (29: secret findings now record tool_result_event
 // coordinates by the persisted slice position (matching
 // tool_result_events.event_index) instead of the parser's raw event
 // index. Existing rows need re-scanning so stored findings normalize
-// and `secrets list --reveal` can re-read the source.
+// and `secrets list --reveal` can re-read the source.)
 //
 // (28: Gemini parser now persists normalized
 // (Anthropic-style) per-message token_usage JSON instead of the raw
@@ -95,7 +102,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 29
+const dataVersion = 30
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -759,6 +759,27 @@ func applyHermesStateMetadata(
 	sess.SourceSessionID = ss.id
 	sess.SourceVersion = "hermes-state-db"
 	sess.DisplayName = ss.title
+
+	// Populate the session-aggregate token columns from Hermes's own
+	// authoritative state.db accounting. These feed the session list,
+	// session detail, and stats portfolio, which read the aggregate
+	// fields directly and do not fall back to usage_events. The
+	// transcript paths yield 0 here (per-message token_count is 0 in
+	// state.db), so these values are strictly better; set them
+	// unconditionally when present. PeakContextTokens uses the
+	// cumulative input + cache_read approximation (matching forge's
+	// convention); a truer last-prompt peak lives only in sessions.json.
+	if ss.outputTokens > 0 {
+		sess.TotalOutputTokens = ss.outputTokens
+		sess.HasTotalOutputTokens = true
+	}
+	if ctx := ss.inputTokens + ss.cacheReadTokens; ctx > 0 {
+		sess.PeakContextTokens = ctx
+		sess.HasPeakContextTokens = true
+	}
+	sess.aggregateTokenPresenceKnown =
+		sess.HasTotalOutputTokens || sess.HasPeakContextTokens
+
 	if selectedPath != "" {
 		if info, err := os.Stat(selectedPath); err == nil {
 			sess.File = FileInfo{
@@ -768,6 +789,14 @@ func applyHermesStateMetadata(
 			}
 		}
 	}
+}
+
+// hermesHasCostSource reports whether a Hermes cost_source represents a
+// real cost determination. "none" (and empty) mean Hermes had no basis
+// for the figure, so a $0 it pairs with cost_status "included" is a
+// default placeholder rather than a confident free-usage signal.
+func hermesHasCostSource(costSource string) bool {
+	return costSource != "" && costSource != "none"
 }
 
 func hermesUsageEvents(
@@ -782,11 +811,23 @@ func hermesUsageEvents(
 		!ss.actualCost.Valid {
 		return nil
 	}
+	// Only emit a cost_usd when Hermes actually knows it. Otherwise
+	// leave it nil so agentsview prices the row from its own model
+	// catalog. A "included" cost_status is a genuine known $0 only when
+	// a real cost_source backs it; Hermes also emits "included" with
+	// cost_source "none" (or empty) as a default for models it does not
+	// price (e.g. gpt-5.5), which is NOT a confident $0 and must fall
+	// through to catalog pricing. Likewise "unknown"/empty with a 0
+	// estimate is not a real figure and must not masquerade as $0.
 	var cost *float64
-	if ss.actualCost.Valid {
+	switch {
+	case ss.actualCost.Valid:
 		v := ss.actualCost.Float64
 		cost = &v
-	} else if ss.estimatedCost.Valid {
+	case ss.costStatus == "included" && hermesHasCostSource(ss.costSource):
+		zero := 0.0
+		cost = &zero
+	case ss.estimatedCost.Valid && ss.estimatedCost.Float64 > 0:
 		v := ss.estimatedCost.Float64
 		cost = &v
 	}

--- a/internal/parser/hermes_test.go
+++ b/internal/parser/hermes_test.go
@@ -267,6 +267,129 @@ func TestBuildHermesStateResultKeepsUsageOnlySessions(t *testing.T) {
 	assert.Equal(t, 10, res.UsageEvents[0].InputTokens)
 }
 
+func TestBuildHermesStateResultPopulatesSessionAggregateTokens(t *testing.T) {
+	res, ok := buildHermesStateResult(
+		hermesStateSession{
+			id:              "agg",
+			source:          "cli",
+			model:           "gpt-5.5",
+			startedAt:       time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+			inputTokens:     300,
+			outputTokens:    70,
+			cacheReadTokens: 20,
+		},
+		nil, t.TempDir(), "state.db", "", "local",
+	)
+	require.True(t, ok)
+	// Session-aggregate columns (session list / detail / stats portfolio)
+	// must reflect Hermes's own authoritative accounting, not stay at 0.
+	assert.True(t, res.Session.HasTotalOutputTokens)
+	assert.Equal(t, 70, res.Session.TotalOutputTokens)
+	assert.True(t, res.Session.HasPeakContextTokens)
+	assert.Equal(t, 320, res.Session.PeakContextTokens)
+}
+
+func TestHermesUsageEvents_UnknownCostStatusLeavesCostUnpriced(t *testing.T) {
+	// estimated_cost_usd is a literal 0 with cost_status "unknown":
+	// Hermes does not actually know the cost, so the event must leave
+	// CostUSD nil and let agentsview price it from the catalog rather
+	// than asserting a false known $0.
+	events := hermesUsageEvents(hermesStateSession{
+		model:         "gpt-5.5",
+		inputTokens:   100,
+		outputTokens:  50,
+		estimatedCost: sql.NullFloat64{Float64: 0, Valid: true},
+		costStatus:    "unknown",
+	}, "hermes:unknown-cost")
+	require.Len(t, events, 1)
+	assert.Nil(t, events[0].CostUSD)
+}
+
+func TestHermesUsageEvents_IncludedCostStatusIsKnownZero(t *testing.T) {
+	// cost_status "included" backed by a real cost_source means the
+	// usage is genuinely covered/free, so a known $0 is correct even
+	// when no estimated cost is recorded.
+	events := hermesUsageEvents(hermesStateSession{
+		model:        "openrouter/owl-alpha",
+		inputTokens:  100,
+		outputTokens: 50,
+		costStatus:   "included",
+		costSource:   "provider_models_api",
+	}, "hermes:included-cost")
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].CostUSD)
+	assert.Equal(t, 0.0, *events[0].CostUSD)
+}
+
+func TestHermesUsageEvents_IncludedWithoutCostSourceLeavesCostUnpriced(t *testing.T) {
+	// Hermes marks models it does not price (e.g. gpt-5.5) cost_status
+	// "included" with cost_source "none". That is a default placeholder,
+	// not a confident free-usage signal, so the event must leave CostUSD
+	// nil and let agentsview price it from the catalog instead of
+	// reporting a false $0.
+	for _, src := range []string{"none", ""} {
+		events := hermesUsageEvents(hermesStateSession{
+			model:         "gpt-5.5",
+			inputTokens:   100,
+			outputTokens:  50,
+			estimatedCost: sql.NullFloat64{Float64: 0, Valid: true},
+			costStatus:    "included",
+			costSource:    src,
+		}, "hermes:included-no-source")
+		require.Len(t, events, 1)
+		assert.Nilf(t, events[0].CostUSD,
+			"cost_source %q must not produce a confident $0", src)
+	}
+}
+
+func TestHermesUsageEvents_ActualCostTakesPrecedence(t *testing.T) {
+	events := hermesUsageEvents(hermesStateSession{
+		model:         "gpt-5.5",
+		inputTokens:   100,
+		actualCost:    sql.NullFloat64{Float64: 1.23, Valid: true},
+		estimatedCost: sql.NullFloat64{Float64: 0, Valid: true},
+		costStatus:    "unknown",
+	}, "hermes:actual-cost")
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].CostUSD)
+	assert.Equal(t, 1.23, *events[0].CostUSD)
+}
+
+func TestHermesUsageEvents_PositiveEstimateUsedWhenStatusEmpty(t *testing.T) {
+	events := hermesUsageEvents(hermesStateSession{
+		model:         "gpt-5.5",
+		inputTokens:   100,
+		estimatedCost: sql.NullFloat64{Float64: 0.5, Valid: true},
+		costStatus:    "",
+	}, "hermes:estimate-cost")
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].CostUSD)
+	assert.Equal(t, 0.5, *events[0].CostUSD)
+}
+
+func TestBuildHermesStateResultLeavesAggregatesUnsetWhenNoTokens(t *testing.T) {
+	res, ok := buildHermesStateResult(
+		hermesStateSession{
+			id:        "no-usage",
+			source:    "cli",
+			model:     "gpt-5.5",
+			startedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+			// No token counts: a session with messages but no recorded usage.
+		},
+		[]hermesStateMessage{{
+			role:      "user",
+			content:   "hi",
+			timestamp: time.Date(2026, 5, 14, 12, 0, 1, 0, time.UTC),
+		}},
+		t.TempDir(), "state.db", "", "local",
+	)
+	require.True(t, ok)
+	assert.False(t, res.Session.HasTotalOutputTokens)
+	assert.Zero(t, res.Session.TotalOutputTokens)
+	assert.False(t, res.Session.HasPeakContextTokens)
+	assert.Zero(t, res.Session.PeakContextTokens)
+}
+
 func TestCountHermesUsersSkipsToolResultOnlyMessages(t *testing.T) {
 	got := countHermesUsers([]ParsedMessage{
 		{Role: RoleUser, Content: "real prompt"},

--- a/internal/pidlock/lock_unix.go
+++ b/internal/pidlock/lock_unix.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package pidlock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func openLockedFile(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening lock: %w", err)
+	}
+	if err := syscall.Flock(
+		int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB,
+	); err != nil {
+		_ = file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) ||
+			errors.Is(err, syscall.EAGAIN) {
+			return nil, lockHeldError(path, err)
+		}
+		return nil, fmt.Errorf("locking: %w", err)
+	}
+	return file, nil
+}
+
+func releaseLockedFile(file *os.File) error {
+	unlockErr := syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	closeErr := file.Close()
+	if unlockErr != nil {
+		return fmt.Errorf("unlocking lock: %w", unlockErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing lock: %w", closeErr)
+	}
+	return nil
+}

--- a/internal/pidlock/lock_windows.go
+++ b/internal/pidlock/lock_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package pidlock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func openLockedFile(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening lock: %w", err)
+	}
+	var overlapped windows.Overlapped
+	err = windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+	if err != nil {
+		_ = file.Close()
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			return nil, lockHeldError(path, err)
+		}
+		return nil, fmt.Errorf("locking: %w", err)
+	}
+	return file, nil
+}
+
+func releaseLockedFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	unlockErr := windows.UnlockFileEx(
+		windows.Handle(file.Fd()), 0, 1, 0, &overlapped,
+	)
+	closeErr := file.Close()
+	if unlockErr != nil {
+		return fmt.Errorf("unlocking lock: %w", unlockErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing lock: %w", closeErr)
+	}
+	return nil
+}

--- a/internal/pidlock/pidlock.go
+++ b/internal/pidlock/pidlock.go
@@ -1,0 +1,76 @@
+// Package pidlock provides a single-instance lock backed by an OS file lock
+// plus a PID marker file. The operating system releases the lock when the
+// holder exits, so stale PID marker files are harmless and are overwritten by
+// the next holder.
+package pidlock
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Lock represents an acquired PID lock file.
+type Lock struct {
+	path string
+	file *os.File
+}
+
+// Acquire exclusively locks path and writes the current PID into it.
+// It fails if another process currently holds the lock.
+func Acquire(path string) (*Lock, error) {
+	file, err := openLockedFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := writePID(file); err != nil {
+		_ = releaseLockedFile(file)
+		return nil, fmt.Errorf("writing lock: %w", err)
+	}
+	return &Lock{path: path, file: file}, nil
+}
+
+func writePID(file *os.File) error {
+	if err := file.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		return err
+	}
+	_, err := file.WriteString(strconv.Itoa(os.Getpid()) + "\n")
+	return err
+}
+
+func lockHeldError(path string, cause error) error {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if pid, ok := parsePID(data); ok {
+			return fmt.Errorf("already locked by process %d (%s)", pid, path)
+		}
+	}
+	return fmt.Errorf("already locked (%s): %w", path, cause)
+}
+
+func parsePID(data []byte) (int, bool) {
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(fields[0])
+	return pid, err == nil && pid > 0
+}
+
+// Release unlocks and closes the lock file. It is safe to call more than once
+// and on a nil Lock. The PID marker file is left in place so Release never
+// deletes a path that may have been replaced by another process.
+func (l *Lock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	err := releaseLockedFile(l.file)
+	l.file = nil
+	l.path = ""
+	return err
+}

--- a/internal/pidlock/pidlock_test.go
+++ b/internal/pidlock/pidlock_test.go
@@ -1,0 +1,67 @@
+package pidlock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcquire_FreshSucceeds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pg-watch.lock")
+	lock, err := Acquire(path)
+	require.NoError(t, err, "Acquire")
+	defer func() { require.NoError(t, lock.Release(), "Release") }()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("lock file not created: %v", err)
+	}
+}
+
+func TestAcquire_LiveHolderFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pg-watch.lock")
+	lock, err := Acquire(path)
+	require.NoError(t, err, "Acquire")
+	defer func() { require.NoError(t, lock.Release(), "Release") }()
+
+	_, err = Acquire(path)
+	require.Error(t, err, "expected Acquire to fail when a live holder exists")
+	assert.Contains(t, err.Error(), "already locked")
+}
+
+func TestAcquire_StalePIDReclaimed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pg-watch.lock")
+	// PID 2147483647 is not a running process.
+	require.NoError(t, os.WriteFile(path, []byte("2147483647"), 0o644))
+	lock, err := Acquire(path)
+	require.NoError(t, err, "Acquire should reclaim a stale lock")
+	defer func() { require.NoError(t, lock.Release(), "Release") }()
+}
+
+func TestRelease_UnlocksAndKeepsMarkerFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pg-watch.lock")
+	lock, err := Acquire(path)
+	require.NoError(t, err, "Acquire")
+	require.NoError(t, lock.Release(), "Release")
+
+	_, err = os.Stat(path)
+	require.NoError(t, err, "PID marker file should remain")
+
+	lock, err = Acquire(path)
+	require.NoError(t, err, "Acquire after Release")
+	defer func() { require.NoError(t, lock.Release(), "Release") }()
+}
+
+func TestAcquire_UnparseableLockReclaimed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pg-watch.lock")
+	require.NoError(t, os.WriteFile(path, []byte("not-a-pid\n"), 0o644))
+	lock, err := Acquire(path)
+	require.NoError(t, err, "Acquire should reclaim an unparseable lock")
+	defer func() { require.NoError(t, lock.Release(), "Release") }()
+}
+
+func TestRelease_NilReceiverNoError(t *testing.T) {
+	var l *Lock
+	require.NoError(t, l.Release())
+}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -965,6 +965,14 @@ func (s *Sync) pushMessages(
 				"deleting stale pg messages: %w", err,
 			)
 		}
+		// Usage events are independent of transcript messages: a
+		// session can carry token/cost accounting (e.g. a hermes
+		// state.db-only session) with zero messages. Sync them here
+		// too so their cost reaches PG instead of being dropped with
+		// the rest of the message-replace path below.
+		if err := s.replaceUsageEvents(ctx, tx, sessionID); err != nil {
+			return 0, err
+		}
 		if err := reconcilePinnedMessages(
 			ctx, tx, sessionID,
 		); err != nil {
@@ -1099,20 +1107,7 @@ func (s *Sync) pushMessages(
 			"deleting pg messages: %w", err,
 		)
 	}
-	if _, err := tx.ExecContext(ctx, `
-		DELETE FROM usage_events
-		WHERE session_id = $1
-	`, sessionID); err != nil {
-		return 0, fmt.Errorf(
-			"deleting pg usage_events: %w", err,
-		)
-	}
-
-	usageEvents, err := s.local.GetUsageEvents(ctx, sessionID)
-	if err != nil {
-		return 0, fmt.Errorf("reading local usage events: %w", err)
-	}
-	if err := bulkInsertUsageEvents(ctx, tx, usageEvents); err != nil {
+	if err := s.replaceUsageEvents(ctx, tx, sessionID); err != nil {
 		return 0, err
 	}
 
@@ -1166,6 +1161,31 @@ func (s *Sync) pushMessages(
 	}
 
 	return count, nil
+}
+
+// replaceUsageEvents replaces a session's usage_events in PG with the
+// current local set. Usage events are synced independently of transcript
+// messages because a session can have token/cost accounting with no
+// messages at all (e.g. a hermes state.db-only session). Both the
+// zero-message and the normal message-replace paths in pushMessages call
+// this so a session's cost always reaches PG.
+func (s *Sync) replaceUsageEvents(
+	ctx context.Context, tx *sql.Tx, sessionID string,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM usage_events
+		WHERE session_id = $1
+	`, sessionID); err != nil {
+		return fmt.Errorf("deleting pg usage_events: %w", err)
+	}
+	usageEvents, err := s.local.GetUsageEvents(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("reading local usage events: %w", err)
+	}
+	if err := bulkInsertUsageEvents(ctx, tx, usageEvents); err != nil {
+		return err
+	}
+	return nil
 }
 
 func reconcilePinnedMessages(

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -190,6 +190,94 @@ func TestPushSessionTerminationStatus(t *testing.T) {
 	assert.Nil(t, got)
 }
 
+// TestPushSyncsUsageEventsForZeroMessageSession verifies that a session
+// carrying token/cost accounting as a usage_event but no transcript
+// messages still has its usage_event pushed to PG. This is the shape of a
+// hermes state.db-only session: parseHermesStateSession emits a single
+// usage_event (model + tokens) with MessageCount 0. The session row (and
+// its aggregate token columns) pushes via pushSession, but pushMessages
+// must not skip usage_event syncing just because the message count is 0 --
+// otherwise the dashboard shows tokens with a $0 cost.
+func TestPushSyncsUsageEventsForZeroMessageSession(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_zeromsg_usage_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessID = "hermes:zero-msg-001"
+	started := "2026-05-26T10:00:00Z"
+	sess := db.Session{
+		ID:                   sessID,
+		Project:              "hermes-proj",
+		Machine:              "test-machine",
+		Agent:                "hermes",
+		MessageCount:         0,
+		StartedAt:            &started,
+		CreatedAt:            started,
+		TotalOutputTokens:    500000,
+		HasTotalOutputTokens: true,
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+
+	// gpt-5.5 usage event with NULL cost so it is priced from the catalog.
+	require.NoError(t, localDB.ReplaceSessionUsageEvents(sessID, []db.UsageEvent{{
+		SessionID:    sessID,
+		Source:       "session",
+		Model:        "gpt-5.5",
+		InputTokens:  1000000,
+		OutputTokens: 500000,
+		CostUSD:      nil,
+		OccurredAt:   started,
+		DedupKey:     "session:" + sessID,
+	}}), "ReplaceSessionUsageEvents")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push")
+
+	// The usage_event must reach PG even though the session has no messages.
+	var pgUsageCount int
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM usage_events WHERE session_id = $1`,
+		sessID,
+	).Scan(&pgUsageCount), "count pg usage_events")
+	assert.Equal(t, 1, pgUsageCount,
+		"usage_event for a zero-message session was not pushed")
+
+	// And the read side prices it from the gpt-5.5 catalog rate:
+	// input 5/Mtok, output 30/Mtok -> 1.0*5 + 0.5*30 = 20.
+	store, err := NewStore(pgURL, schema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	result, err := store.GetDailyUsage(ctx, db.UsageFilter{
+		From:     "2026-05-26",
+		To:       "2026-05-26",
+		Timezone: "UTC",
+	})
+	require.NoError(t, err, "GetDailyUsage")
+	assert.InDelta(t, 20.0, result.Totals.TotalCost, 1e-9,
+		"gpt-5.5 usage should be priced from the catalog")
+}
+
 // checkIsSystem asserts that PG contains exactly wantTotal rows for the
 // session with ordinals 0..wantTotal-1, and that each row's is_system
 // matches wantSystem. Tracking the exact ordinal set prevents false

--- a/internal/pricing/fallback.go
+++ b/internal/pricing/fallback.go
@@ -2,7 +2,7 @@ package pricing
 
 // FallbackVersion must be bumped whenever FallbackPricing
 // rates change so the startup seeder knows to re-upsert.
-const FallbackVersion = "2026-05-28"
+const FallbackVersion = "2026-05-29"
 
 // FallbackPricing returns hardcoded pricing for key Claude
 // models. Used when the LiteLLM fetch fails.
@@ -42,6 +42,12 @@ func FallbackPricing() []ModelPricing {
 			CacheReadPerMTok:     0.10,
 		},
 		// Codex / OpenAI models
+		{
+			ModelPattern:     "gpt-5.5",
+			InputPerMTok:     5.0,
+			OutputPerMTok:    30.0,
+			CacheReadPerMTok: 0.50,
+		},
 		{
 			ModelPattern:  "gpt-5.4",
 			InputPerMTok:  2.50,
@@ -100,6 +106,12 @@ func FallbackPricing() []ModelPricing {
 			OutputPerMTok:        4.0,
 			CacheCreationPerMTok: 1.0,
 			CacheReadPerMTok:     0.08,
+		},
+		// Free OpenRouter model
+		{
+			ModelPattern:  "openrouter/owl-alpha",
+			InputPerMTok:  0,
+			OutputPerMTok: 0,
 		},
 	}
 }

--- a/internal/pricing/fallback_test.go
+++ b/internal/pricing/fallback_test.go
@@ -52,3 +52,25 @@ func TestFallbackPricing_Opus48Rates(t *testing.T) {
 	}
 	assert.Equal(t, want, *got)
 }
+
+func TestFallbackPricing_HermesModels(t *testing.T) {
+	byPattern := make(map[string]ModelPricing)
+	for _, p := range FallbackPricing() {
+		byPattern[p.ModelPattern] = p
+	}
+
+	// gpt-5.5 (Hermes). Source: https://developers.openai.com/api/docs/pricing
+	// standard tier — input $5.00, cached input $0.50, output $30.00 per MTok.
+	gpt, ok := byPattern["gpt-5.5"]
+	require.True(t, ok, "gpt-5.5 entry missing from FallbackPricing")
+	assert.Equal(t, 5.0, gpt.InputPerMTok)
+	assert.Equal(t, 30.0, gpt.OutputPerMTok)
+	assert.Equal(t, 0.50, gpt.CacheReadPerMTok)
+
+	// openrouter/owl-alpha is a free model: a known $0 (present with
+	// zero rates) rather than an unpriced/unknown model.
+	owl, ok := byPattern["openrouter/owl-alpha"]
+	require.True(t, ok, "openrouter/owl-alpha entry missing from FallbackPricing")
+	assert.Zero(t, owl.InputPerMTok)
+	assert.Zero(t, owl.OutputPerMTok)
+}


### PR DESCRIPTION
## Problem

  I track token usage across AI tools with agentsview, and lately I've been
  running more remote agent tools on machines other than my primary dev box.
  Each of those machines records its own sessions locally. The Postgres support
  (`pg push` / `pg serve`) already lets me review everything together, but
  keeping the shared database current meant either remembering to run `pg push`
  by hand on each machine or wiring up a bespoke cron job per host. I wanted a
  touchless way to sync data from multiple machines into one place so remote
  agent token usage shows up in my primary dashboard automatically, without
  maintaining custom cron entries everywhere.

  I also made some updates to hermes specific code because although tokens 
  were being passed through, the associated costs were not being aggregated
  properly.

  ## pg push service 

  A long-running auto-push daemon and a first-class way to install it as an OS
  service, so a recorder machine keeps the shared Postgres current on its own.

  **`agentsview pg push --watch`** start a foreground daemon that pushes to Postgres
  shortly after sessions change, with a periodic floor as a safety net:

  - A file watcher (reusing the same machinery as `serve`) coalesces change
    events over a debounce window (`--debounce`, default 30s) and triggers a
    local sync + incremental push.
  - A periodic floor (`--interval`, default 15m) pushes regardless of file
    events and covers any directories the watch budget couldn't cover.
  - Pushes are serialized by a single goroutine and connect to Postgres lazily,
    reconnecting on error. A transiently unreachable database is logged and
    retried on the next trigger rather than crashing the daemon.
  - A single-instance lock prevents two watchers from racing on the push
    watermarks. On shutdown (SIGINT/SIGTERM) it performs one bounded final flush.
  - It reads the same `[pg]` config and project filters as `pg push`, and
    honors `result_content_blocked_categories` so the push path no longer
    diverges from `serve`.
  
  **`agentsview pg service install|uninstall|status|start|stop|logs`**
  installs and manages the daemon as a per-user OS service:

  - launchd LaunchAgent on macOS, `systemd --user` unit on Linux, behind a small
    platform abstraction with pure (golden-tested) unit-file rendering.
  - `install` validates that the Postgres DSN is resolvable before creating the
    service, and surfaces the systemd linger requirement so the service keeps
    running on headless boxes after logout.
  - `status` reports the manager state plus the last successful push time;
    `logs -f` tails the daemon log and survives log rotation.

  The daemon reads the DSN from the existing config file (no credentials are
  copied into unit files), so protecting `config.toml` is sufficient.

  ## Notes

  - Platform support targets macOS (launchd) and Linux (`systemd --user`); the
    daemon command itself is cross-platform Go.
  - The generated unit always pins `AGENTSVIEW_DATA_DIR` to the install-time data
    dir, so the service resolves the same config regardless of the environment it
    starts in.
  - The watch daemon's initial resync is push-oriented and skips the serve-side
    `Vacuum`/`BackfillSignals` steps, since signal recomputation happens on the
    serve side.
  - A windows service was not added because I don't currently have access to a 
     windows machine that I could use for testing.