### PR TITLE
docs: fix agy-reader install command path

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ agentsview's file watcher detects the sidecar automatically and parses it in
 place of summary mode -- no agentsview restart needed.
 
 ```bash
-go install github.com/mjacobs/agy-reader@latest
+go install github.com/mjacobs/agy-reader/cmd/agy-reader@latest
 
 # Generate sidecars for existing sessions...
 agy-reader --sync


### PR DESCRIPTION
Fix the `go install` command for [agy-reader](https://github.com/mjacobs/agy-reader) shown in the README.

The main package for the CLI binary is located under `cmd/agy-reader`, so the install path must include that segment.

**Before:**
```bash
go install github.com/mjacobs/agy-reader@latest
```

**After:**
```bash
go install github.com/mjacobs/agy-reader/cmd/agy-reader@latest
```

This is a documentation-only change; no code or tests affected.