### PR TITLE
docs: simplify agy-reader install to module-root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ agentsview's file watcher detects the sidecar automatically and parses it in
 place of summary mode -- no agentsview restart needed.
 
 ```bash
-go install github.com/mjacobs/agy-reader/cmd/agy-reader@latest
+go install github.com/mjacobs/agy-reader@latest
 
 # Generate sidecars for existing sessions...
 agy-reader --sync


### PR DESCRIPTION
Reverts the install-path fix from #566. Thanks to @akunzai for catching that the documented command didn't build -- the report was correct at the time.

agy-reader's `main` package now lives at the module root, so `go install github.com/mjacobs/agy-reader@latest` works directly. This drops the longer `cmd/agy-reader` path from the README.