### PR TITLE
Support Antigravity CLI SQLite sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,12 +255,14 @@ Each directory can be overridden with an environment variable. See the
 
 ### Antigravity CLI: high-resolution transcripts
 
-By default, agentsview indexes Antigravity CLI sessions in **summary mode**:
-your prompts from `history.jsonl` plus any plain-text artifacts under `brain/`
-(plans, walkthroughs, checkpoints). Assistant turns and tool calls live in
-AES-GCM-encrypted `.pb` files and are not visible in this mode.
+Antigravity CLI sessions now appear in two on-disk formats. Newer releases
+store conversation trajectories as SQLite `.db` files, which agentsview indexes
+directly. Older releases stored assistant turns and tool calls in
+AES-GCM-encrypted `.pb` files; for those sessions, agentsview falls back to
+**summary mode** using your prompts from `history.jsonl` plus any plain-text
+artifacts under `brain/` (plans, walkthroughs, checkpoints).
 
-To unlock full transcripts, run
+To unlock full transcripts for older `.pb` sessions, run
 [agy-reader](https://github.com/mjacobs/agy-reader) alongside agentsview.
 agy-reader talks to the local Antigravity daemon, decrypts each conversation,
 and writes a `<uuid>.trajectory.json` sidecar next to the encrypted `.pb` file.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,12 +28,22 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 30: Hermes parser no longer treats cost_status
+// Bumped to 32: Antigravity DB parsers now filter internal
+// protocol strings from visible message content, remove raw step
+// headers, prefer prompt-like user text, and merge matching
+// Antigravity CLI history prompts when DB decoding drops short user
+// turns. Existing Antigravity DB rows need re-parsing so previously
+// indexed noisy or assistant-only transcripts are rewritten.
+//
+// (31: Copilot shutdown usage events use positional DedupKey to
+// handle multi-segment sessions correctly.)
+//
+// (30: Hermes parser no longer treats cost_status
 // "included" as a confident $0 when cost_source is "none"/empty (its
 // default for models it does not price, e.g. gpt-5.5). Such rows now
 // leave cost_usd nil so they are catalog-priced. Existing Hermes rows
 // need re-parsing so their usage cost reflects the catalog instead of a
-// baked-in $0.
+// baked-in $0.)
 //
 // (29: secret findings now record tool_result_event
 // coordinates by the persisted slice position (matching
@@ -102,9 +112,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-// (31: Copilot shutdown usage events use positional DedupKey to
-// handle multi-segment sessions correctly.)
-const dataVersion = 31
+const dataVersion = 32
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -177,15 +177,30 @@ func ParseAntigravitySession(
 }
 
 func loadAntigravitySteps(db *sql.DB) ([]ParsedMessage, error) {
+	result, err := loadAntigravityStepsWithRawCount(db)
+	if err != nil {
+		return nil, err
+	}
+	return result.messages, nil
+}
+
+type antigravityStepLoadResult struct {
+	messages     []ParsedMessage
+	rawStepCount int
+}
+
+func loadAntigravityStepsWithRawCount(
+	db *sql.DB,
+) (antigravityStepLoadResult, error) {
 	rows, err := db.Query(
 		`SELECT idx, step_type, step_payload FROM steps ` +
 			`ORDER BY idx`,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("query steps: %w", err)
+		return antigravityStepLoadResult{}, fmt.Errorf("query steps: %w", err)
 	}
 	defer rows.Close()
-	var out []ParsedMessage
+	var result antigravityStepLoadResult
 	for rows.Next() {
 		var (
 			idx      int
@@ -193,18 +208,19 @@ func loadAntigravitySteps(db *sql.DB) ([]ParsedMessage, error) {
 			payload  []byte
 		)
 		if err := rows.Scan(&idx, &stepType, &payload); err != nil {
-			return nil, fmt.Errorf("scan step: %w", err)
+			return antigravityStepLoadResult{}, fmt.Errorf("scan step: %w", err)
 		}
+		result.rawStepCount++
 		msg, ok := decodeAntigravityStep(idx, stepType, payload)
 		if !ok {
 			continue
 		}
-		out = append(out, msg)
+		result.messages = append(result.messages, msg)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate steps: %w", err)
+		return antigravityStepLoadResult{}, fmt.Errorf("iterate steps: %w", err)
 	}
-	return out, nil
+	return result, nil
 }
 
 // decodeAntigravityStep extracts a ParsedMessage from one step's

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -23,6 +24,10 @@ import (
 // per-session JSON). Each row of `steps` becomes one ParsedMessage.
 
 const antigravityIDPrefix = "antigravity:"
+
+var antigravityUUIDLikeRE = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
+)
 
 // DiscoverAntigravitySessions returns one DiscoveredFile per
 // conversations/<uuid>.db under the IDE root.
@@ -207,8 +212,10 @@ func loadAntigravitySteps(db *sql.DB) ([]ParsedMessage, error) {
 //   - role: step_type 14 has been observed to carry user prompts.
 //     Every other type is rendered as assistant. (TODO: refine
 //     when more sample data is available.)
-//   - content: concatenation of every UTF-8 string >= 20 chars
-//     found anywhere in the payload tree, deduped.
+//   - content: best-effort human-facing strings found in the
+//     payload tree. Internal ids, local Antigravity config paths,
+//     model placeholders, and duplicate payload echoes are filtered
+//     out. User-input steps prefer a single prompt-like string.
 //   - timestamp: earliest google.protobuf.Timestamp-shaped field.
 func decodeAntigravityStep(
 	idx, stepType int, payload []byte,
@@ -220,7 +227,9 @@ func decodeAntigravityStep(
 	if err != nil || len(fields) == 0 {
 		return ParsedMessage{}, false
 	}
-	strs := dedupeStrings(agProtoCollectStrings(fields, 20))
+	strs := cleanAntigravityStepStrings(
+		dedupeStrings(agProtoCollectStrings(fields, 20)), stepType,
+	)
 	ts := earliestAntigravityTimestamp(fields)
 	if len(strs) == 0 {
 		return ParsedMessage{}, false
@@ -229,10 +238,7 @@ func decodeAntigravityStep(
 	if stepType == 14 {
 		role = RoleUser
 	}
-	header := fmt.Sprintf(
-		"[step %d · type %d]", idx, stepType,
-	)
-	content := header + "\n" + strings.Join(strs, "\n\n")
+	content := strings.Join(strs, "\n\n")
 	return ParsedMessage{
 		Role:          role,
 		Content:       content,
@@ -252,6 +258,135 @@ func dedupeStrings(in []string) []string {
 		out = append(out, s)
 	}
 	return out
+}
+
+func cleanAntigravityStepStrings(
+	strs []string, stepType int,
+) []string {
+	var cleaned []string
+	for _, s := range strs {
+		s = strings.TrimSpace(s)
+		if isNoisyAntigravityStepString(s) {
+			continue
+		}
+		cleaned = append(cleaned, s)
+	}
+	cleaned = dedupeStrings(cleaned)
+	if stepType == 14 {
+		if prompt := bestAntigravityUserPrompt(cleaned); prompt != "" {
+			return []string{prompt}
+		}
+	}
+	return cleaned
+}
+
+func isNoisyAntigravityStepString(s string) bool {
+	if s == "" {
+		return true
+	}
+	if antigravityUUIDLikeRE.MatchString(s) {
+		return true
+	}
+	if strings.HasPrefix(s, "MODEL_PLACEHOLDER_") {
+		return true
+	}
+	if strings.HasPrefix(s, "{") &&
+		(strings.Contains(s, `"toolAction"`) ||
+			strings.Contains(s, `"toolSummary"`) ||
+			strings.Contains(s, `"DirectoryPath"`)) {
+		return true
+	}
+	if looksLikeAntigravityOpaqueID(s) {
+		return true
+	}
+	if strings.HasPrefix(s, "file:///home/") {
+		return true
+	}
+	if strings.HasPrefix(s, "/home/") &&
+		strings.Contains(s, "/.gemini/") {
+		return true
+	}
+	if strings.HasPrefix(s, "/Users/") &&
+		strings.Contains(s, "/.gemini/") {
+		return true
+	}
+	if strings.HasPrefix(s, `C:\Users\`) &&
+		strings.Contains(s, `\.gemini\`) {
+		return true
+	}
+	if strings.HasPrefix(s, "command(") ||
+		strings.HasPrefix(s, "execute_url(") ||
+		strings.HasPrefix(s, "read_url(") ||
+		strings.HasPrefix(s, "mcp(") {
+		return true
+	}
+	return false
+}
+
+func looksLikeAntigravityOpaqueID(s string) bool {
+	if strings.ContainsAny(s, " \n\t") {
+		return false
+	}
+	if len(s) < 16 || len(s) > 128 {
+		return false
+	}
+	var alpha, digit, symbol int
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+			alpha++
+		case r >= '0' && r <= '9':
+			digit++
+		case r == '_' || r == '-' || r == '.':
+			symbol++
+		default:
+			return false
+		}
+	}
+	if alpha+digit+symbol != len(s) {
+		return false
+	}
+	if digit == len(s) || digit+symbol == len(s) {
+		return true
+	}
+	return alpha > 0 && digit > 0
+}
+
+func bestAntigravityUserPrompt(strs []string) string {
+	var best string
+	bestScore := -1
+	for _, s := range strs {
+		score := antigravityPromptScore(s)
+		if score > bestScore {
+			best = s
+			bestScore = score
+		}
+	}
+	if bestScore <= 0 {
+		return ""
+	}
+	return best
+}
+
+func antigravityPromptScore(s string) int {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" || isNoisyAntigravityStepString(trimmed) {
+		return -1
+	}
+	score := len(trimmed)
+	if strings.ContainsAny(trimmed, " \n\t") {
+		score += 50
+	}
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		score -= 100
+	}
+	if strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "file://") {
+		score -= 100
+	}
+	if !strings.ContainsAny(trimmed, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+		score -= 100
+	}
+	return score
 }
 
 // earliestAntigravityTimestamp walks the field tree and returns

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -191,15 +191,17 @@ func ParseAntigravityCLISessionWithStatus(
 	var messages []ParsedMessage
 	var hasTrajectory bool
 	if ext == ".db" {
-		if tMsgs, err := loadAntigravityCLIDBSteps(path); err == nil {
-			if hasDisplayableAntigravityCLITrajectoryMessage(tMsgs) {
+		if result, err := loadAntigravityCLIDBSteps(path); err == nil {
+			if hasDisplayableAntigravityCLITrajectoryMessage(result.messages) {
 				messages = mergeAntigravityDBHistoryMessages(
-					tMsgs,
+					result.messages,
 					collectAntigravityHistoryMessages(
 						filepath.Join(root, "history.jsonl"), id,
 					),
 				)
 				hasTrajectory = true
+			} else if result.rawStepCount > 0 {
+				status.NeedsRetry = true
 			}
 		} else {
 			status.NeedsRetry = true
@@ -309,14 +311,18 @@ func ParseAntigravityCLISessionWithStatus(
 	return sess, messages, status, nil
 }
 
-func loadAntigravityCLIDBSteps(path string) ([]ParsedMessage, error) {
+func loadAntigravityCLIDBSteps(
+	path string,
+) (antigravityStepLoadResult, error) {
 	dsn := "file:" + path + "?mode=ro&immutable=0"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
-		return nil, fmt.Errorf("open antigravity cli db %s: %w", path, err)
+		return antigravityStepLoadResult{}, fmt.Errorf(
+			"open antigravity cli db %s: %w", path, err,
+		)
 	}
 	defer db.Close()
-	return loadAntigravitySteps(db)
+	return loadAntigravityStepsWithRawCount(db)
 }
 
 func mergeAntigravityDBHistoryMessages(

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bufio"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ const maxTrajectorySidecarBytes = 64 << 20
 
 // Antigravity CLI sessions live under ~/.gemini/antigravity-cli/:
 //
+//   conversations/<uuid>.db      SQLite trajectory DB (newer CLI releases)
 //   conversations/<uuid>.pb      AES-encrypted conversation stream
 //   implicit/<uuid>.pb           AES-encrypted implicit conversation
 //   brain/<uuid>/*.md(+.json)    plaintext task/plan/walkthrough docs
@@ -46,9 +48,9 @@ const (
 	antigravityImplicitTag = "implicit-"
 )
 
-// DiscoverAntigravityCLISessions enumerates conversations/*.pb and
-// implicit/*.pb under the CLI root and tags each with its workspace
-// (resolved via history.jsonl).
+// DiscoverAntigravityCLISessions enumerates conversations/*.db,
+// conversations/*.pb, and implicit/*.pb under the CLI root and tags each with
+// its workspace (resolved via history.jsonl).
 func DiscoverAntigravityCLISessions(root string) []DiscoveredFile {
 	if root == "" {
 		return nil
@@ -63,20 +65,26 @@ func DiscoverAntigravityCLISessions(root string) []DiscoveredFile {
 		if err != nil {
 			continue
 		}
+		byID := make(map[string]string)
 		for _, e := range entries {
 			if e.IsDir() {
 				continue
 			}
 			name := e.Name()
-			if !strings.HasSuffix(name, ".pb") {
+			id, ext, ok := antigravityCLIPathID(name)
+			if !ok || (sub == "implicit" && ext != ".pb") {
 				continue
 			}
-			id := strings.TrimSuffix(name, ".pb")
-			if !IsValidSessionID(id) {
-				continue
+			// Prefer the new SQLite source when both old and new files
+			// exist for a conversation. They share a storage ID.
+			if prev := byID[id]; prev == "" ||
+				(strings.HasSuffix(prev, ".pb") && ext == ".db") {
+				byID[id] = filepath.Join(dir, name)
 			}
+		}
+		for id, path := range byID {
 			files = append(files, DiscoveredFile{
-				Path:    filepath.Join(dir, name),
+				Path:    path,
 				Project: projects[id],
 				Agent:   AgentAntigravityCLI,
 			})
@@ -88,7 +96,7 @@ func DiscoverAntigravityCLISessions(root string) []DiscoveredFile {
 	return files
 }
 
-// FindAntigravityCLISourceFile locates the .pb file for a session
+// FindAntigravityCLISourceFile locates the source file for a session
 // id (without the agent prefix). An "implicit-" prefix routes to
 // the implicit/ subdir; bare ids resolve under conversations/.
 func FindAntigravityCLISourceFile(root, id string) string {
@@ -99,20 +107,37 @@ func FindAntigravityCLISourceFile(root, id string) string {
 		if !IsValidSessionID(uuid) {
 			return ""
 		}
-		p := filepath.Join(root, "implicit", uuid+".pb")
-		if _, err := os.Stat(p); err == nil {
-			return p
+		for _, ext := range []string{".pb"} {
+			p := filepath.Join(root, "implicit", uuid+ext)
+			if _, err := os.Stat(p); err == nil {
+				return p
+			}
 		}
 		return ""
 	}
 	if !IsValidSessionID(id) {
 		return ""
 	}
-	p := filepath.Join(root, "conversations", id+".pb")
-	if _, err := os.Stat(p); err == nil {
-		return p
+	for _, ext := range []string{".db", ".pb"} {
+		p := filepath.Join(root, "conversations", id+ext)
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
 	}
 	return ""
+}
+
+func antigravityCLIPathID(name string) (string, string, bool) {
+	for _, ext := range []string{".db", ".pb"} {
+		if !strings.HasSuffix(name, ext) {
+			continue
+		}
+		id := strings.TrimSuffix(name, ext)
+		if IsValidSessionID(id) {
+			return id, ext, true
+		}
+	}
+	return "", "", false
 }
 
 // ParseAntigravityCLISession parses one CLI session into the
@@ -120,18 +145,41 @@ func FindAntigravityCLISourceFile(root, id string) string {
 func ParseAntigravityCLISession(
 	path, project, machine string,
 ) (*ParsedSession, []ParsedMessage, error) {
+	sess, msgs, _, err := ParseAntigravityCLISessionWithStatus(
+		path, project, machine,
+	)
+	return sess, msgs, err
+}
+
+// AntigravityCLIParseStatus carries sync-relevant parser metadata
+// that is not part of the canonical session/message shape.
+type AntigravityCLIParseStatus struct {
+	// NeedsRetry is true when a high-resolution source failed to
+	// decode and the parser returned lower-resolution fallback
+	// messages instead. Sync can store the fallback while leaving
+	// data_version stale so the next pass retries.
+	NeedsRetry bool
+}
+
+// ParseAntigravityCLISessionWithStatus parses one CLI session into
+// the canonical ParsedSession + messages shape and reports whether
+// the result should be retried on the next sync.
+func ParseAntigravityCLISessionWithStatus(
+	path, project, machine string,
+) (*ParsedSession, []ParsedMessage, AntigravityCLIParseStatus, error) {
+	var status AntigravityCLIParseStatus
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+		return nil, nil, status, fmt.Errorf("stat %s: %w", path, err)
 	}
-	id := strings.TrimSuffix(filepath.Base(path), ".pb")
-	if !IsValidSessionID(id) {
-		return nil, nil, fmt.Errorf(
+	id, ext, ok := antigravityCLIPathID(filepath.Base(path))
+	if !ok {
+		return nil, nil, status, fmt.Errorf(
 			"invalid Antigravity CLI session filename: %s", path,
 		)
 	}
-	// Root = two levels up from the .pb file
-	// (conversations/<id>.pb or implicit/<id>.pb).
+	// Root = two levels up from the source file
+	// (conversations/<id>.db, conversations/<id>.pb, or implicit/<id>.pb).
 	root := filepath.Dir(filepath.Dir(path))
 	// Tag implicit/ sessions so they don't collide with the
 	// conversations/ entry that may share the same UUID.
@@ -140,15 +188,31 @@ func ParseAntigravityCLISession(
 		storageID = antigravityImplicitTag + id
 	}
 
-	sidecarPath := strings.TrimSuffix(path, ".pb") + ".trajectory.json"
 	var messages []ParsedMessage
 	var hasTrajectory bool
-	if sidecarInfo, err := os.Stat(sidecarPath); err == nil &&
-		!sidecarInfo.ModTime().Before(info.ModTime()) {
-		if tMsgs, err := parseAntigravityCLITrajectory(sidecarPath); err == nil {
+	if ext == ".db" {
+		if tMsgs, err := loadAntigravityCLIDBSteps(path); err == nil {
 			if hasDisplayableAntigravityCLITrajectoryMessage(tMsgs) {
-				messages = tMsgs
+				messages = mergeAntigravityDBHistoryMessages(
+					tMsgs,
+					collectAntigravityHistoryMessages(
+						filepath.Join(root, "history.jsonl"), id,
+					),
+				)
 				hasTrajectory = true
+			}
+		} else {
+			status.NeedsRetry = true
+		}
+	} else {
+		sidecarPath := strings.TrimSuffix(path, ".pb") + ".trajectory.json"
+		if sidecarInfo, err := os.Stat(sidecarPath); err == nil &&
+			!sidecarInfo.ModTime().Before(info.ModTime()) {
+			if tMsgs, err := parseAntigravityCLITrajectory(sidecarPath); err == nil {
+				if hasDisplayableAntigravityCLITrajectoryMessage(tMsgs) {
+					messages = tMsgs
+					hasTrajectory = true
+				}
 			}
 		}
 	}
@@ -164,7 +228,7 @@ func ParseAntigravityCLISession(
 		)...,
 	)
 
-	if !hasTrajectory && hasAntigravityKey() {
+	if ext == ".pb" && !hasTrajectory && hasAntigravityKey() {
 		if extra, ok := decryptAntigravityCLITranscript(path); ok {
 			messages = append(messages, extra)
 		}
@@ -240,9 +304,104 @@ func ParseAntigravityCLISession(
 		},
 	}
 	if len(messages) == 0 {
-		return sess, nil, nil
+		return sess, nil, status, nil
 	}
-	return sess, messages, nil
+	return sess, messages, status, nil
+}
+
+func loadAntigravityCLIDBSteps(path string) ([]ParsedMessage, error) {
+	dsn := "file:" + path + "?mode=ro&immutable=0"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open antigravity cli db %s: %w", path, err)
+	}
+	defer db.Close()
+	return loadAntigravitySteps(db)
+}
+
+func mergeAntigravityDBHistoryMessages(
+	dbMessages []ParsedMessage, history []ParsedMessage,
+) []ParsedMessage {
+	if len(dbMessages) == 0 || len(history) == 0 {
+		return dbMessages
+	}
+	history = nonEmptyAntigravityHistoryMessages(history)
+	if len(history) == 0 {
+		return dbMessages
+	}
+	userCount := 0
+	for _, msg := range dbMessages {
+		if msg.Role == RoleUser {
+			userCount++
+		}
+	}
+	if userCount != len(history) {
+		return appendMissingAntigravityHistoryMessages(
+			dbMessages, history,
+		)
+	}
+	historyIdx := 0
+	for i := range dbMessages {
+		if dbMessages[i].Role != RoleUser {
+			continue
+		}
+		if historyIdx >= len(history) {
+			return appendMissingAntigravityHistoryMessages(
+				dbMessages, history,
+			)
+		}
+		dbMessages[i].Content = history[historyIdx].Content
+		dbMessages[i].ContentLength = len(history[historyIdx].Content)
+		if !history[historyIdx].Timestamp.IsZero() {
+			dbMessages[i].Timestamp = history[historyIdx].Timestamp
+		}
+		historyIdx++
+	}
+	return dbMessages
+}
+
+func appendMissingAntigravityHistoryMessages(
+	dbMessages []ParsedMessage, history []ParsedMessage,
+) []ParsedMessage {
+	seen := make(map[string]struct{})
+	for _, msg := range dbMessages {
+		if msg.Role != RoleUser {
+			continue
+		}
+		if key := normalizedAntigravityPrompt(msg.Content); key != "" {
+			seen[key] = struct{}{}
+		}
+	}
+	out := dbMessages
+	for _, msg := range history {
+		key := normalizedAntigravityPrompt(msg.Content)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		out = append(out, msg)
+		seen[key] = struct{}{}
+	}
+	return out
+}
+
+func normalizedAntigravityPrompt(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func nonEmptyAntigravityHistoryMessages(
+	history []ParsedMessage,
+) []ParsedMessage {
+	var out []ParsedMessage
+	for _, msg := range history {
+		if strings.TrimSpace(msg.Content) == "" {
+			continue
+		}
+		out = append(out, msg)
+	}
+	return out
 }
 
 func hasDisplayableAntigravityCLITrajectoryMessage(
@@ -430,15 +589,20 @@ func decryptAntigravityCLITranscript(
 // AntigravityCLIFileInfo returns a fake os.FileInfo whose size and mtime are
 // computed by looking at both <uuid>.pb and <uuid>.trajectory.json.
 // If the trajectory file exists, its mtime and size are factored in.
-func AntigravityCLIFileInfo(pbPath string) (os.FileInfo, error) {
-	pbInfo, err := os.Stat(pbPath)
+func AntigravityCLIFileInfo(path string) (os.FileInfo, error) {
+	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
 	}
-	size := pbInfo.Size()
-	mtime := pbInfo.ModTime().UnixNano()
+	if strings.HasSuffix(path, ".db") {
+		return antigravityCLICombinedFileInfo(
+			info, path+"-wal", path+"-shm",
+		), nil
+	}
+	size := info.Size()
+	mtime := info.ModTime().UnixNano()
 
-	sidecar := strings.TrimSuffix(pbPath, ".pb") + ".trajectory.json"
+	sidecar := strings.TrimSuffix(path, ".pb") + ".trajectory.json"
 	if sidecarInfo, err := os.Stat(sidecar); err == nil {
 		size += sidecarInfo.Size()
 		if sidecarInfo.ModTime().UnixNano() > mtime {
@@ -447,10 +611,32 @@ func AntigravityCLIFileInfo(pbPath string) (os.FileInfo, error) {
 	}
 
 	return fakeFileInfo{
-		name:  pbInfo.Name(),
+		name:  info.Name(),
 		size:  size,
 		mtime: mtime,
 	}, nil
+}
+
+func antigravityCLICombinedFileInfo(
+	base os.FileInfo, companions ...string,
+) os.FileInfo {
+	size := base.Size()
+	mtime := base.ModTime().UnixNano()
+	for _, p := range companions {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		size += info.Size()
+		if info.ModTime().UnixNano() > mtime {
+			mtime = info.ModTime().UnixNano()
+		}
+	}
+	return fakeFileInfo{
+		name:  base.Name(),
+		size:  size,
+		mtime: mtime,
+	}
 }
 
 type fakeFileInfo struct {

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -221,6 +221,92 @@ func TestAntigravityCLIDiscoverAndParse(t *testing.T) {
 	assert.Equal(t, int64(1779000000000), sess.StartedAt.UnixMilli())
 }
 
+func TestAntigravityCLIDiscoverAndParseDB(t *testing.T) {
+	root := t.TempDir()
+	id := "33333333-4444-5555-6666-777777777777"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustMkdir(t, filepath.Join(root, "brain", id))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath)
+	mustWrite(t, filepath.Join(root, "conversations", id+".pb"),
+		[]byte("old-encrypted-placeholder"))
+	mustWrite(t, filepath.Join(root, "history.jsonl"),
+		[]byte(`{"display":"db prompt fallback","timestamp":1779000000000,`+
+			`"workspace":"/tmp/db-proj","conversationId":"`+id+`"}`))
+
+	files := DiscoverAntigravityCLISessions(root)
+	require.Len(t, files, 1, "discover")
+	assert.Equal(t, dbPath, files[0].Path, "prefer db over pb")
+	assert.Equal(t, "/tmp/db-proj", files[0].Project, "project")
+	assert.Equal(t, dbPath, FindAntigravityCLISourceFile(root, id), "find")
+
+	sess, msgs, err := ParseAntigravityCLISession(
+		files[0].Path, files[0].Project, "test-machine",
+	)
+	require.NoError(t, err, "parse")
+	assert.Equal(t, "antigravity-cli:"+id, sess.ID)
+	assert.Equal(t, AgentAntigravityCLI, sess.Agent)
+	assert.Equal(t, dbPath, sess.File.Path)
+	assert.Equal(t, "/tmp/db-proj", sess.Project)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "db prompt fallback", msgs[0].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Contains(t, msgs[1].Content, "assistant reply content body")
+	assert.Equal(t, 2, sess.MessageCount)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, "db prompt fallback", sess.FirstMessage)
+}
+
+func TestAntigravityCLIDBFileInfoIncludesSQLiteSidecars(t *testing.T) {
+	root := t.TempDir()
+	id := "44444444-5555-6666-7777-888888888888"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	mustWrite(t, dbPath, []byte("db"))
+	mustWrite(t, dbPath+"-wal", []byte("wal"))
+	mustWrite(t, dbPath+"-shm", []byte("shm"))
+
+	early := time.Unix(1779000000, 0)
+	late := time.Unix(1779000300, 0)
+	require.NoError(t, os.Chtimes(dbPath, early, early))
+	require.NoError(t, os.Chtimes(dbPath+"-wal", late, late))
+	require.NoError(t, os.Chtimes(dbPath+"-shm", early, early))
+
+	info, err := AntigravityCLIFileInfo(dbPath)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("dbwalshm")), info.Size())
+	assert.Equal(t, late.UnixNano(), info.ModTime().UnixNano())
+}
+
+func TestAntigravityCLIDBInsertsShortHistoryPrompt(t *testing.T) {
+	root := t.TempDir()
+	id := "55555555-6666-7777-8888-999999999999"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityShortPromptDB(t, dbPath)
+	mustWrite(t, filepath.Join(root, "history.jsonl"),
+		[]byte(`{"display":"fix lint","timestamp":1779000000000,`+
+			`"workspace":"/tmp/db-proj","conversationId":"`+id+`"}`))
+
+	sess, msgs, err := ParseAntigravityCLISession(
+		dbPath, "", "test-machine",
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "fix lint", msgs[0].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Contains(t, msgs[1].Content, "assistant reply content body")
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, "fix lint", sess.FirstMessage)
+}
+
 func TestAntigravityCLIDiscoverIgnoresJunk(t *testing.T) {
 	root := t.TempDir()
 	mustMkdir(t, filepath.Join(root, "conversations"))
@@ -288,6 +374,120 @@ func TestAntigravityIDEDiscoverAndParse(t *testing.T) {
 	// Annotation overrides endedAt to 2026-05-20T... =
 	// 1779326586
 	assert.Equal(t, int64(1779326586), sess.EndedAt.Unix())
+}
+
+func TestDecodeAntigravityStepFiltersInternalStrings(t *testing.T) {
+	ts := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000000},
+	})
+	payload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: ts},
+		{
+			num: 17, wire: pbWireBytes,
+			bytes: []byte("67fdbde7-4a15-4599-a206-5ed536cf1fc4"),
+		},
+		{
+			num: 18, wire: pbWireBytes,
+			bytes: []byte("can you review the proposed issues before filing?"),
+		},
+		{
+			num: 19, wire: pbWireBytes,
+			bytes: []byte("can you review the proposed issues before filing?"),
+		},
+		{
+			num: 20, wire: pbWireBytes,
+			bytes: []byte("/home/mj/.gemini/antigravity-cli/skills"),
+		},
+	})
+
+	msg, ok := decodeAntigravityStep(0, 14, payload)
+	require.True(t, ok)
+	assert.Equal(t, RoleUser, msg.Role)
+	assert.Equal(t, "can you review the proposed issues before filing?", msg.Content)
+	assert.NotContains(t, msg.Content, "[step")
+	assert.NotContains(t, msg.Content, "67fdbde7")
+	assert.NotContains(t, msg.Content, ".gemini")
+}
+
+func TestDecodeAntigravityStepKeepsCleanAssistantText(t *testing.T) {
+	payload := encodePB([]pbField{
+		{
+			num: 17, wire: pbWireBytes,
+			bytes: []byte("06b66779-eebe-4869-ba1b-ccf3d42be70b"),
+		},
+		{
+			num: 18, wire: pbWireBytes,
+			bytes: []byte("-3750763034362895579"),
+		},
+		{
+			num: 19, wire: pbWireBytes,
+			bytes: []byte("mYseaoyPDcS6qtsP7c6Z6QE"),
+		},
+		{
+			num: 20, wire: pbWireBytes,
+			bytes: []byte("I will start by listing the directory structure."),
+		},
+		{
+			num: 21, wire: pbWireBytes,
+			bytes: []byte(`{"DirectoryPath":"/tmp/project","toolAction":"Listing workspace files","toolSummary":"List directory contents"}`),
+		},
+		{
+			num: 22, wire: pbWireBytes,
+			bytes: []byte("MODEL_PLACEHOLDER_M20"),
+		},
+		{
+			num: 23, wire: pbWireBytes,
+			bytes: []byte("I will start by listing the directory structure."),
+		},
+	})
+
+	msg, ok := decodeAntigravityStep(1, 15, payload)
+	require.True(t, ok)
+	assert.Equal(t, RoleAssistant, msg.Role)
+	assert.Equal(t, "I will start by listing the directory structure.", msg.Content)
+	assert.NotContains(t, msg.Content, "[step")
+	assert.NotContains(t, msg.Content, "06b66779")
+	assert.NotContains(t, msg.Content, "-3750763034362895579")
+	assert.NotContains(t, msg.Content, "mYseaoyPDcS6qtsP7c6Z6QE")
+	assert.NotContains(t, msg.Content, "toolAction")
+	assert.NotContains(t, msg.Content, "MODEL_PLACEHOLDER")
+}
+
+func TestMergeAntigravityDBHistoryMessagesAppendsMissingPrompts(t *testing.T) {
+	msgs := []ParsedMessage{
+		{Role: RoleUser, Content: "first decoded prompt"},
+		{Role: RoleAssistant, Content: "assistant"},
+		{Role: RoleUser, Content: "second decoded prompt"},
+	}
+	history := []ParsedMessage{
+		{Role: RoleUser, Content: "only tagged history prompt"},
+	}
+
+	got := mergeAntigravityDBHistoryMessages(msgs, history)
+
+	require.Len(t, got, 4)
+	assert.Equal(t, "first decoded prompt", got[0].Content)
+	assert.Equal(t, "second decoded prompt", got[2].Content)
+	assert.Equal(t, "only tagged history prompt", got[3].Content)
+}
+
+func TestMergeAntigravityDBHistoryMessagesIgnoresBlankHistoryRows(t *testing.T) {
+	ts := time.Unix(1779000000, 0)
+	msgs := []ParsedMessage{
+		{Role: RoleUser, Content: "decoded prompt"},
+		{Role: RoleAssistant, Content: "assistant"},
+	}
+	history := []ParsedMessage{
+		{Role: RoleUser, Content: ""},
+		{Role: RoleUser, Content: "history prompt", Timestamp: ts},
+		{Role: RoleUser, Content: "   "},
+	}
+
+	got := mergeAntigravityDBHistoryMessages(msgs, history)
+
+	assert.Equal(t, "history prompt", got[0].Content)
+	assert.Equal(t, len("history prompt"), got[0].ContentLength)
+	assert.Equal(t, ts, got[0].Timestamp)
 }
 
 // ---- crypto: key loading --------------------------------------
@@ -516,19 +716,7 @@ func createAntigravityTestDB(t *testing.T, path string) {
 	db, err := sql.Open("sqlite3", path)
 	require.NoError(t, err, "open")
 	defer db.Close()
-	mustExec(t, db, `CREATE TABLE trajectory_meta (
-		trajectory_id text, cascade_id text,
-		trajectory_type integer, source integer,
-		PRIMARY KEY (trajectory_id))`)
-	mustExec(t, db, `CREATE TABLE steps (
-		idx integer, step_type integer NOT NULL DEFAULT 0,
-		status integer NOT NULL DEFAULT 0,
-		has_subtrajectory numeric NOT NULL DEFAULT false,
-		metadata blob, error_details blob,
-		permissions blob, task_details blob,
-		render_info blob, step_payload blob,
-		step_format integer NOT NULL DEFAULT 0,
-		PRIMARY KEY (idx))`)
+	createAntigravityStepTables(t, db)
 
 	tsEarly := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: 1779000000},
@@ -561,6 +749,63 @@ func createAntigravityTestDB(t *testing.T, path string) {
 		`INSERT INTO steps (idx, step_type, step_payload) `+
 			`VALUES (?, ?, ?)`,
 		1, 17, asstPayload)
+}
+
+func createAntigravityShortPromptDB(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open")
+	defer db.Close()
+	createAntigravityStepTables(t, db)
+
+	tsEarly := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000000},
+	})
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsEarly},
+		{
+			num:   17,
+			wire:  pbWireBytes,
+			bytes: []byte("fix lint"),
+		},
+	})
+	tsLate := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000100},
+	})
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsLate},
+		{
+			num:   17,
+			wire:  pbWireBytes,
+			bytes: []byte("assistant reply content body"),
+		},
+	})
+
+	mustExec(t, db,
+		`INSERT INTO steps (idx, step_type, step_payload) `+
+			`VALUES (?, ?, ?)`,
+		0, 14, userPayload)
+	mustExec(t, db,
+		`INSERT INTO steps (idx, step_type, step_payload) `+
+			`VALUES (?, ?, ?)`,
+		1, 17, asstPayload)
+}
+
+func createAntigravityStepTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	mustExec(t, db, `CREATE TABLE trajectory_meta (
+		trajectory_id text, cascade_id text,
+		trajectory_type integer, source integer,
+		PRIMARY KEY (trajectory_id))`)
+	mustExec(t, db, `CREATE TABLE steps (
+		idx integer, step_type integer NOT NULL DEFAULT 0,
+		status integer NOT NULL DEFAULT 0,
+		has_subtrajectory numeric NOT NULL DEFAULT false,
+		metadata blob, error_details blob,
+		permissions blob, task_details blob,
+		render_info blob, step_payload blob,
+		step_format integer NOT NULL DEFAULT 0,
+		PRIMARY KEY (idx))`)
 }
 
 func mustExec(

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
@@ -299,6 +300,52 @@ func TestSyncEngineAntigravityCLI_DBDecodeFallbackRetries(t *testing.T) {
 		"unchanged DB decode fallback should keep retrying")
 }
 
+func TestSyncEngineAntigravityCLI_DBUndisplayableStepsFallbackRetries(t *testing.T) {
+	env := setupTestEnv(t)
+	uuid := "88888888-9999-aaaa-bbbb-cccccccccccc"
+	sessionID := "antigravity-cli:" + uuid
+
+	convDir := filepath.Join(env.antigravityCLIDir, "conversations")
+	require.NoError(t, os.MkdirAll(convDir, 0o755))
+
+	historyLine := `{"conversationId": "` + uuid + `", "workspace": "/home/user/workspace-db-filtered", "timestamp": 1716244800000, "display": "History Prompt"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(env.antigravityCLIDir, "history.jsonl"), []byte(historyLine), 0o644))
+
+	dbPath := filepath.Join(convDir, uuid+".db")
+	createAntigravityCLIUndisplayableStepDB(t, dbPath)
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+
+	assertSessionMessageCount(t, env.db, sessionID, 1)
+	msgs := fetchMessages(t, env.db, sessionID)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "History Prompt", msgs[0].Content)
+	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
+		"DB fallback after dropping all raw steps should stay stale so unchanged syncs retry")
+
+	require.NoError(t, env.db.SetSessionDataVersion(sessionID, db.CurrentDataVersion()))
+	require.NoError(t, env.db.ResetAllMtimes(), "force fallback rewrite")
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
+		"DB fallback after dropping all raw steps should demote previously current rows")
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
+		"unchanged DB fallback after dropping all raw steps should keep retrying")
+}
+
 func TestSyncSingleSessionAntigravityCLI_DBDecodeFallbackRetries(t *testing.T) {
 	env := setupTestEnv(t)
 	uuid := "99999999-aaaa-bbbb-cccc-dddddddddddd"
@@ -352,4 +399,26 @@ func TestSyncEngineAntigravityCLI_MissingPbOrphanSidecar(t *testing.T) {
 		Synced:        0,
 		Skipped:       0,
 	})
+}
+
+func createAntigravityCLIUndisplayableStepDB(t *testing.T, path string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open antigravity cli test db")
+	defer conn.Close()
+
+	_, err = conn.Exec(`CREATE TABLE steps (
+		idx integer,
+		step_type integer NOT NULL DEFAULT 0,
+		step_payload blob,
+		PRIMARY KEY (idx))`)
+	require.NoError(t, err, "create steps table")
+
+	noisy := []byte("MODEL_PLACEHOLDER_0")
+	payload := append([]byte{0x8a, 0x01, byte(len(noisy))}, noisy...)
+	_, err = conn.Exec(
+		`INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)`,
+		0, 14, payload,
+	)
+	require.NoError(t, err, "insert undisplayable step")
 }

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -224,6 +224,59 @@ func TestSyncEngineAntigravityCLI_SyncAllSinceReSyncsSidecarUpdate(t *testing.T)
 	assert.Equal(t, "Prompt from SyncAllSince Trajectory", msgs[0].Content)
 }
 
+func TestSyncEngineAntigravityCLI_SyncAllSinceReSyncsDBWalUpdate(t *testing.T) {
+	env := setupTestEnv(t)
+	uuid := "22222222-3333-4444-5555-777777777777"
+	sessionID := "antigravity-cli:" + uuid
+
+	convDir := filepath.Join(env.antigravityCLIDir, "conversations")
+	require.NoError(t, os.MkdirAll(convDir, 0o755))
+
+	historyLine := `{"conversationId": "` + uuid + `", "workspace": "/home/user/workspace-db-wal", "timestamp": 1716244800000, "display": "History Prompt"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(env.antigravityCLIDir, "history.jsonl"), []byte(historyLine), 0o644))
+
+	dbPath := filepath.Join(convDir, uuid+".db")
+	createAntigravityCLIDisplayStepDB(t, dbPath, "Initial database prompt text")
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+
+	baseInfo, err := os.Stat(dbPath)
+	require.NoError(t, err)
+	baseMtime := baseInfo.ModTime()
+
+	time.Sleep(10 * time.Millisecond)
+
+	writer := openAntigravityCLITestWALDB(t, dbPath)
+	defer writer.Close()
+	insertAntigravityCLIStep(t, writer, 1, 17, "Assistant response from WAL text")
+
+	walInfo, err := os.Stat(dbPath + "-wal")
+	require.NoError(t, err, "expected WAL sidecar after uncheckpointed write")
+	require.Greater(t, walInfo.ModTime().UnixNano(), baseMtime.UnixNano())
+
+	require.NoError(t, os.Chtimes(dbPath, baseMtime, baseMtime))
+	baseAfter, err := os.Stat(dbPath)
+	require.NoError(t, err)
+	require.Equal(t, baseInfo.Size(), baseAfter.Size(), "base DB size changed")
+	require.Equal(t, baseMtime.UnixNano(), baseAfter.ModTime().UnixNano(),
+		"base DB mtime should not reveal WAL-only update")
+
+	stats := env.engine.SyncAllSince(context.Background(), baseMtime.Add(time.Nanosecond), nil)
+	assert.Equal(t, 1, stats.TotalSessions)
+	assert.Equal(t, 1, stats.Synced)
+	assert.Equal(t, 0, stats.Skipped)
+
+	assertSessionMessageCount(t, env.db, sessionID, 2)
+	msgs := fetchMessages(t, env.db, sessionID)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "Assistant response from WAL text", msgs[0].Content)
+	assert.Equal(t, "History Prompt", msgs[1].Content)
+}
+
 func TestSyncEngineAntigravityCLI_MalformedSidecarFallback(t *testing.T) {
 	env := setupTestEnv(t)
 	uuid := "55555555-6666-7777-8888-999999999999"
@@ -298,6 +351,47 @@ func TestSyncEngineAntigravityCLI_DBDecodeFallbackRetries(t *testing.T) {
 	})
 	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
 		"unchanged DB decode fallback should keep retrying")
+}
+
+func TestSyncEngineAntigravityCLI_NeedsRetryReplacesCurrentMessages(t *testing.T) {
+	env := setupTestEnv(t)
+	uuid := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	sessionID := "antigravity-cli:" + uuid
+
+	convDir := filepath.Join(env.antigravityCLIDir, "conversations")
+	require.NoError(t, os.MkdirAll(convDir, 0o755))
+
+	historyLine := `{"conversationId": "` + uuid + `", "workspace": "/home/user/workspace-db-retry", "timestamp": 1716244800000, "display": "History Prompt"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(env.antigravityCLIDir, "history.jsonl"), []byte(historyLine), 0o644))
+
+	dbPath := filepath.Join(convDir, uuid+".db")
+	createAntigravityCLIDisplayStepDB(t, dbPath, "Initial database prompt text")
+	conn := openAntigravityCLITestDB(t, dbPath)
+	insertAntigravityCLIStep(t, conn, 1, 17, "Initial assistant response text")
+	require.NoError(t, conn.Close())
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assertSessionMessageCount(t, env.db, sessionID, 2)
+	assert.Equal(t, db.CurrentDataVersion(), env.db.GetSessionDataVersion(sessionID))
+
+	require.NoError(t, os.WriteFile(dbPath, []byte("not a sqlite database"), 0o644))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+
+	assertSessionMessageCount(t, env.db, sessionID, 1)
+	msgs := fetchMessages(t, env.db, sessionID)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "History Prompt", msgs[0].Content)
+	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
+		"retry fallback should be written before the row is demoted")
 }
 
 func TestSyncEngineAntigravityCLI_DBUndisplayableStepsFallbackRetries(t *testing.T) {
@@ -403,22 +497,65 @@ func TestSyncEngineAntigravityCLI_MissingPbOrphanSidecar(t *testing.T) {
 
 func createAntigravityCLIUndisplayableStepDB(t *testing.T, path string) {
 	t.Helper()
-	conn, err := sql.Open("sqlite3", path)
-	require.NoError(t, err, "open antigravity cli test db")
+	conn := openAntigravityCLITestDB(t, path)
 	defer conn.Close()
 
-	_, err = conn.Exec(`CREATE TABLE steps (
+	createAntigravityCLITestStepsTable(t, conn)
+	insertAntigravityCLIStep(t, conn, 0, 14, "MODEL_PLACEHOLDER_0")
+}
+
+func createAntigravityCLIDisplayStepDB(t *testing.T, path, prompt string) {
+	t.Helper()
+	conn := openAntigravityCLITestDB(t, path)
+	defer conn.Close()
+
+	createAntigravityCLITestStepsTable(t, conn)
+	insertAntigravityCLIStep(t, conn, 0, 14, prompt)
+}
+
+func openAntigravityCLITestDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open antigravity cli test db")
+
+	return conn
+}
+
+func openAntigravityCLITestWALDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	conn := openAntigravityCLITestDB(t, path)
+
+	_, err := conn.Exec(`PRAGMA journal_mode=WAL`)
+	require.NoError(t, err, "enable WAL mode")
+	_, err = conn.Exec(`PRAGMA wal_autocheckpoint=0`)
+	require.NoError(t, err, "disable WAL autocheckpoint")
+
+	return conn
+}
+
+func createAntigravityCLITestStepsTable(t *testing.T, conn *sql.DB) {
+	t.Helper()
+	_, err := conn.Exec(`CREATE TABLE steps (
 		idx integer,
 		step_type integer NOT NULL DEFAULT 0,
 		step_payload blob,
 		PRIMARY KEY (idx))`)
 	require.NoError(t, err, "create steps table")
+}
 
-	noisy := []byte("MODEL_PLACEHOLDER_0")
-	payload := append([]byte{0x8a, 0x01, byte(len(noisy))}, noisy...)
-	_, err = conn.Exec(
+func insertAntigravityCLIStep(
+	t *testing.T, conn *sql.DB, idx, stepType int, content string,
+) {
+	t.Helper()
+	payload := antigravityCLIStringPayload(content)
+	_, err := conn.Exec(
 		`INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)`,
-		0, 14, payload,
+		idx, stepType, payload,
 	)
-	require.NoError(t, err, "insert undisplayable step")
+	require.NoError(t, err, "insert antigravity cli step")
+}
+
+func antigravityCLIStringPayload(s string) []byte {
+	content := []byte(s)
+	return append([]byte{0x8a, 0x01, byte(len(content))}, content...)
 }

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -299,6 +299,42 @@ func TestSyncEngineAntigravityCLI_DBDecodeFallbackRetries(t *testing.T) {
 		"unchanged DB decode fallback should keep retrying")
 }
 
+func TestSyncSingleSessionAntigravityCLI_DBDecodeFallbackRetries(t *testing.T) {
+	env := setupTestEnv(t)
+	uuid := "99999999-aaaa-bbbb-cccc-dddddddddddd"
+	sessionID := "antigravity-cli:" + uuid
+
+	convDir := filepath.Join(env.antigravityCLIDir, "conversations")
+	require.NoError(t, os.MkdirAll(convDir, 0o755))
+
+	historyLine := `{"conversationId": "` + uuid + `", "workspace": "/home/user/workspace-db-single", "timestamp": 1716244800000, "display": "History Prompt"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(env.antigravityCLIDir, "history.jsonl"), []byte(historyLine), 0o644))
+
+	dbPath := filepath.Join(convDir, uuid+".db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("not a sqlite database"), 0o644))
+
+	// An explicit single-session sync (the file-watcher path) of a .db
+	// whose decode fails must store the fallback at a stale data_version
+	// so a later sync retries the high-resolution source.
+	require.NoError(t, env.engine.SyncSingleSession(sessionID))
+
+	assertSessionMessageCount(t, env.db, sessionID, 1)
+	msgs := fetchMessages(t, env.db, sessionID)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "History Prompt", msgs[0].Content)
+	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
+		"single-session DB fallback should stay stale so later syncs retry")
+
+	// A previously current row must be demoted when an explicit re-sync
+	// hits the same decode failure, otherwise the high-resolution DB is
+	// never retried once it has been stamped current.
+	require.NoError(t, env.db.SetSessionDataVersion(sessionID, db.CurrentDataVersion()))
+	require.NoError(t, env.db.ResetAllMtimes(), "force fallback rewrite")
+	require.NoError(t, env.engine.SyncSingleSession(sessionID))
+	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
+		"single-session DB decode fallback should demote previously current rows")
+}
+
 func TestSyncEngineAntigravityCLI_MissingPbOrphanSidecar(t *testing.T) {
 	env := setupTestEnv(t)
 	uuid := "66666666-7777-8888-9999-000000000000"

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/sync"
 )
 
@@ -250,6 +251,52 @@ func TestSyncEngineAntigravityCLI_MalformedSidecarFallback(t *testing.T) {
 	msgs := fetchMessages(t, env.db, "antigravity-cli:"+uuid)
 	require.Len(t, msgs, 1)
 	assert.Equal(t, "History Prompt", msgs[0].Content)
+}
+
+func TestSyncEngineAntigravityCLI_DBDecodeFallbackRetries(t *testing.T) {
+	env := setupTestEnv(t)
+	uuid := "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+	sessionID := "antigravity-cli:" + uuid
+
+	convDir := filepath.Join(env.antigravityCLIDir, "conversations")
+	require.NoError(t, os.MkdirAll(convDir, 0o755))
+
+	historyLine := `{"conversationId": "` + uuid + `", "workspace": "/home/user/workspace-db", "timestamp": 1716244800000, "display": "History Prompt"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(env.antigravityCLIDir, "history.jsonl"), []byte(historyLine), 0o644))
+
+	dbPath := filepath.Join(convDir, uuid+".db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("not a sqlite database"), 0o644))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+
+	assertSessionMessageCount(t, env.db, sessionID, 1)
+	msgs := fetchMessages(t, env.db, sessionID)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "History Prompt", msgs[0].Content)
+	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
+		"degraded DB fallback should stay stale so unchanged syncs retry")
+
+	require.NoError(t, env.db.SetSessionDataVersion(sessionID, db.CurrentDataVersion()))
+	require.NoError(t, env.db.ResetAllMtimes(), "force fallback rewrite")
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
+		"DB decode fallback should demote previously current rows")
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
+		"unchanged DB decode fallback should keep retrying")
 }
 
 func TestSyncEngineAntigravityCLI_MissingPbOrphanSidecar(t *testing.T) {

--- a/internal/sync/classify_antigravity_cli_test.go
+++ b/internal/sync/classify_antigravity_cli_test.go
@@ -13,6 +13,7 @@ import (
 func TestClassifyOnePath_AntigravityCLI(t *testing.T) {
 	dir := t.TempDir()
 	uuid := "11111111-2222-3333-4444-555555555555"
+	dbUUID := "33333333-4444-5555-6666-777777777777"
 
 	// Create conversations and implicit subdirectories
 	convDir := filepath.Join(dir, "conversations")
@@ -23,9 +24,15 @@ func TestClassifyOnePath_AntigravityCLI(t *testing.T) {
 	// Files under conversations
 	pbPath := filepath.Join(convDir, uuid+".pb")
 	trajPath := filepath.Join(convDir, uuid+".trajectory.json")
+	dbPath := filepath.Join(convDir, dbUUID+".db")
+	dbWalPath := dbPath + "-wal"
+	dbShmPath := dbPath + "-shm"
 
 	require.NoError(t, os.WriteFile(pbPath, []byte("pb-data"), 0o644))
 	require.NoError(t, os.WriteFile(trajPath, []byte("trajectory-data"), 0o644))
+	require.NoError(t, os.WriteFile(dbPath, []byte("sqlite-data"), 0o644))
+	require.NoError(t, os.WriteFile(dbWalPath, []byte("wal-data"), 0o644))
+	require.NoError(t, os.WriteFile(dbShmPath, []byte("shm-data"), 0o644))
 
 	// Files under implicit
 	implPbPath := filepath.Join(implDir, uuid+".pb")
@@ -58,6 +65,24 @@ func TestClassifyOnePath_AntigravityCLI(t *testing.T) {
 			path:    trajPath,
 			want:    true,
 			retPath: pbPath,
+		},
+		{
+			name:    "conversations db file is classified",
+			path:    dbPath,
+			want:    true,
+			retPath: dbPath,
+		},
+		{
+			name:    "conversations db wal maps to db file",
+			path:    dbWalPath,
+			want:    true,
+			retPath: dbPath,
+		},
+		{
+			name:    "conversations db shm maps to db file",
+			path:    dbShmPath,
+			want:    true,
+			retPath: dbPath,
 		},
 		{
 			name:    "implicit pb file is classified",

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1024,7 +1024,8 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
-	// Antigravity CLI: <root>/conversations|implicit/<uuid>.pb (+ trajectory.json sidecars)
+	// Antigravity CLI: <root>/conversations/<uuid>.db or
+	// <root>/conversations|implicit/<uuid>.pb (+ trajectory.json sidecars)
 	for _, agDir := range e.agentDirs[parser.AgentAntigravityCLI] {
 		if agDir == "" {
 			continue
@@ -1037,13 +1038,20 @@ func (e *Engine) classifyOnePath(
 				continue
 			}
 			name := parts[1]
-			var pbPath string
+			var sourcePath string
 			var id string
 			if strings.HasSuffix(name, ".pb") {
-				pbPath = path
+				sourcePath = path
 				id = strings.TrimSuffix(name, ".pb")
+			} else if strings.HasSuffix(name, ".db") ||
+				strings.HasSuffix(name, ".db-wal") ||
+				strings.HasSuffix(name, ".db-shm") {
+				name = strings.TrimSuffix(name, "-wal")
+				name = strings.TrimSuffix(name, "-shm")
+				sourcePath = filepath.Join(agDir, parts[0], name)
+				id = strings.TrimSuffix(name, ".db")
 			} else if strings.HasSuffix(name, ".trajectory.json") {
-				pbPath = strings.TrimSuffix(path, ".trajectory.json") + ".pb"
+				sourcePath = strings.TrimSuffix(path, ".trajectory.json") + ".pb"
 				id = strings.TrimSuffix(name, ".trajectory.json")
 			} else {
 				continue
@@ -1051,11 +1059,18 @@ func (e *Engine) classifyOnePath(
 			if !parser.IsValidSessionID(id) {
 				continue
 			}
-			if _, err := os.Stat(pbPath); err != nil {
+			if parts[0] == "conversations" &&
+				strings.HasSuffix(sourcePath, ".pb") {
+				dbPath := filepath.Join(agDir, parts[0], id+".db")
+				if _, err := os.Stat(dbPath); err == nil {
+					sourcePath = dbPath
+				}
+			}
+			if _, err := os.Stat(sourcePath); err != nil {
 				continue
 			}
 			return parser.DiscoveredFile{
-				Path:  pbPath,
+				Path:  sourcePath,
 				Agent: parser.AgentAntigravityCLI,
 			}, true
 		}
@@ -2669,6 +2684,7 @@ func (e *Engine) collectAndBatch(
 					sess:         pr.Session,
 					msgs:         pr.Messages,
 					usageEvents:  pr.UsageEvents,
+					needsRetry:   r.needsRetry,
 					forceReplace: r.forceReplace,
 				})
 			}
@@ -2748,6 +2764,7 @@ type processResult struct {
 	err         error
 	incremental *incrementalUpdate
 	cacheSkip   bool
+	needsRetry  bool
 	// forceReplace requests full message replacement on write,
 	// even when the existing rows would otherwise be left in
 	// place. Set when a fall-through to full parse is recovering
@@ -4037,7 +4054,7 @@ func (e *Engine) processAntigravityCLI(
 		return processResult{skip: true}
 	}
 
-	sess, msgs, err := parser.ParseAntigravityCLISession(
+	sess, msgs, parseStatus, err := parser.ParseAntigravityCLISessionWithStatus(
 		file.Path, file.Project, e.machine,
 	)
 	if err != nil {
@@ -4053,8 +4070,12 @@ func (e *Engine) processAntigravityCLI(
 	}
 
 	return processResult{
+		needsRetry: parseStatus.NeedsRetry,
 		results: []parser.ParseResult{
-			{Session: *sess, Messages: msgs},
+			{
+				Session:  *sess,
+				Messages: msgs,
+			},
 		},
 	}
 }
@@ -4371,7 +4392,21 @@ type pendingWrite struct {
 	sess         parser.ParsedSession
 	msgs         []parser.ParsedMessage
 	usageEvents  []parser.ParsedUsageEvent
+	needsRetry   bool
 	forceReplace bool
+}
+
+func dataVersionForWrite(pw pendingWrite) int {
+	if !pw.needsRetry {
+		return db.CurrentDataVersion()
+	}
+	// Keep successfully written fallback content visible while
+	// forcing the next sync to retry the higher-resolution source.
+	v := db.CurrentDataVersion() - 1
+	if v < 0 {
+		return 0
+	}
+	return v
 }
 
 type worktreeProjectResolver func(
@@ -4502,7 +4537,7 @@ func (e *Engine) writeBatch(
 		// won't leave the session marked at the current
 		// parser version with stale messages.
 		if err := e.db.SetSessionDataVersion(
-			s.ID, db.CurrentDataVersion(),
+			s.ID, dataVersionForWrite(pw),
 		); err != nil {
 			log.Printf(
 				"set data_version for %s: %v", s.ID, err,
@@ -4585,7 +4620,7 @@ func (e *Engine) writeBatchBulk(
 			UsageEvents:     toDBUsageEvents(s.ID, pw.usageEvents),
 			Signals:         update,
 			Findings:        findings,
-			DataVersion:     db.CurrentDataVersion(),
+			DataVersion:     dataVersionForWrite(pw),
 			ReplaceMessages: replaceMessages,
 		})
 		if pw.sess.File.Path != "" {
@@ -4787,7 +4822,7 @@ func (e *Engine) writeSessionFullWithResolver(
 	// See writeBatch for why data_version is bumped here
 	// rather than inside UpsertSession.
 	if err := e.db.SetSessionDataVersion(
-		s.ID, db.CurrentDataVersion(),
+		s.ID, dataVersionForWrite(pw),
 	); err != nil {
 		log.Printf(
 			"set data_version for %s: %v", s.ID, err,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5574,6 +5574,7 @@ func (e *Engine) SyncSingleSessionContext(
 				sess:        pr.Session,
 				msgs:        pr.Messages,
 				usageEvents: pr.UsageEvents,
+				needsRetry:  res.needsRetry,
 			},
 		); err != nil &&
 			!isIntentionalSessionSkip(err) &&

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4048,9 +4048,11 @@ func (e *Engine) processAntigravity(
 }
 
 func (e *Engine) processAntigravityCLI(
-	file parser.DiscoveredFile, info os.FileInfo,
+	file parser.DiscoveredFile, effectiveInfo os.FileInfo,
 ) processResult {
-	if e.shouldSkipByPath(file.Path, info) {
+	// processFile supplies AntigravityCLIFileInfo here, so .db WAL/SHM
+	// sidecars and .pb trajectory sidecars participate in skip checks.
+	if e.shouldSkipByPath(file.Path, effectiveInfo) {
 		return processResult{skip: true}
 	}
 
@@ -4500,7 +4502,7 @@ func (e *Engine) writeBatch(
 			continue
 		}
 
-		replaceMessages := forceReplace || pw.forceReplace ||
+		replaceMessages := forceReplace || pw.forceReplace || pw.needsRetry ||
 			stale || pw.sess.Agent == parser.AgentOpenCode ||
 			pw.sess.Agent == parser.AgentAntigravityCLI
 
@@ -4608,7 +4610,7 @@ func (e *Engine) writeBatchBulk(
 		if !ok {
 			continue
 		}
-		replaceMessages := forceReplace || pw.forceReplace ||
+		replaceMessages := forceReplace || pw.forceReplace || pw.needsRetry ||
 			pw.sess.Agent == parser.AgentOpenCode ||
 			pw.sess.Agent == parser.AgentAntigravityCLI
 		tScan := time.Now()


### PR DESCRIPTION
## Summary

*Resolves a breaking change in antigravity-cli release 1.0.4 (2026-06-01) release.*

Adds support for newer Antigravity CLI sessions that are stored as per-conversation SQLite `.db` files under `~/.gemini/antigravity-cli/conversations/`.

This keeps the existing encrypted `.pb` + `agy-reader` sidecar flow intact, while allowing Agentsview to index the newer DB-backed sessions directly.

## Changes

- Discover Antigravity CLI `conversations/<uuid>.db` files and prefer them over same-ID `.pb` files.
- Classify `.db`, `.db-wal`, and `.db-shm` filesystem events back to the canonical DB source.
- Parse CLI SQLite DB steps through the existing Antigravity SQLite/protobuf path.
- Include SQLite WAL/SHM mtimes in effective file info so live session updates resync reliably.
- Clean noisy internal strings from DB-decoded transcripts, including step headers, UUIDs, opaque request IDs, model placeholders, AGY config paths, and tool-action JSON blobs.
- Tighten prompt replacement from `history.jsonl` so sparse or blank history rows do not misassign prompts.
- Update README guidance for the two Antigravity CLI storage formats.

## Root Cause

Recent Antigravity CLI releases now write `conversations/<uuid>.db` instead of the older encrypted `conversations/<uuid>.pb` format. Agentsview only discovered `.pb` files for Antigravity CLI, so newer sessions were invisible. Once DB discovery was added, the old protobuf string-extraction heuristic surfaced internal protocol strings in the visible transcript; this PR filters those strings and prefers human-facing prompt text.

## Follow-up

Tracked in #579: newer `history.jsonl` rows may omit `conversationId`, so DB sessions can parse cleanly but still lack project inference from history. That should be handled conservatively by matching prompt/timestamp proximity rather than assuming every nearby history row belongs to a DB.

## Validation

- `go test ./internal/parser ./internal/sync`
- Tested against local Antigravity CLI `.db` sessions before and after the code changes; transcript parsing produced a clean first user message without step headers or internal IDs.
