### PR TITLE
fix: resolve dotted model names to dashed pricing keys

### DIFF
--- a/internal/db/pricing_match_test.go
+++ b/internal/db/pricing_match_test.go
@@ -1,0 +1,32 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupModelRates_DotDashFallback(t *testing.T) {
+	pricing := map[string]modelRates{
+		"claude-opus-4-7": {input: 5, output: 25},
+		"claude-opus-4.6": {input: 99, output: 99},
+	}
+
+	rates, ok := lookupModelRates(pricing, "claude-opus-4.7")
+	require.True(t, ok, "dotted model should resolve via normalized key")
+	assert.Equal(t, 5.0, rates.input)
+	assert.Equal(t, 25.0, rates.output)
+
+	dashed, ok := lookupModelRates(pricing, "claude-opus-4-7")
+	require.True(t, ok, "already-dashed model should resolve exactly")
+	assert.Equal(t, 5.0, dashed.input)
+
+	exact, ok := lookupModelRates(pricing, "claude-opus-4.6")
+	require.True(t, ok)
+	assert.Equal(t, 99.0, exact.input,
+		"exact match must win over normalized fallback")
+
+	_, ok = lookupModelRates(pricing, "gpt-5.5")
+	assert.False(t, ok, "unknown model stays unpriced")
+}

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -1024,7 +1024,7 @@ func addMessageToCacheTotals(
 	totals.cacheCreateT += cacheCrTok
 	totals.cacheReadT += cacheRdTok
 
-	rates := pricing[model]
+	rates, _ := lookupModelRates(pricing, model)
 	totals.dollarsSpent += (float64(inputTok)*rates.input +
 		float64(outputTok)*rates.output +
 		float64(cacheCrTok)*rates.cacheCreation +

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -9,7 +9,15 @@ import (
 	"time"
 
 	"github.com/tidwall/gjson"
+
+	pricingpkg "go.kenn.io/agentsview/internal/pricing"
 )
+
+func lookupModelRates(
+	pricing map[string]modelRates, model string,
+) (modelRates, bool) {
+	return pricingpkg.Resolve(pricing, model)
+}
 
 // UsageFilter controls the date range, agent, and timezone
 // for daily usage aggregation queries.
@@ -303,7 +311,7 @@ func usageAmounts(
 		cacheRdTok = r.cacheReadInputTokens
 	}
 
-	rates := pricing[r.model]
+	rates, _ := lookupModelRates(pricing, r.model)
 	if r.costUSD.Valid {
 		cost = r.costUSD.Float64
 	} else {
@@ -1091,7 +1099,7 @@ func sessionRowCost(
 	if inTok == 0 && outTok == 0 && crTok == 0 && rdTok == 0 {
 		return 0, true, false
 	}
-	rates, ok := pricing[r.model]
+	rates, ok := lookupModelRates(pricing, r.model)
 	if !ok {
 		return 0, false, true
 	}

--- a/internal/postgres/pricing.go
+++ b/internal/postgres/pricing.go
@@ -18,6 +18,12 @@ type modelRates struct {
 	cacheRead     float64
 }
 
+func lookupModelRates(
+	prices map[string]modelRates, model string,
+) (modelRates, bool) {
+	return pricing.Resolve(prices, model)
+}
+
 func fallbackPricingRows() []db.ModelPricing {
 	src := pricing.FallbackPricing()
 	out := make([]db.ModelPricing, len(src))

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -263,7 +263,7 @@ func pgUsageAmounts(
 		cacheRdTok = r.cacheReadInputTokens
 	}
 
-	rates := pricing[r.model]
+	rates, _ := lookupModelRates(pricing, r.model)
 	if r.costUSD.Valid {
 		cost = r.costUSD.Float64
 	} else {
@@ -303,7 +303,7 @@ func pgSessionRowCost(
 	if inTok == 0 && outTok == 0 && crTok == 0 && rdTok == 0 {
 		return 0, true, false
 	}
-	rates, ok := pricing[r.model]
+	rates, ok := lookupModelRates(pricing, r.model)
 	if !ok {
 		return 0, false, true
 	}

--- a/internal/pricing/normalize.go
+++ b/internal/pricing/normalize.go
@@ -1,0 +1,26 @@
+package pricing
+
+import "strings"
+
+// NormalizeModelName converts a model id's dots to dashes so agents
+// that report dotted ids (e.g. opencode's claude-opus-4.7) match the
+// dashed LiteLLM pricing keys (claude-opus-4-7). Use only as a
+// fallback after an exact match.
+func NormalizeModelName(model string) string {
+	return strings.ReplaceAll(model, ".", "-")
+}
+
+// Resolve looks up model in m, falling back to NormalizeModelName when
+// there is no exact match. Shared by the sqlite and postgres lookups.
+func Resolve[T any](m map[string]T, model string) (T, bool) {
+	if v, ok := m[model]; ok {
+		return v, true
+	}
+	if norm := NormalizeModelName(model); norm != model {
+		if v, ok := m[norm]; ok {
+			return v, true
+		}
+	}
+	var zero T
+	return zero, false
+}

--- a/internal/pricing/normalize_test.go
+++ b/internal/pricing/normalize_test.go
@@ -1,0 +1,43 @@
+package pricing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeModelName(t *testing.T) {
+	cases := map[string]string{
+		"claude-opus-4.7":   "claude-opus-4-7",
+		"claude-sonnet-4.6": "claude-sonnet-4-6",
+		"claude-haiku-4.5":  "claude-haiku-4-5",
+		"claude-opus-4-8":   "claude-opus-4-8",
+		"gpt-5.5":           "gpt-5-5",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, NormalizeModelName(in), "input %q", in)
+	}
+}
+
+func TestResolve(t *testing.T) {
+	rates := map[string]int{
+		"claude-opus-4-7": 5,
+		"claude-opus-4.6": 99,
+	}
+
+	got, ok := Resolve(rates, "claude-opus-4.7")
+	require.True(t, ok, "dotted model should resolve via normalized key")
+	assert.Equal(t, 5, got)
+
+	got, ok = Resolve(rates, "claude-opus-4-7")
+	require.True(t, ok, "already-dashed model should resolve exactly")
+	assert.Equal(t, 5, got)
+
+	got, ok = Resolve(rates, "claude-opus-4.6")
+	require.True(t, ok)
+	assert.Equal(t, 99, got, "exact match must win over normalized fallback")
+
+	_, ok = Resolve(rates, "gpt-5.5")
+	assert.False(t, ok, "unknown model stays unresolved")
+}


### PR DESCRIPTION
Some agents report model ids with dots (e.g. opencode's claude-opus-4.7) while the LiteLLM pricing table keys them by API string with dashes (claude-opus-4-7), so 'usage daily' reported $0.00 for those sessions. Add a Resolve helper that falls back to the dot-to-dash form, routed through every cost lookup.