### PR TITLE
Add Command Code session support

### DIFF
--- a/internal/parser/commandcode.go
+++ b/internal/parser/commandcode.go
@@ -1,0 +1,420 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+type commandCodeMeta struct {
+	Title       string `json:"title"`
+	UserRenamed bool   `json:"userRenamed"`
+	ProjectPath string `json:"projectPath"`
+	Cwd         string `json:"cwd"`
+}
+
+// DiscoverCommandCodeSessions finds Command Code transcripts under
+// ~/.commandcode/projects/<slugified-cwd>/<session-id>.jsonl.
+func DiscoverCommandCodeSessions(projectsDir string) []DiscoveredFile {
+	if projectsDir == "" {
+		return nil
+	}
+
+	projectEntries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return nil
+	}
+
+	var files []DiscoveredFile
+	for _, entry := range projectEntries {
+		if !isDirOrSymlink(entry, projectsDir) {
+			continue
+		}
+
+		projectDir := filepath.Join(projectsDir, entry.Name())
+		sessionEntries, err := os.ReadDir(projectDir)
+		if err != nil {
+			continue
+		}
+
+		for _, sessionEntry := range sessionEntries {
+			if sessionEntry.IsDir() {
+				continue
+			}
+			name := sessionEntry.Name()
+			if !strings.HasSuffix(name, ".jsonl") ||
+				strings.HasSuffix(name, ".checkpoints.jsonl") ||
+				strings.HasSuffix(name, ".prompts.jsonl") {
+				continue
+			}
+			id := strings.TrimSuffix(name, ".jsonl")
+			if !IsValidSessionID(id) {
+				continue
+			}
+			files = append(files, DiscoveredFile{
+				Path:  filepath.Join(projectDir, name),
+				Agent: AgentCommandCode,
+			})
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+// FindCommandCodeSourceFile locates a Command Code transcript by
+// its raw session ID (without the "commandcode:" prefix).
+func FindCommandCodeSourceFile(projectsDir, rawID string) string {
+	if projectsDir == "" || !IsValidSessionID(rawID) {
+		return ""
+	}
+
+	projectEntries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range projectEntries {
+		if !isDirOrSymlink(entry, projectsDir) {
+			continue
+		}
+
+		candidate := filepath.Join(projectsDir, entry.Name(), rawID+".jsonl")
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// ParseCommandCodeSession parses a Command Code JSONL transcript.
+func ParseCommandCodeSession(
+	path, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	lr := newLineReader(f, maxLineSize)
+	var (
+		sessionID      string
+		cwd            string
+		gitBranch      string
+		firstMessage   string
+		startedAt      time.Time
+		endedAt        time.Time
+		ordinal        int
+		userCount      int
+		malformedLines int
+		messages       []ParsedMessage
+	)
+
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		if !gjson.Valid(line) {
+			malformedLines++
+			continue
+		}
+
+		root := gjson.Parse(line)
+		if sessionID == "" {
+			sessionID = root.Get("sessionId").Str
+		}
+		if cwd == "" {
+			cwd = commandCodeCwd(root)
+		}
+		if gitBranch == "" {
+			gitBranch = root.Get("gitBranch").Str
+		}
+
+		ts := parseTimestamp(root.Get("timestamp").Str)
+		if !ts.IsZero() {
+			if startedAt.IsZero() || ts.Before(startedAt) {
+				startedAt = ts
+			}
+			if endedAt.IsZero() || ts.After(endedAt) {
+				endedAt = ts
+			}
+		}
+
+		role := root.Get("role").Str
+		content := root.Get("content")
+		text, thinking, hasThinking, hasToolUse, toolCalls, toolResults :=
+			extractCommandCodeContent(content)
+		text = strings.TrimSpace(text)
+
+		switch role {
+		case "user":
+			if text == "" && len(toolResults) == 0 {
+				continue
+			}
+			if firstMessage == "" && text != "" {
+				firstMessage = truncate(
+					strings.ReplaceAll(text, "\n", " "),
+					300,
+				)
+			}
+			messages = append(messages, ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleUser,
+				Content:       text,
+				ThinkingText:  thinking,
+				Timestamp:     ts,
+				HasThinking:   hasThinking,
+				HasToolUse:    hasToolUse,
+				ContentLength: len(text),
+				ToolCalls:     toolCalls,
+				ToolResults:   toolResults,
+			})
+			ordinal++
+			if text != "" {
+				userCount++
+			}
+
+		case "assistant":
+			if text == "" && !hasThinking &&
+				len(toolCalls) == 0 && len(toolResults) == 0 {
+				continue
+			}
+			messages = append(messages, ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleAssistant,
+				Content:       text,
+				ThinkingText:  thinking,
+				Timestamp:     ts,
+				HasThinking:   hasThinking,
+				HasToolUse:    hasToolUse,
+				ContentLength: len(text),
+				ToolCalls:     toolCalls,
+				ToolResults:   toolResults,
+			})
+			ordinal++
+
+		case "tool":
+			if len(toolResults) == 0 {
+				continue
+			}
+			messages = append(messages, ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleUser,
+				Timestamp:     ts,
+				ContentLength: 0,
+				ToolResults:   toolResults,
+			})
+			ordinal++
+		}
+	}
+
+	if err := lr.Err(); err != nil {
+		return nil, nil, fmt.Errorf("reading command-code %s: %w", path, err)
+	}
+	if len(messages) == 0 {
+		return nil, nil, nil
+	}
+
+	meta := loadCommandCodeMeta(path)
+	if meta != nil {
+		if cwd == "" {
+			cwd = commandCodeFirstNonEmpty(meta.Cwd, meta.ProjectPath)
+		}
+		if firstMessage == "" {
+			firstMessage = meta.Title
+		}
+	}
+	if sessionID == "" {
+		sessionID = strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	}
+
+	project := ExtractProjectFromCwd(cwd)
+	if project == "" {
+		project = NormalizeName(filepath.Base(filepath.Dir(path)))
+	}
+
+	sessionName := ""
+	if meta != nil {
+		sessionName = meta.Title
+	}
+
+	sess := &ParsedSession{
+		ID:               "commandcode:" + sessionID,
+		Project:          project,
+		Machine:          machine,
+		Agent:            AgentCommandCode,
+		Cwd:              cwd,
+		GitBranch:        gitBranch,
+		SourceVersion:    "2",
+		MalformedLines:   malformedLines,
+		FirstMessage:     firstMessage,
+		SessionName:      sessionName,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     len(messages),
+		UserMessageCount: userCount,
+		File: FileInfo{
+			Path:  path,
+			Size:  info.Size(),
+			Mtime: info.ModTime().UnixNano(),
+		},
+	}
+	return sess, messages, nil
+}
+
+func loadCommandCodeMeta(path string) *commandCodeMeta {
+	metaPath := strings.TrimSuffix(path, ".jsonl") + ".meta.json"
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return nil
+	}
+	var meta commandCodeMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil
+	}
+	return &meta
+}
+
+func commandCodeCwd(root gjson.Result) string {
+	for _, key := range []string{
+		"metadata.cwd",
+		"metadata.projectPath",
+		"metadata.context.cwd",
+		"cwd",
+	} {
+		if v := root.Get(key).Str; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func extractCommandCodeContent(
+	content gjson.Result,
+) (string, string, bool, bool, []ParsedToolCall, []ParsedToolResult) {
+	if content.Type == gjson.String {
+		return content.Str, "", false, false, nil, nil
+	}
+	if !content.IsArray() {
+		return "", "", false, false, nil, nil
+	}
+
+	var (
+		textParts     []string
+		thinkingParts []string
+		toolCalls     []ParsedToolCall
+		toolResults   []ParsedToolResult
+		hasThinking   bool
+		hasToolUse    bool
+	)
+
+	content.ForEach(func(_, block gjson.Result) bool {
+		switch block.Get("type").Str {
+		case "text":
+			if text := block.Get("text").Str; text != "" {
+				textParts = append(textParts, text)
+			}
+		case "reasoning", "thinking":
+			thinking := commandCodeFirstNonEmpty(
+				block.Get("text").Str,
+				block.Get("thinking").Str,
+			)
+			if thinking != "" {
+				hasThinking = true
+				thinkingParts = append(thinkingParts, thinking)
+			}
+		case "tool-call", "tool_use":
+			toolName := commandCodeFirstNonEmpty(
+				block.Get("toolName").Str,
+				block.Get("name").Str,
+			)
+			if toolName == "" {
+				return true
+			}
+			hasToolUse = true
+			input := block.Get("input")
+			inputJSON := input.Raw
+			if inputJSON == "" {
+				inputJSON = "{}"
+			}
+			toolCalls = append(toolCalls, ParsedToolCall{
+				ToolUseID: blockID(block, "toolCallId", "id"),
+				ToolName:  toolName,
+				Category:  NormalizeToolCategory(toolName),
+				InputJSON: inputJSON,
+			})
+		case "tool-result", "tool_result":
+			toolUseID := blockID(block, "toolCallId", "tool_use_id")
+			contentRaw, contentLen := commandCodeToolResultContent(block)
+			if toolUseID == "" || contentRaw == "" {
+				return true
+			}
+			toolResults = append(toolResults, ParsedToolResult{
+				ToolUseID:     toolUseID,
+				ContentLength: contentLen,
+				ContentRaw:    contentRaw,
+			})
+		}
+		return true
+	})
+
+	return strings.Join(textParts, "\n"),
+		strings.Join(thinkingParts, "\n\n"),
+		hasThinking, hasToolUse, toolCalls, toolResults
+}
+
+func commandCodeToolResultContent(block gjson.Result) (string, int) {
+	output := block.Get("output")
+	if !output.Exists() {
+		output = block.Get("content")
+	}
+	if output.Exists() {
+		if output.IsObject() {
+			if value := output.Get("value"); value.Exists() &&
+				value.Type == gjson.String {
+				return strconv.Quote(value.Str), len(value.Str)
+			}
+		}
+		return output.Raw, toolResultContentLength(output)
+	}
+
+	for _, key := range []string{"text", "error", "value"} {
+		if text := block.Get(key).Str; text != "" {
+			return strconv.Quote(text), len(text)
+		}
+	}
+	return "", 0
+}
+
+func blockID(block gjson.Result, keys ...string) string {
+	for _, key := range keys {
+		if value := block.Get(key).Str; value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func commandCodeFirstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/parser/commandcode_test.go
+++ b/internal/parser/commandcode_test.go
@@ -1,0 +1,88 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverCommandCodeSessions(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "users-alice-code-sample-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "sess_a.jsonl"), []byte("{}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "sess_a.meta.json"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "sess_a.checkpoints.jsonl"), []byte("{}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "sess_a.prompts.jsonl"), []byte("{}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "notes.txt"), []byte("ignore"), 0o644))
+
+	files := DiscoverCommandCodeSessions(root)
+	require.Len(t, files, 1)
+	assert.Equal(t, AgentCommandCode, files[0].Agent)
+	assert.Equal(t, filepath.Join(projectDir, "sess_a.jsonl"), files[0].Path)
+}
+
+func TestFindCommandCodeSourceFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "users-alice-code-sample-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	path := filepath.Join(projectDir, "sess_123.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
+
+	assert.Equal(t, path, FindCommandCodeSourceFile(root, "sess_123"))
+	assert.Empty(t, FindCommandCodeSourceFile(root, "sess_missing"))
+}
+
+func TestParseCommandCodeSession(t *testing.T) {
+	t.Parallel()
+
+	content := `{"id":"m1","timestamp":"2026-06-01T10:00:00Z","sessionId":"sess_123","role":"user","content":[{"type":"text","text":"Inspect server logs"}],"gitBranch":"feature/command-code","metadata":{"version":2,"cwd":"/Users/alice/code/sample-project"}}
+{"id":"m2","timestamp":"2026-06-01T10:00:01Z","sessionId":"sess_123","role":"assistant","content":[{"type":"reasoning","text":"I should read the logs first."},{"type":"tool-call","toolCallId":"tc1","toolName":"Read","input":{"file_path":"server.log"}}],"gitBranch":"feature/command-code","metadata":{"version":2}}
+{"id":"m3","timestamp":"2026-06-01T10:00:02Z","sessionId":"sess_123","role":"tool","content":[{"type":"tool-result","toolCallId":"tc1","toolName":"Read","output":{"type":"text","value":"error: boom"}}],"gitBranch":"feature/command-code","metadata":{"version":2}}
+{"id":"m4","timestamp":"2026-06-01T10:00:03Z","sessionId":"sess_123","role":"assistant","content":[{"type":"text","text":"The error is in the startup path."}],"gitBranch":"feature/command-code","metadata":{"version":2}}`
+
+	path := createTestFile(t, "commandcode.jsonl", content)
+	metaPath := strings.TrimSuffix(path, ".jsonl") + ".meta.json"
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"title":"Startup investigation"}`), 0o644))
+
+	sess, msgs, err := ParseCommandCodeSession(path, "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 4)
+
+	assert.Equal(t, "commandcode:sess_123", sess.ID)
+	assert.Equal(t, AgentCommandCode, sess.Agent)
+	assert.Equal(t, "sample_project", sess.Project)
+	assert.Equal(t, "/Users/alice/code/sample-project", sess.Cwd)
+	assert.Equal(t, "feature/command-code", sess.GitBranch)
+	assert.Equal(t, "Inspect server logs", sess.FirstMessage)
+	assert.Equal(t, "Startup investigation", sess.SessionName)
+	assert.Equal(t, 4, sess.MessageCount)
+	assert.Equal(t, 1, sess.UserMessageCount)
+
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "Inspect server logs", msgs[0].Content)
+
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.True(t, msgs[1].HasThinking)
+	assert.Equal(t, "I should read the logs first.", msgs[1].ThinkingText)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "tc1", msgs[1].ToolCalls[0].ToolUseID)
+	assert.Equal(t, "Read", msgs[1].ToolCalls[0].ToolName)
+
+	assert.Equal(t, RoleUser, msgs[2].Role)
+	require.Len(t, msgs[2].ToolResults, 1)
+	assert.Equal(t, "tc1", msgs[2].ToolResults[0].ToolUseID)
+	assert.Equal(t, "error: boom", DecodeContent(msgs[2].ToolResults[0].ContentRaw))
+
+	assert.Equal(t, RoleAssistant, msgs[3].Role)
+	assert.Equal(t, "The error is in the startup path.", msgs[3].Content)
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -23,6 +23,7 @@ const (
 	AgentVSCodeCopilot  AgentType = "vscode-copilot"
 	AgentPi             AgentType = "pi"
 	AgentQwen           AgentType = "qwen"
+	AgentCommandCode    AgentType = "commandcode"
 	AgentOpenClaw       AgentType = "openclaw"
 	AgentQClaw          AgentType = "qclaw"
 	AgentKimi           AgentType = "kimi"
@@ -241,6 +242,17 @@ var Registry = []AgentDef{
 		FileBased:      true,
 		DiscoverFunc:   DiscoverQwenSessions,
 		FindSourceFunc: FindQwenSourceFile,
+	},
+	{
+		Type:           AgentCommandCode,
+		DisplayName:    "Command Code",
+		EnvVar:         "COMMANDCODE_PROJECTS_DIR",
+		ConfigKey:      "commandcode_project_dirs",
+		DefaultDirs:    []string{".commandcode/projects"},
+		IDPrefix:       "commandcode:",
+		FileBased:      true,
+		DiscoverFunc:   DiscoverCommandCodeSessions,
+		FindSourceFunc: FindCommandCodeSourceFile,
 	},
 	{
 		Type:           AgentOpenClaw,

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -265,6 +265,8 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentAmp,
 		AgentVSCodeCopilot,
 		AgentPi,
+		AgentQwen,
+		AgentCommandCode,
 		AgentOpenClaw,
 		AgentQClaw,
 		AgentKimi,
@@ -427,6 +429,16 @@ func TestOpenCodeRegistryEntry(t *testing.T) {
 	}
 	require.Truef(t, slices.Equal(def.WatchSubdirs, want),
 		"OpenCode WatchSubdirs = %v, want %v", def.WatchSubdirs, want)
+}
+
+func TestCommandCodeRegistryEntry(t *testing.T) {
+	def, ok := AgentByType(AgentCommandCode)
+	require.True(t, ok, "AgentCommandCode missing from Registry")
+	require.True(t, def.FileBased, "Command Code FileBased")
+	require.NotNil(t, def.DiscoverFunc, "Command Code DiscoverFunc")
+	require.NotNil(t, def.FindSourceFunc, "Command Code FindSourceFunc")
+	assert.Equal(t, []string{".commandcode/projects"}, def.DefaultDirs)
+	assert.Equal(t, "commandcode:", def.IDPrefix)
 }
 
 func TestResolveOpenCodeSourcePrefersStorage(t *testing.T) {

--- a/internal/sync/commandcode_integration_test.go
+++ b/internal/sync/commandcode_integration_test.go
@@ -1,0 +1,183 @@
+package sync_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+func TestSyncPathsCommandCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	commandCodeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCommandCode: {commandCodeDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "adc026b4-c620-43e4-8cc4-295593889d18"
+	projectDir := filepath.Join(commandCodeDir, "users-alice-code-sample-project")
+	path := filepath.Join(projectDir, sessionID+".jsonl")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755), "MkdirAll(%q)", projectDir)
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"id":"m1","timestamp":"2026-06-01T10:00:00Z","sessionId":"adc026b4-c620-43e4-8cc4-295593889d18","role":"user","content":[{"type":"text","text":"Inspect server logs"}],"gitBranch":"feature/command-code","metadata":{"version":2,"cwd":"/Users/alice/code/sample-project"}}
+{"id":"m2","timestamp":"2026-06-01T10:00:01Z","sessionId":"adc026b4-c620-43e4-8cc4-295593889d18","role":"assistant","content":[{"type":"text","text":"The error is in startup."}],"gitBranch":"feature/command-code","metadata":{"version":2}}
+`), 0o644), "WriteFile(%q)", path)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, sessionID+".meta.json"),
+		[]byte(`{"title":"Startup investigation"}`),
+		0o644,
+	), "WriteFile(meta)")
+
+	engine.SyncPaths([]string{path})
+
+	assertSessionState(t, testDB, "commandcode:"+sessionID, func(sess *db.Session) {
+		assert.Equal(t, "commandcode", sess.Agent)
+		assert.Equal(t, "sample_project", sess.Project)
+		require.NotNil(t, sess.FirstMessage)
+		assert.Equal(t, "Inspect server logs", *sess.FirstMessage)
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Startup investigation", *sess.DisplayName)
+		assert.Equal(t, 2, sess.MessageCount)
+		assert.Equal(t, 1, sess.UserMessageCount)
+	})
+}
+
+func TestSyncPathsCommandCodeMetaArrivalTriggersResync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	commandCodeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCommandCode: {commandCodeDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "adc026b4-c620-43e4-8cc4-295593889d18"
+	projectDir := filepath.Join(commandCodeDir, "users-alice-code-sample-project")
+	jsonlPath := filepath.Join(projectDir, sessionID+".jsonl")
+	metaPath := filepath.Join(projectDir, sessionID+".meta.json")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755), "MkdirAll(%q)", projectDir)
+	require.NoError(t, os.WriteFile(jsonlPath, []byte(
+		`{"id":"m1","timestamp":"2026-06-01T10:00:00Z","sessionId":"adc026b4-c620-43e4-8cc4-295593889d18","role":"user","content":[{"type":"text","text":"Inspect server logs"}],"gitBranch":"feature/command-code","metadata":{"version":2}}
+{"id":"m2","timestamp":"2026-06-01T10:00:01Z","sessionId":"adc026b4-c620-43e4-8cc4-295593889d18","role":"assistant","content":[{"type":"text","text":"The error is in startup."}],"gitBranch":"feature/command-code","metadata":{"version":2}}
+`), 0o644), "WriteFile(%q)", jsonlPath)
+
+	engine.SyncPaths([]string{jsonlPath})
+	assertSessionState(t, testDB, "commandcode:"+sessionID, func(sess *db.Session) {
+		assert.Equal(t, "users_alice_code_sample_project", sess.Project)
+		assert.Empty(t, sess.Cwd)
+	})
+
+	// Ensure the later meta file is included in the effective snapshot and
+	// reparses the unchanged transcript to fill fallback cwd/project metadata.
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"title":"Startup investigation","cwd":"/Users/alice/code/sample-project"}`), 0o644), "WriteFile(meta)")
+	require.NoError(t, os.Chtimes(metaPath, time.Now().Add(2*time.Second), time.Now().Add(2*time.Second)))
+
+	engine.SyncPaths([]string{metaPath})
+	assertSessionState(t, testDB, "commandcode:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Startup investigation", *sess.DisplayName)
+		assert.Equal(t, "sample_project", sess.Project)
+		assert.Equal(t, "/Users/alice/code/sample-project", sess.Cwd)
+	})
+}
+
+func TestSyncAllSinceCommandCodeMetaArrivalTriggersResync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	commandCodeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCommandCode: {commandCodeDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "adc026b4-c620-43e4-8cc4-295593889d18"
+	projectDir := filepath.Join(commandCodeDir, "users-alice-code-sample-project")
+	jsonlPath := filepath.Join(projectDir, sessionID+".jsonl")
+	metaPath := filepath.Join(projectDir, sessionID+".meta.json")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755), "MkdirAll(%q)", projectDir)
+	require.NoError(t, os.WriteFile(jsonlPath, []byte(
+		`{"id":"m1","timestamp":"2026-06-01T10:00:00Z","sessionId":"adc026b4-c620-43e4-8cc4-295593889d18","role":"user","content":[{"type":"text","text":"Inspect server logs"}],"gitBranch":"feature/command-code","metadata":{"version":2}}
+{"id":"m2","timestamp":"2026-06-01T10:00:01Z","sessionId":"adc026b4-c620-43e4-8cc4-295593889d18","role":"assistant","content":[{"type":"text","text":"The error is in startup."}],"gitBranch":"feature/command-code","metadata":{"version":2}}
+`), 0o644), "WriteFile(%q)", jsonlPath)
+
+	engine.SyncPaths([]string{jsonlPath})
+	assertSessionState(t, testDB, "commandcode:"+sessionID, func(sess *db.Session) {
+		assert.Equal(t, "users_alice_code_sample_project", sess.Project)
+		assert.Empty(t, sess.Cwd)
+	})
+
+	cutoff := time.Now()
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"title":"Startup investigation","cwd":"/Users/alice/code/sample-project"}`), 0o644), "WriteFile(meta)")
+	require.NoError(t, os.Chtimes(metaPath, time.Now().Add(2*time.Second), time.Now().Add(2*time.Second)))
+
+	stats := engine.SyncAllSince(context.Background(), cutoff, nil)
+	require.Equal(t, 1, stats.Synced, "synced = %d, want 1", stats.Synced)
+
+	assertSessionState(t, testDB, "commandcode:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Startup investigation", *sess.DisplayName)
+		assert.Equal(t, "sample_project", sess.Project)
+		assert.Equal(t, "/Users/alice/code/sample-project", sess.Cwd)
+	})
+}
+
+func TestSourceMtimeCommandCodeIncludesMetaMtime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	commandCodeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCommandCode: {commandCodeDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "adc026b4-c620-43e4-8cc4-295593889d18"
+	projectDir := filepath.Join(commandCodeDir, "users-alice-code-sample-project")
+	jsonlPath := filepath.Join(projectDir, sessionID+".jsonl")
+	metaPath := filepath.Join(projectDir, sessionID+".meta.json")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755), "MkdirAll(%q)", projectDir)
+	require.NoError(t, os.WriteFile(jsonlPath, []byte(
+		`{"id":"m1","timestamp":"2026-06-01T10:00:00Z","sessionId":"adc026b4-c620-43e4-8cc4-295593889d18","role":"user","content":[{"type":"text","text":"Inspect server logs"}],"metadata":{"version":2}}
+`), 0o644), "WriteFile(%q)", jsonlPath)
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"title":"Startup investigation"}`), 0o644), "WriteFile(meta)")
+
+	jsonlTime := time.Unix(1_717_238_800, 0)
+	metaTime := jsonlTime.Add(5 * time.Second)
+	require.NoError(t, os.Chtimes(jsonlPath, jsonlTime, jsonlTime))
+	require.NoError(t, os.Chtimes(metaPath, metaTime, metaTime))
+
+	engine.SyncPaths([]string{jsonlPath})
+	assert.Equal(t, metaTime.UnixNano(),
+		engine.SourceMtime("commandcode:"+sessionID))
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -863,6 +863,46 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
+	// Command Code: <projectsDir>/<slugified-cwd>/<session>.jsonl
+	for _, commandCodeDir := range e.agentDirs[parser.AgentCommandCode] {
+		if commandCodeDir == "" {
+			continue
+		}
+		if rel, ok := isUnder(commandCodeDir, path); ok {
+			parts := strings.Split(rel, sep)
+			if len(parts) != 2 {
+				continue
+			}
+			if sessionID, ok := strings.CutSuffix(parts[1], ".meta.json"); ok {
+				if !parser.IsValidSessionID(sessionID) {
+					continue
+				}
+				jsonlPath := filepath.Join(commandCodeDir, parts[0], sessionID+".jsonl")
+				if _, err := os.Stat(jsonlPath); err != nil {
+					continue
+				}
+				return parser.DiscoveredFile{
+					Path:    jsonlPath,
+					Project: parser.NormalizeName(parts[0]),
+					Agent:   parser.AgentCommandCode,
+				}, true
+			}
+			if strings.HasSuffix(parts[1], ".checkpoints.jsonl") ||
+				strings.HasSuffix(parts[1], ".prompts.jsonl") {
+				continue
+			}
+			sessionID, ok := strings.CutSuffix(parts[1], ".jsonl")
+			if !ok || !parser.IsValidSessionID(sessionID) {
+				continue
+			}
+			return parser.DiscoveredFile{
+				Path:    path,
+				Project: parser.NormalizeName(parts[0]),
+				Agent:   parser.AgentCommandCode,
+			}, true
+		}
+	}
+
 	// OpenClaw: <openclawDir>/<agentId>/sessions/<sessionId>.jsonl
 	//       or: <openclawDir>/<agentId>/sessions/<sessionId>.jsonl.<archiveSuffix>
 	for _, ocDir := range e.agentDirs[parser.AgentOpenClaw] {
@@ -2283,6 +2323,13 @@ func discoveredFileMtime(
 		}
 		return info.ModTime().UnixNano(), nil
 	}
+	if file.Agent == parser.AgentCommandCode {
+		info, err := os.Stat(file.Path)
+		if err != nil {
+			return 0, err
+		}
+		return commandCodeEffectiveInfo(file.Path, info).ModTime().UnixNano(), nil
+	}
 
 	info, err := os.Stat(file.Path)
 	if err != nil {
@@ -2961,6 +3008,8 @@ func (e *Engine) processFile(
 		res = e.processPi(file, info)
 	case parser.AgentQwen:
 		res = e.processQwen(file, info)
+	case parser.AgentCommandCode:
+		res = e.processCommandCode(file, info)
 	case parser.AgentOpenClaw:
 		res = e.processOpenClaw(file, info)
 	case parser.AgentQClaw:
@@ -4410,6 +4459,52 @@ func (e *Engine) processQwen(
 	}
 }
 
+func (e *Engine) processCommandCode(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	effectiveInfo := commandCodeEffectiveInfo(file.Path, info)
+	if e.shouldSkipByPath(file.Path, effectiveInfo) {
+		return processResult{skip: true}
+	}
+
+	sess, msgs, err := parser.ParseCommandCodeSession(
+		file.Path, e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if sess == nil {
+		return processResult{}
+	}
+
+	hash, err := ComputeFileHash(file.Path)
+	if err == nil {
+		sess.File.Hash = hash
+	}
+	sess.File.Size = effectiveInfo.Size()
+	sess.File.Mtime = effectiveInfo.ModTime().UnixNano()
+
+	return processResult{
+		results: []parser.ParseResult{{
+			Session:  *sess,
+			Messages: msgs,
+		}},
+	}
+}
+
+func commandCodeEffectiveInfo(path string, info os.FileInfo) os.FileInfo {
+	size := info.Size()
+	mtime := info.ModTime().UnixNano()
+	metaPath := strings.TrimSuffix(path, ".jsonl") + ".meta.json"
+	if metaInfo, err := os.Stat(metaPath); err == nil {
+		size += metaInfo.Size()
+		if metaMtime := metaInfo.ModTime().UnixNano(); metaMtime > mtime {
+			mtime = metaMtime
+		}
+	}
+	return fakeSnapshotInfo{fSize: size, fMtime: mtime}
+}
+
 // validateCursorContainment re-resolves both root and path
 // to verify the file still resides within the cursor projects
 // directory. Returns an error if containment fails.
@@ -5574,6 +5669,13 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 			return 0
 		}
 		return info.ModTime().UnixNano()
+	}
+	if def.Type == parser.AgentCommandCode {
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0
+		}
+		return commandCodeEffectiveInfo(path, info).ModTime().UnixNano()
 	}
 
 	info, err := os.Stat(path)

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -928,6 +928,23 @@ func TestShouldSkipByPathWithRewriter(t *testing.T) {
 	assert.False(t, got2, "shouldSkipByPath without rewriter should return false")
 }
 
+func TestToDBSessionStoresSessionName(t *testing.T) {
+	pw := pendingWrite{sess: parser.ParsedSession{
+		ID:           "commandcode:test",
+		Project:      "sample_project",
+		Machine:      "local",
+		Agent:        parser.AgentCommandCode,
+		SessionName:  "Startup investigation",
+		FirstMessage: "Inspect server logs",
+	}}
+
+	got := toDBSession(pw)
+	require.NotNil(t, got.SessionName)
+	assert.Equal(t, "Startup investigation", *got.SessionName)
+	require.NotNil(t, got.FirstMessage)
+	assert.Equal(t, "Inspect server logs", *got.FirstMessage)
+}
+
 func TestBlockedCategorySet(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -1480,6 +1497,50 @@ func TestEngine_ClassifyPathsQwenSession(t *testing.T) {
 	}
 	got := engine.classifyPaths(bogus)
 	assert.Empty(t, got, "expected no Qwen classifications for %v, got %v", bogus, got)
+}
+
+func TestEngine_ClassifyPathsCommandCodeSession(t *testing.T) {
+	db := openTestDB(t)
+	commandCodeDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCommandCode: {commandCodeDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "adc026b4-c620-43e4-8cc4-295593889d18"
+	projectDir := filepath.Join(commandCodeDir, "users-alice-code-sample-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755), "MkdirAll(%q)", projectDir)
+	sessionPath := filepath.Join(projectDir, sessionID+".jsonl")
+	dbtest.WriteTestFile(t, sessionPath, []byte("{}\n"))
+
+	files := engine.classifyPaths([]string{sessionPath})
+	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
+	assert.Equal(t, sessionPath, files[0].Path)
+	assert.Equal(t, parser.AgentCommandCode, files[0].Agent)
+	assert.Equal(t, "users_alice_code_sample_project", files[0].Project)
+
+	bogus := []string{
+		filepath.Join(commandCodeDir, "stray.jsonl"),
+		filepath.Join(projectDir, "notes.txt"),
+		filepath.Join(projectDir, sessionID+".checkpoints.jsonl"),
+		filepath.Join(projectDir, sessionID+".prompts.jsonl"),
+		filepath.Join(projectDir, "nested", sessionID+".jsonl"),
+	}
+	for _, p := range bogus {
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755), "MkdirAll(%q)", p)
+		dbtest.WriteTestFile(t, p, []byte("{}"))
+	}
+	got := engine.classifyPaths(bogus)
+	assert.Empty(t, got, "expected no Command Code classifications for %v, got %v", bogus, got)
+
+	metaPath := filepath.Join(projectDir, sessionID+".meta.json")
+	dbtest.WriteTestFile(t, metaPath, []byte("{}"))
+	files = engine.classifyPaths([]string{metaPath})
+	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
+	assert.Equal(t, sessionPath, files[0].Path)
+	assert.Equal(t, parser.AgentCommandCode, files[0].Agent)
 }
 
 func TestEngine_ClassifyPathsQClawSession(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a Command Code file-based parser and transcript discovery for ~/.commandcode/projects
- register the new agent and wire it into sync processing
- add parser and registry tests for Command Code sessions

## Testing
- mise exec -- go test ./internal/parser ./internal/sync