### PR TITLE
fix(postgres): create content trigram index with fastupdate=off

### DIFF
--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -722,6 +722,18 @@ func createContentSearchIndexesPG(ctx context.Context, db *sql.DB) {
 		log.Printf(
 			"pg schema: creating messages.content trigram index failed: %v", err,
 		)
+		return
+	}
+	// CREATE INDEX IF NOT EXISTS only applies WITH (fastupdate = off) on
+	// first creation. Re-apply on every boot so stores upgraded from a
+	// prior schema (which left fastupdate=on) also get the bounded index.
+	if _, err := db.ExecContext(ctx,
+		`ALTER INDEX idx_messages_content_trgm SET (fastupdate = off)`,
+	); err != nil {
+		log.Printf(
+			"pg schema: disabling fastupdate on messages.content trigram index failed: %v",
+			err,
+		)
 	}
 }
 

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -711,9 +711,13 @@ func createContentSearchIndexesPG(ctx context.Context, db *sql.DB) {
 		log.Printf("pg schema: invalid pg_trgm schema %q: %v", extSchema, err)
 		return
 	}
+	// fastupdate=off keeps the index bounded: the default fastupdate=on
+	// buffers inserts into a pending list that only VACUUM merges, which grows
+	// unbounded when continuous ingest starves autovacuum.
 	if _, err := db.ExecContext(ctx, fmt.Sprintf(
 		`CREATE INDEX IF NOT EXISTS idx_messages_content_trgm
-		 ON messages USING gin (content %s.gin_trgm_ops)`, quotedExt,
+		 ON messages USING gin (content %s.gin_trgm_ops)
+		 WITH (fastupdate = off)`, quotedExt,
 	)); err != nil {
 		log.Printf(
 			"pg schema: creating messages.content trigram index failed: %v", err,

--- a/internal/postgres/search_content_pgtest_test.go
+++ b/internal/postgres/search_content_pgtest_test.go
@@ -481,6 +481,24 @@ func TestPGContentSearchTrigramIndex(t *testing.T) {
 	).Scan(&hasIdx), "query pg_indexes")
 	assert.True(t, hasIdx,
 		"idx_messages_content_trgm missing after EnsureSchema")
+
+	// fastupdate=off must be set so the pending list cannot grow
+	// unbounded under continuous ingest. The schema bootstrap applies
+	// this on every boot (including stores upgraded from an earlier
+	// schema that created the index with the default fastupdate=on).
+	var fastupdateOff bool
+	require.NoError(t, store.DB().QueryRowContext(ctx,
+		`SELECT EXISTS (
+			SELECT 1
+			  FROM pg_class c
+			  JOIN pg_namespace n ON n.oid = c.relnamespace
+			 WHERE n.nspname = $1
+			   AND c.relname = 'idx_messages_content_trgm'
+			   AND 'fastupdate=off' = ANY(c.reloptions)
+		)`, contentSearchSchema,
+	).Scan(&fastupdateOff), "query pg_class.reloptions")
+	assert.True(t, fastupdateOff,
+		"idx_messages_content_trgm must have fastupdate=off")
 }
 
 // TestPGSearchContentRegex verifies regex mode.

--- a/internal/postgres/search_content_pgtest_test.go
+++ b/internal/postgres/search_content_pgtest_test.go
@@ -501,6 +501,53 @@ func TestPGContentSearchTrigramIndex(t *testing.T) {
 		"idx_messages_content_trgm must have fastupdate=off")
 }
 
+// TestPGContentSearchTrigramIndexUpgrade verifies the upgrade path: a store
+// whose trigram index was created by an earlier schema with the default
+// fastupdate=on gets fastupdate=off reapplied on the next EnsureSchema run.
+func TestPGContentSearchTrigramIndexUpgrade(t *testing.T) {
+	store := setupContentSearch(t)
+	ctx := context.Background()
+
+	hasFastupdateOff := func() bool {
+		var off bool
+		require.NoError(t, store.DB().QueryRowContext(ctx,
+			`SELECT EXISTS (
+				SELECT 1
+				  FROM pg_class c
+				  JOIN pg_namespace n ON n.oid = c.relnamespace
+				 WHERE n.nspname = $1
+				   AND c.relname = 'idx_messages_content_trgm'
+				   AND 'fastupdate=off' = ANY(c.reloptions)
+			)`, contentSearchSchema,
+		).Scan(&off), "query pg_class.reloptions")
+		return off
+	}
+
+	var hasIdx bool
+	require.NoError(t, store.DB().QueryRowContext(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM pg_indexes
+			WHERE schemaname = $1 AND indexname = 'idx_messages_content_trgm'
+		)`, contentSearchSchema,
+	).Scan(&hasIdx), "query pg_indexes")
+	if !hasIdx {
+		t.Skip("trigram index not created on this instance; index is best-effort")
+	}
+
+	// Simulate an index left behind by the pre-#606 schema, which created
+	// it with the PostgreSQL default fastupdate=on.
+	_, err := store.DB().ExecContext(ctx,
+		`ALTER INDEX idx_messages_content_trgm SET (fastupdate = on)`)
+	require.NoError(t, err, "reset index to fastupdate=on")
+	require.False(t, hasFastupdateOff(),
+		"precondition: index should report fastupdate=on")
+
+	require.NoError(t, EnsureSchema(ctx, store.DB(), contentSearchSchema),
+		"rerun EnsureSchema")
+	assert.True(t, hasFastupdateOff(),
+		"EnsureSchema must reapply fastupdate=off to a pre-existing index")
+}
+
 // TestPGSearchContentRegex verifies regex mode.
 func TestPGSearchContentRegex(t *testing.T) {
 	store := setupContentSearch(t)


### PR DESCRIPTION
Closes #605.

Adds `WITH (fastupdate = off)` to the `idx_messages_content_trgm` creation in `createContentSearchIndexesPG`, and reapplies it idempotently via `ALTER INDEX` on every schema bootstrap so stores upgraded from a schema that created the index with the default `fastupdate=on` are covered too. A pgtest assertion guards `reloptions`. See #605 for the diagnosis and impact.

**Validation:** recreating the index with `fastupdate=off` reduced the same data from 283 GB to 388 MB.

Existing over-sized indexes stop growing immediately; a one-time `REINDEX` reclaims space already consumed.