### PR TITLE
Improve CockroachDB analytics query performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,27 @@ Instructions for autonomous coding agents working in this repository.
 - After Go code changes, run `go fmt ./...` and `go vet ./...` before
   committing.
 
+## Backend Parity
+
+- Preserve behavior and query-shape parity between supported storage backends
+  whenever practical. SQLite and PostgreSQL/Cockroach queries, indexes,
+  aggregations, filtering, and ordering should match until there is a concrete,
+  documented reason for them to differ.
+- Do not implement a performance or correctness fix for only one backend and
+  call the problem solved unless the user explicitly scopes the work to that
+  backend, for example "this is only for PostgreSQL". If one backend needs a
+  different implementation, explain why and keep the observable behavior the
+  same.
+
+## Test Style
+
+- Go tests use `github.com/stretchr/testify` for assertions. Use `require.X`
+  when a failed check should abort the test (setup, nil receivers, length checks
+  before indexing) and `assert.X` for independent checks that should keep
+  running. Don't write `if got != want { t.Fatalf(...) }` in new tests.
+- Domain-specific helpers are fine, but they must use testify internally rather
+  than stdlib comparisons.
+
 ## Safety
 
 - Do not revert user-authored or unrelated local changes unless explicitly

--- a/frontend/src/lib/api/generated/services/UsageService.ts
+++ b/frontend/src/lib/api/generated/services/UsageService.ts
@@ -2,11 +2,130 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { Comparison } from '../models/Comparison';
 import type { UsageSummaryResponse } from '../models/UsageSummaryResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 export class UsageService {
+  /**
+   * Get usage comparison
+   * @returns Comparison OK
+   * @throws ApiError
+   */
+  public static getApiV1UsageComparison({
+    currentCost,
+    from,
+    to,
+    timezone,
+    agent,
+    project,
+    machine,
+    excludeProject,
+    excludeAgent,
+    excludeModel,
+    model,
+    minUserMessages,
+    activeSince,
+    includeOneShot = true,
+    includeAutomated,
+  }: {
+    /**
+     * Current period total cost
+     */
+    currentCost: number,
+    /**
+     * Range start date
+     */
+    from?: string,
+    /**
+     * Range end date
+     */
+    to?: string,
+    /**
+     * IANA timezone name
+     */
+    timezone?: string,
+    /**
+     * Filter by agent
+     */
+    agent?: string,
+    /**
+     * Filter by project
+     */
+    project?: string,
+    /**
+     * Filter by machine
+     */
+    machine?: string,
+    /**
+     * Exclude a project
+     */
+    excludeProject?: string,
+    /**
+     * Exclude an agent
+     */
+    excludeAgent?: string,
+    /**
+     * Exclude a model
+     */
+    excludeModel?: string,
+    /**
+     * Filter by model
+     */
+    model?: string,
+    /**
+     * Minimum user message count
+     */
+    minUserMessages?: number,
+    /**
+     * Filter sessions active since this RFC3339 timestamp
+     */
+    activeSince?: string,
+    /**
+     * Include one-shot sessions
+     */
+    includeOneShot?: boolean,
+    /**
+     * Include automated sessions
+     */
+    includeAutomated?: boolean,
+  }): CancelablePromise<Comparison> {
+    return __request(OpenAPI, {
+      method: 'GET',
+      url: '/api/v1/usage/comparison',
+      query: {
+        'from': from,
+        'to': to,
+        'timezone': timezone,
+        'agent': agent,
+        'project': project,
+        'machine': machine,
+        'exclude_project': excludeProject,
+        'exclude_agent': excludeAgent,
+        'exclude_model': excludeModel,
+        'model': model,
+        'min_user_messages': minUserMessages,
+        'active_since': activeSince,
+        'include_one_shot': includeOneShot,
+        'include_automated': includeAutomated,
+        'current_cost': currentCost,
+      },
+      errors: {
+        400: `Bad Request`,
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        404: `Not Found`,
+        409: `Conflict`,
+        422: `Unprocessable Entity`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+        502: `Bad Gateway`,
+        503: `Service Unavailable`,
+        504: `Gateway Timeout`,
+      },
+    });
+  }
   /**
    * Get usage summary
    * @returns UsageSummaryResponse OK

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -11,7 +11,10 @@ import type {
   SignalsAnalyticsResponse,
 } from "../api/types.js";
 import { AnalyticsService } from "../api/generated/index";
-import { callGenerated } from "../api/runtime.js";
+import {
+  callGenerated,
+  isAbortError,
+} from "../api/runtime.js";
 import { sessions } from "./sessions.svelte.js";
 
 type AnalyticsParams = Parameters<
@@ -128,6 +131,7 @@ class AnalyticsStore {
     topSessions: 0,
     signals: 0,
   };
+  private abortControllers: Partial<Record<Panel, AbortController>> = {};
 
   get timezone(): string {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -400,6 +404,7 @@ class AnalyticsStore {
     hasExistingData: () => boolean = () => false,
   ) {
     const v = ++this.versions[panel];
+    const signal = this.nextAbortSignal(panel);
     // Only show the skeleton when we don't already have data to
     // display. Refetches triggered by live events or filter changes
     // replace data in place instead of flashing to loading state.
@@ -410,12 +415,13 @@ class AnalyticsStore {
     // fresh.
     if (isFirstLoad) this.errors[panel] = null;
     try {
-      const data = await callGenerated(fetchRequest);
+      const data = await callGenerated(fetchRequest, signal);
       if (this.versions[panel] === v) {
         onSuccess(data);
         this.errors[panel] = null;
       }
     } catch (e) {
+      if (isAbortError(e)) return;
       if (this.versions[panel] === v) {
         // On refetch failure with cached data, swallow the error so
         // existing values stay visible instead of flipping to an
@@ -428,9 +434,26 @@ class AnalyticsStore {
         }
       }
     } finally {
+      this.clearAbortSignal(panel, signal);
       if (this.versions[panel] === v) {
         this.loading[panel] = false;
       }
+    }
+  }
+
+  private nextAbortSignal(panel: Panel): AbortSignal {
+    this.abortControllers[panel]?.abort();
+    const controller = new AbortController();
+    this.abortControllers[panel] = controller;
+    return controller.signal;
+  }
+
+  private clearAbortSignal(
+    panel: Panel,
+    signal: AbortSignal,
+  ): void {
+    if (this.abortControllers[panel]?.signal === signal) {
+      delete this.abortControllers[panel];
     }
   }
 

--- a/frontend/src/lib/stores/analytics.test.ts
+++ b/frontend/src/lib/stores/analytics.test.ts
@@ -8,6 +8,7 @@ import {
 } from "vitest";
 import { analytics } from "./analytics.svelte.js";
 import { AnalyticsService } from "../api/generated/index";
+import { callGenerated } from "../api/runtime.js";
 import type {
   AnalyticsSummary,
   ActivityResponse,
@@ -23,6 +24,7 @@ import type {
 vi.mock("../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
   callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  isAbortError: vi.fn(() => false),
 }));
 
 vi.mock("../api/generated/index", () => ({
@@ -637,6 +639,27 @@ describe("executeFetch concurrency and error handling", () => {
     resolveSecond(makeSummary());
     await secondFetch;
     expect(analytics.loading.summary).toBe(false);
+  });
+
+  it("aborts stale panel requests when a newer fetch starts", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    vi.mocked(callGenerated).mockImplementation(
+      (request: () => Promise<unknown>, signal?: AbortSignal) => {
+        signals.push(signal);
+        return request();
+      },
+    );
+    vi.mocked(analyticsService.getApiV1AnalyticsSummary)
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce(makeSummary());
+
+    void analytics.fetchSummary();
+    await Promise.resolve();
+    void analytics.fetchSummary();
+    await Promise.resolve();
+
+    expect(signals[0]).toBeDefined();
+    expect(signals[0]?.aborted).toBe(true);
   });
 });
 

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -416,6 +416,7 @@ class UsageStore {
   ): Promise<LoadedUsageSummary | null> {
     const loadComparison = options.loadComparison ?? true;
     const v = ++this.versions.summary;
+    this.abortPanel("comparison");
     const signal = this.nextAbortSignal("summary");
     // Only show the skeleton when we don't already have data to
     // display. Refetches triggered by live events or filter changes
@@ -527,6 +528,10 @@ class UsageStore {
 
   private invalidatePanel(panel: Endpoint): void {
     this.versions[panel]++;
+    this.abortPanel(panel);
+  }
+
+  private abortPanel(panel: UsagePanel): void {
     this.abortControllers[panel]?.abort();
     delete this.abortControllers[panel];
   }

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -393,13 +393,14 @@ class UsageStore {
 
   async fetchAll() {
     const fetchVersion = ++this.fetchAllVersion;
+    this.invalidatePanel("topSessions");
     this.rollDates();
     saveUsageFilters(this);
     const loadedSummary = await this.fetchSummary({
       loadComparison: false,
     });
-    if (fetchVersion !== this.fetchAllVersion) return;
-    await this.fetchTopSessions();
+    if (fetchVersion !== this.fetchAllVersion || !loadedSummary) return;
+    await this.fetchTopSessions(loadedSummary.params);
     if (fetchVersion !== this.fetchAllVersion) return;
     if (loadedSummary) {
       void this.fetchComparison(
@@ -466,6 +467,7 @@ class UsageStore {
     summary: UsageSummaryResponse,
     params: UsageParams,
   ) {
+    if (this.versions.summary !== summaryVersion) return;
     const signal = this.nextAbortSignal("comparison");
     try {
       const comparison = await callGenerated(() =>
@@ -488,7 +490,7 @@ class UsageStore {
     }
   }
 
-  async fetchTopSessions() {
+  async fetchTopSessions(params: UsageParams | null = null) {
     const v = ++this.versions.topSessions;
     const signal = this.nextAbortSignal("topSessions");
     const isFirstLoad = this.topSessions === null;
@@ -496,7 +498,9 @@ class UsageStore {
     if (isFirstLoad) this.errors.topSessions = null;
     try {
       const data = await callGenerated(() =>
-        UsageService.getApiV1UsageTopSessions(this.baseParams()),
+        UsageService.getApiV1UsageTopSessions(
+          params ?? this.baseParams(),
+        ),
         signal,
       ) as unknown as TopUsageSessionsResponse;
       if (this.versions.topSessions === v) {
@@ -519,6 +523,12 @@ class UsageStore {
         this.loading.topSessions = false;
       }
     }
+  }
+
+  private invalidatePanel(panel: Endpoint): void {
+    this.versions[panel]++;
+    this.abortControllers[panel]?.abort();
+    delete this.abortControllers[panel];
   }
 
   private nextAbortSignal(panel: UsagePanel): AbortSignal {

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -1,12 +1,22 @@
 import type {
+  UsageComparison,
   UsageSummaryResponse,
   TopUsageSessionsResponse,
 } from "../api/types/usage.js";
 import { UsageService } from "../api/generated/index";
-import { callGenerated } from "../api/runtime.js";
+import {
+  callGenerated,
+  isAbortError,
+} from "../api/runtime.js";
 import { sessions } from "./sessions.svelte.js";
 
 type UsageParams = Parameters<typeof UsageService.getApiV1UsageSummary>[0];
+type UsagePanel = "summary" | "comparison" | "topSessions";
+type LoadedUsageSummary = {
+  version: number;
+  summary: UsageSummaryResponse;
+  params: UsageParams;
+};
 
 export type GroupBy = "project" | "model" | "agent";
 export type TimeSeriesView = "stacked-area" | "bars" | "lines";
@@ -192,6 +202,8 @@ class UsageStore {
     summary: 0,
     topSessions: 0,
   };
+  private fetchAllVersion = 0;
+  private abortControllers: Partial<Record<UsagePanel, AbortController>> = {};
 
   private get timezone(): string {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -380,16 +392,30 @@ class UsageStore {
   }
 
   async fetchAll() {
+    const fetchVersion = ++this.fetchAllVersion;
     this.rollDates();
     saveUsageFilters(this);
-    await Promise.all([
-      this.fetchSummary(),
-      this.fetchTopSessions(),
-    ]);
+    const loadedSummary = await this.fetchSummary({
+      loadComparison: false,
+    });
+    if (fetchVersion !== this.fetchAllVersion) return;
+    await this.fetchTopSessions();
+    if (fetchVersion !== this.fetchAllVersion) return;
+    if (loadedSummary) {
+      void this.fetchComparison(
+        loadedSummary.version,
+        loadedSummary.summary,
+        loadedSummary.params,
+      );
+    }
   }
 
-  async fetchSummary() {
+  async fetchSummary(
+    options: { loadComparison?: boolean } = {},
+  ): Promise<LoadedUsageSummary | null> {
+    const loadComparison = options.loadComparison ?? true;
     const v = ++this.versions.summary;
+    const signal = this.nextAbortSignal("summary");
     // Only show the skeleton when we don't already have data to
     // display. Refetches triggered by live events or filter changes
     // replace data in place instead of flashing to loading state.
@@ -399,14 +425,22 @@ class UsageStore {
     // error state in place until we have a definitive result.
     if (isFirstLoad) this.errors.summary = null;
     try {
+      const params = this.baseParams();
       const data = await callGenerated(() =>
-        UsageService.getApiV1UsageSummary(this.baseParams()),
+        UsageService.getApiV1UsageSummary(params),
+        signal,
       ) as unknown as UsageSummaryResponse;
       if (this.versions.summary === v) {
         this.summary = data;
         this.errors.summary = null;
+        const loaded = { version: v, summary: data, params };
+        if (loadComparison) {
+          void this.fetchComparison(v, data, params);
+        }
+        return loaded;
       }
     } catch (e) {
+      if (isAbortError(e)) return null;
       if (this.versions.summary === v) {
         // On refetch failure with cached data, swallow the error so
         // existing values stay visible instead of flipping to a "--"
@@ -419,26 +453,58 @@ class UsageStore {
         }
       }
     } finally {
+      this.clearAbortSignal("summary", signal);
       if (this.versions.summary === v) {
         this.loading.summary = false;
       }
+    }
+    return null;
+  }
+
+  private async fetchComparison(
+    summaryVersion: number,
+    summary: UsageSummaryResponse,
+    params: UsageParams,
+  ) {
+    const signal = this.nextAbortSignal("comparison");
+    try {
+      const comparison = await callGenerated(() =>
+        UsageService.getApiV1UsageComparison({
+          ...params,
+          currentCost: summary.totals.totalCost,
+        }),
+        signal,
+      ) as unknown as UsageComparison;
+      if (this.versions.summary === summaryVersion) {
+        this.summary = { ...summary, comparison };
+      }
+    } catch (e) {
+      if (isAbortError(e)) return;
+      if (this.versions.summary === summaryVersion) {
+        console.warn("usage.fetchComparison failed:", e);
+      }
+    } finally {
+      this.clearAbortSignal("comparison", signal);
     }
   }
 
   async fetchTopSessions() {
     const v = ++this.versions.topSessions;
+    const signal = this.nextAbortSignal("topSessions");
     const isFirstLoad = this.topSessions === null;
     if (isFirstLoad) this.loading.topSessions = true;
     if (isFirstLoad) this.errors.topSessions = null;
     try {
       const data = await callGenerated(() =>
         UsageService.getApiV1UsageTopSessions(this.baseParams()),
+        signal,
       ) as unknown as TopUsageSessionsResponse;
       if (this.versions.topSessions === v) {
         this.topSessions = data;
         this.errors.topSessions = null;
       }
     } catch (e) {
+      if (isAbortError(e)) return;
       if (this.versions.topSessions === v) {
         if (this.topSessions === null) {
           this.errors.topSessions =
@@ -448,9 +514,26 @@ class UsageStore {
         }
       }
     } finally {
+      this.clearAbortSignal("topSessions", signal);
       if (this.versions.topSessions === v) {
         this.loading.topSessions = false;
       }
+    }
+  }
+
+  private nextAbortSignal(panel: UsagePanel): AbortSignal {
+    this.abortControllers[panel]?.abort();
+    const controller = new AbortController();
+    this.abortControllers[panel] = controller;
+    return controller.signal;
+  }
+
+  private clearAbortSignal(
+    panel: UsagePanel,
+    signal: AbortSignal,
+  ): void {
+    if (this.abortControllers[panel]?.signal === signal) {
+      delete this.abortControllers[panel];
     }
   }
 }

--- a/frontend/src/lib/stores/usage.test.ts
+++ b/frontend/src/lib/stores/usage.test.ts
@@ -36,17 +36,28 @@ const usageServiceMocks = vi.hoisted(() => ({
       savingsVsUncached: 0,
     },
   }),
+  getApiV1UsageComparison: vi.fn().mockResolvedValue({
+    priorFrom: "2023-12-01",
+    priorTo: "2023-12-31",
+    priorTotalCost: 1,
+    deltaPct: 0.5,
+  }),
   getApiV1UsageTopSessions: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("../api/runtime.js", () => ({
+const apiRuntimeMocks = vi.hoisted(() => ({
   configureGeneratedClient: vi.fn(),
   callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  isAbortError: vi.fn(() => false),
 }));
+
+vi.mock("../api/runtime.js", () => apiRuntimeMocks);
 
 vi.mock("../api/generated/index", () => ({
   UsageService: {
     getApiV1UsageSummary: usageServiceMocks.getApiV1UsageSummary,
+    getApiV1UsageComparison:
+      usageServiceMocks.getApiV1UsageComparison,
     getApiV1UsageTopSessions: usageServiceMocks.getApiV1UsageTopSessions,
   },
 }));
@@ -219,6 +230,161 @@ describe("UsageStore session filter params", () => {
         includeAutomated: true,
       }),
     );
+  });
+
+  it("waits for summary before requesting follow-up usage data", async () => {
+    const calls: string[] = [];
+    let resolveSummary:
+      | ((value: unknown) => void)
+      | undefined;
+    const summaryPromise = new Promise((resolve) => {
+      resolveSummary = resolve;
+    });
+    usageServiceMocks.getApiV1UsageSummary.mockImplementationOnce(
+      () => {
+        calls.push("summary");
+        return summaryPromise;
+      },
+    );
+    usageServiceMocks.getApiV1UsageTopSessions.mockImplementationOnce(
+      () => {
+        calls.push("topSessions");
+        return Promise.resolve([]);
+      },
+    );
+    usageServiceMocks.getApiV1UsageComparison.mockImplementationOnce(
+      () => {
+        calls.push("comparison");
+        return Promise.resolve({
+          priorFrom: "2023-12-01",
+          priorTo: "2023-12-31",
+          priorTotalCost: 1,
+          deltaPct: 0.5,
+        });
+      },
+    );
+
+    const { usage } = await loadStore();
+    const fetch = usage.fetchAll();
+    await Promise.resolve();
+
+    expect(calls).toEqual(["summary"]);
+    expect(usage.summary).toBeNull();
+
+    resolveSummary?.({
+      from: "2024-01-01",
+      to: "2024-01-31",
+      totals: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalCost: 0,
+      },
+      daily: [],
+      projectTotals: [],
+      modelTotals: [],
+      agentTotals: [],
+      sessionCounts: {
+        total: 0,
+        byProject: {},
+        byAgent: {},
+      },
+      cacheStats: {
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        uncachedInputTokens: 0,
+        outputTokens: 0,
+        hitRate: 0,
+        savingsVsUncached: 0,
+      },
+    });
+    await fetch;
+    await Promise.resolve();
+
+    expect(calls).toEqual(["summary", "topSessions", "comparison"]);
+    expect(usage.summary).not.toBeNull();
+    expect(usage.summary?.comparison).toEqual({
+      priorFrom: "2023-12-01",
+      priorTo: "2023-12-31",
+      priorTotalCost: 1,
+      deltaPct: 0.5,
+    });
+    expect(
+      usageServiceMocks.getApiV1UsageComparison,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ currentCost: 0 }),
+    );
+  });
+
+  it("refreshes comparison when summary is refreshed directly", async () => {
+    const { usage } = await loadStore();
+
+    await usage.fetchSummary();
+    await Promise.resolve();
+
+    expect(
+      usageServiceMocks.getApiV1UsageComparison,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      usageServiceMocks.getApiV1UsageTopSessions,
+    ).not.toHaveBeenCalled();
+    expect(usage.summary?.comparison).toEqual({
+      priorFrom: "2023-12-01",
+      priorTo: "2023-12-31",
+      priorTotalCost: 1,
+      deltaPct: 0.5,
+    });
+  });
+
+  it("aborts stale summary requests when a newer fetch starts", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation(
+      (request: () => Promise<unknown>, signal?: AbortSignal) => {
+        signals.push(signal);
+        return request();
+      },
+    );
+    usageServiceMocks.getApiV1UsageSummary
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce({
+        from: "2024-01-01",
+        to: "2024-01-31",
+        totals: {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+          totalCost: 0,
+        },
+        daily: [],
+        projectTotals: [],
+        modelTotals: [],
+        agentTotals: [],
+        sessionCounts: {
+          total: 0,
+          byProject: {},
+          byAgent: {},
+        },
+        cacheStats: {
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          uncachedInputTokens: 0,
+          outputTokens: 0,
+          hitRate: 0,
+          savingsVsUncached: 0,
+        },
+      });
+
+    const { usage } = await loadStore();
+
+    void usage.fetchSummary();
+    await Promise.resolve();
+    void usage.fetchSummary();
+    await Promise.resolve();
+
+    expect(signals[0]).toBeDefined();
+    expect(signals[0]?.aborted).toBe(true);
   });
 });
 

--- a/frontend/src/lib/stores/usage.test.ts
+++ b/frontend/src/lib/stores/usage.test.ts
@@ -486,6 +486,50 @@ describe("UsageStore session filter params", () => {
     await currentComparison;
   });
 
+  it("aborts active comparison when a newer summary starts", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation(
+      (request: () => Promise<unknown>, signal?: AbortSignal) => {
+        signals.push(signal);
+        return request();
+      },
+    );
+
+    const { usage } = await loadStore();
+    const loaded = await usage.fetchSummary({ loadComparison: false });
+    expect(loaded).not.toBeNull();
+    if (!loaded) return;
+    const loadedSummary = loaded;
+
+    usageServiceMocks.getApiV1UsageComparison.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+    const compare = usage as unknown as {
+      fetchComparison: (
+        summaryVersion: number,
+        summary: UsageSummaryResponse,
+        params: typeof loadedSummary.params,
+      ) => Promise<void>;
+    };
+    void compare.fetchComparison(
+      loadedSummary.version,
+      loadedSummary.summary,
+      loadedSummary.params,
+    );
+    await Promise.resolve();
+    const comparisonSignal = signals[1];
+    expect(comparisonSignal).toBeDefined();
+    expect(comparisonSignal?.aborted).toBe(false);
+
+    usageServiceMocks.getApiV1UsageSummary.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+    void usage.fetchSummary({ loadComparison: false });
+    await Promise.resolve();
+
+    expect(comparisonSignal?.aborted).toBe(true);
+  });
+
   it("refreshes comparison when summary is refreshed directly", async () => {
     const { usage } = await loadStore();
 

--- a/frontend/src/lib/stores/usage.test.ts
+++ b/frontend/src/lib/stores/usage.test.ts
@@ -6,6 +6,10 @@ import {
   it,
   vi,
 } from "vitest";
+import type {
+  UsageComparison,
+  UsageSummaryResponse,
+} from "../api/types/usage.js";
 
 const usageServiceMocks = vi.hoisted(() => ({
   getApiV1UsageSummary: vi.fn().mockResolvedValue({
@@ -90,6 +94,52 @@ async function loadStore() {
   vi.resetModules();
   return import("./usage.svelte.js");
 }
+
+function usageSummary(totalCost = 0): UsageSummaryResponse {
+  return {
+    from: "2024-01-01",
+    to: "2024-01-31",
+    totals: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      totalCost,
+    },
+    daily: [],
+    projectTotals: [],
+    modelTotals: [],
+    agentTotals: [],
+    sessionCounts: {
+      total: 0,
+      byProject: {},
+      byAgent: {},
+    },
+    cacheStats: {
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      uncachedInputTokens: 0,
+      outputTokens: 0,
+      hitRate: 0,
+      savingsVsUncached: 0,
+    },
+  };
+}
+
+function usageComparison(): UsageComparison {
+  return {
+    priorFrom: "2023-12-01",
+    priorTo: "2023-12-31",
+    priorTotalCost: 1,
+    deltaPct: 0.5,
+  };
+}
+
+afterEach(() => {
+  apiRuntimeMocks.callGenerated.mockImplementation(
+    (request: () => Promise<unknown>) => request(),
+  );
+});
 
 describe("UsageStore filter persistence", () => {
   beforeEach(() => {
@@ -315,6 +365,125 @@ describe("UsageStore session filter params", () => {
     ).toHaveBeenCalledWith(
       expect.objectContaining({ currentCost: 0 }),
     );
+  });
+
+  it("aborts stale top sessions when a new full refresh starts", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation(
+      (request: () => Promise<unknown>, signal?: AbortSignal) => {
+        signals.push(signal);
+        return request();
+      },
+    );
+    usageServiceMocks.getApiV1UsageTopSessions.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+    usageServiceMocks.getApiV1UsageSummary.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+
+    const { usage } = await loadStore();
+
+    void usage.fetchTopSessions();
+    await Promise.resolve();
+    expect(signals[0]?.aborted).toBe(false);
+
+    void usage.fetchAll();
+    await Promise.resolve();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it("reuses summary params for top sessions during full refresh", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date("2026-04-25T12:00:00"));
+      let resolveSummary:
+        | ((value: UsageSummaryResponse) => void)
+        | undefined;
+      usageServiceMocks.getApiV1UsageSummary.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSummary = resolve;
+          }),
+      );
+
+      const { usage } = await loadStore();
+      const { sessions } = await import("./sessions.svelte.js");
+      sessions.filters.recentlyActive = true;
+
+      const fetch = usage.fetchAll();
+      await Promise.resolve();
+      const summaryParams =
+        usageServiceMocks.getApiV1UsageSummary.mock.lastCall?.[0];
+
+      vi.setSystemTime(new Date("2026-04-26T12:00:00"));
+      resolveSummary?.(usageSummary());
+      await fetch;
+
+      const topSessionParams =
+        usageServiceMocks.getApiV1UsageTopSessions.mock.lastCall?.[0];
+      expect(topSessionParams?.activeSince).toBe(summaryParams?.activeSince);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let stale comparison abort the current comparison", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation(
+      (request: () => Promise<unknown>, signal?: AbortSignal) => {
+        signals.push(signal);
+        return request();
+      },
+    );
+
+    const { usage } = await loadStore();
+    const loaded = await usage.fetchSummary({ loadComparison: false });
+    expect(loaded).not.toBeNull();
+    if (!loaded) return;
+    const loadedSummary = loaded;
+
+    let resolveComparison:
+      | ((value: UsageComparison) => void)
+      | undefined;
+    usageServiceMocks.getApiV1UsageComparison.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveComparison = resolve;
+        }),
+    );
+    const compare = usage as unknown as {
+      fetchComparison: (
+        summaryVersion: number,
+        summary: UsageSummaryResponse,
+        params: typeof loadedSummary.params,
+      ) => Promise<void>;
+    };
+
+    const currentComparison = compare.fetchComparison(
+      loadedSummary.version,
+      loadedSummary.summary,
+      loadedSummary.params,
+    );
+    await Promise.resolve();
+    const currentSignal = signals[1];
+    expect(currentSignal).toBeDefined();
+    expect(currentSignal?.aborted).toBe(false);
+
+    await compare.fetchComparison(
+      loadedSummary.version - 1,
+      loadedSummary.summary,
+      loadedSummary.params,
+    );
+
+    expect(currentSignal?.aborted).toBe(false);
+    expect(
+      usageServiceMocks.getApiV1UsageComparison,
+    ).toHaveBeenCalledTimes(1);
+
+    resolveComparison?.(usageComparison());
+    await currentComparison;
   });
 
   it("refreshes comparison when summary is refreshed directly", async () => {

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -1491,6 +1491,13 @@ type ToolsAnalyticsResponse struct {
 	Trend      []ToolTrendEntry     `json:"trend"`
 }
 
+func analyticsToolsQuery(placeholders string) string {
+	return `SELECT session_id, category, COUNT(*)
+		FROM tool_calls
+		WHERE session_id IN ` + placeholders + `
+		GROUP BY session_id, category`
+}
+
 // GetAnalyticsTools returns tool usage analytics aggregated
 // from the tool_calls table.
 func (db *DB) GetAnalyticsTools(
@@ -1562,15 +1569,14 @@ func (db *DB) GetAnalyticsTools(
 	type toolRow struct {
 		sessionID string
 		category  string
+		count     int
 	}
 	var toolRows []toolRow
 
 	err = queryChunked(sessionIDs,
 		func(chunk []string) error {
 			ph, chunkArgs := inPlaceholders(chunk)
-			q := `SELECT session_id, category
-				FROM tool_calls
-				WHERE session_id IN ` + ph
+			q := analyticsToolsQuery(ph)
 			rows, qErr := db.getReader().QueryContext(
 				ctx, q, chunkArgs...,
 			)
@@ -1582,13 +1588,18 @@ func (db *DB) GetAnalyticsTools(
 			defer rows.Close()
 			for rows.Next() {
 				var sid, cat string
-				if err := rows.Scan(&sid, &cat); err != nil {
+				var count int
+				if err := rows.Scan(
+					&sid, &cat, &count,
+				); err != nil {
 					return fmt.Errorf(
 						"scanning tool_call: %w", err,
 					)
 				}
 				toolRows = append(toolRows, toolRow{
-					sessionID: sid, category: cat,
+					sessionID: sid,
+					category:  cat,
+					count:     count,
 				})
 			}
 			return rows.Err()
@@ -1608,21 +1619,23 @@ func (db *DB) GetAnalyticsTools(
 
 	for _, tr := range toolRows {
 		info := sessionMap[tr.sessionID]
-		catCounts[tr.category]++
+		catCounts[tr.category] += tr.count
 
 		if agentCats[info.agent] == nil {
 			agentCats[info.agent] = make(map[string]int)
 		}
-		agentCats[info.agent][tr.category]++
+		agentCats[info.agent][tr.category] += tr.count
 
 		week := bucketDate(info.date, "week")
 		if trendBuckets[week] == nil {
 			trendBuckets[week] = make(map[string]int)
 		}
-		trendBuckets[week][tr.category]++
+		trendBuckets[week][tr.category] += tr.count
 	}
 
-	resp.TotalCalls = len(toolRows)
+	for _, count := range catCounts {
+		resp.TotalCalls += count
+	}
 
 	// Build ByCategory sorted by count desc.
 	resp.ByCategory = make(

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -1301,6 +1302,16 @@ func TestGetAnalyticsTools(t *testing.T) {
 		require.NoError(t, err, "GetAnalyticsTools")
 		assert.Equal(t, 0, resp.TotalCalls, "TotalCalls")
 	})
+}
+
+func TestAnalyticsToolsToolCallsQueryAggregatesInSQL(t *testing.T) {
+	q := analyticsToolsQuery("(?,?)")
+	normalized := strings.Join(strings.Fields(strings.ToLower(q)), " ")
+
+	assert.Contains(t, normalized,
+		"select session_id, category, count(*)")
+	assert.Contains(t, normalized,
+		"group by session_id, category")
 }
 
 func TestGetAnalyticsToolsCanceled(t *testing.T) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -770,6 +770,11 @@ func (db *DB) createPartialIndexesLocked(w *sql.DB) error {
 		 ON messages(session_id) WHERE is_sidechain = 1`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_source_uuid
 		 ON messages(source_uuid) WHERE source_uuid != ''`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_usage_timestamp
+		 ON messages(timestamp, session_id, ordinal)
+		 WHERE token_usage != ''
+		   AND model != ''
+		   AND model != '<synthetic>'`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_has_secret
 		 ON sessions(secret_leak_count) WHERE secret_leak_count > 0`,
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5124,6 +5124,21 @@ func TestSessionsTerminationStatusIndex(t *testing.T) {
 		count)
 }
 
+func TestMessagesUsageTimestampIndex(t *testing.T) {
+	d := testDB(t)
+
+	var count int
+	err := d.getReader().QueryRow(
+		`SELECT count(*) FROM sqlite_master
+		 WHERE type = 'index' AND name = 'idx_messages_usage_timestamp'`,
+	).Scan(&count)
+	requireNoError(t, err, "probing idx_messages_usage_timestamp")
+
+	require.Equal(t, 1, count,
+		"expected idx_messages_usage_timestamp to exist, got count=%d",
+		count)
+}
+
 // TestMigration_TerminationStatusColumn simulates upgrading from a
 // pre-termination_status schema. Drops the column and its index from
 // a freshly-opened DB, reopens, and verifies the migration restores

--- a/internal/db/pricing.go
+++ b/internal/db/pricing.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 // ModelPricing holds per-model token pricing (per million tokens).
@@ -15,13 +17,138 @@ type ModelPricing struct {
 	UpdatedAt            string  `json:"updated_at"`
 }
 
+// PricingChangeSummary describes how desired pricing rows compare
+// with rows already stored in a backend.
+type PricingChangeSummary struct {
+	Total     int
+	Missing   int
+	Changed   int
+	Unchanged int
+}
+
+const pricingWriteBatch = 100
+
+// FilterChangedModelPricing returns the subset of desired rows that
+// would actually insert or update pricing fields. UpdatedAt-only
+// differences are intentionally ignored to match the upsert WHERE
+// clause used by both SQLite and PostgreSQL.
+func FilterChangedModelPricing(
+	existing, desired []ModelPricing,
+) (PricingChangeSummary, []ModelPricing) {
+	byPattern := make(map[string]ModelPricing, len(existing))
+	for _, p := range existing {
+		byPattern[p.ModelPattern] = p
+	}
+
+	summary := PricingChangeSummary{Total: len(desired)}
+	changed := make([]ModelPricing, 0, len(desired))
+	for _, p := range desired {
+		current, ok := byPattern[p.ModelPattern]
+		if !ok {
+			summary.Missing++
+			changed = append(changed, p)
+			continue
+		}
+		if pricingFieldsEqual(current, p) {
+			summary.Unchanged++
+			continue
+		}
+		summary.Changed++
+		changed = append(changed, p)
+	}
+	return summary, changed
+}
+
+func pricingFieldsEqual(a, b ModelPricing) bool {
+	return a.InputPerMTok == b.InputPerMTok &&
+		a.OutputPerMTok == b.OutputPerMTok &&
+		a.CacheCreationPerMTok == b.CacheCreationPerMTok &&
+		a.CacheReadPerMTok == b.CacheReadPerMTok
+}
+
+func sqlitePricingValues(
+	b *strings.Builder, args *[]any, prices []ModelPricing,
+) {
+	for i, p := range prices {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(
+			"(?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+		)
+		*args = append(*args,
+			p.ModelPattern,
+			p.InputPerMTok,
+			p.OutputPerMTok,
+			p.CacheCreationPerMTok,
+			p.CacheReadPerMTok,
+		)
+	}
+}
+
+func sqlitePricingUpsertStatement(prices []ModelPricing) (string, []any) {
+	var b strings.Builder
+	b.WriteString(`INSERT INTO model_pricing
+		(model_pattern, input_per_mtok, output_per_mtok,
+		 cache_creation_per_mtok, cache_read_per_mtok,
+		 updated_at)
+	VALUES `)
+	args := make([]any, 0, len(prices)*5)
+	sqlitePricingValues(&b, &args, prices)
+	b.WriteString(`
+	ON CONFLICT(model_pattern) DO UPDATE SET
+		input_per_mtok          = excluded.input_per_mtok,
+		output_per_mtok         = excluded.output_per_mtok,
+		cache_creation_per_mtok = excluded.cache_creation_per_mtok,
+		cache_read_per_mtok     = excluded.cache_read_per_mtok,
+		updated_at              = excluded.updated_at
+	WHERE model_pricing.input_per_mtok IS NOT excluded.input_per_mtok
+		OR model_pricing.output_per_mtok IS NOT excluded.output_per_mtok
+		OR model_pricing.cache_creation_per_mtok IS NOT
+			excluded.cache_creation_per_mtok
+		OR model_pricing.cache_read_per_mtok IS NOT
+			excluded.cache_read_per_mtok`)
+	return b.String(), args
+}
+
+func sqlitePricingInsertMissingStatement(
+	prices []ModelPricing,
+) (string, []any) {
+	var b strings.Builder
+	b.WriteString(`INSERT INTO model_pricing
+		(model_pattern, input_per_mtok, output_per_mtok,
+		 cache_creation_per_mtok, cache_read_per_mtok,
+		 updated_at)
+	VALUES `)
+	args := make([]any, 0, len(prices)*5)
+	sqlitePricingValues(&b, &args, prices)
+	b.WriteString(`
+	ON CONFLICT(model_pattern) DO NOTHING`)
+	return b.String(), args
+}
+
 // UpsertModelPricing inserts or replaces pricing rows in a
 // single transaction.
 func (db *DB) UpsertModelPricing(
 	prices []ModelPricing,
 ) error {
+	if len(prices) == 0 {
+		return nil
+	}
+
 	db.mu.Lock()
 	defer db.mu.Unlock()
+
+	existing, err := db.listModelPricing(context.Background())
+	if err != nil {
+		return fmt.Errorf(
+			"listing current pricing before upsert: %w", err,
+		)
+	}
+	_, prices = FilterChangedModelPricing(existing, prices)
+	if len(prices) == 0 {
+		return nil
+	}
 
 	tx, err := db.getWriter().Begin()
 	if err != nil {
@@ -29,34 +156,13 @@ func (db *DB) UpsertModelPricing(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	stmt, err := tx.Prepare(`
-		INSERT INTO model_pricing
-			(model_pattern, input_per_mtok, output_per_mtok,
-			 cache_creation_per_mtok, cache_read_per_mtok,
-			 updated_at)
-		VALUES (?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-		ON CONFLICT(model_pattern) DO UPDATE SET
-			input_per_mtok          = excluded.input_per_mtok,
-			output_per_mtok         = excluded.output_per_mtok,
-			cache_creation_per_mtok = excluded.cache_creation_per_mtok,
-			cache_read_per_mtok     = excluded.cache_read_per_mtok,
-			updated_at              = excluded.updated_at`)
-	if err != nil {
-		return fmt.Errorf("preparing pricing upsert: %w", err)
-	}
-	defer stmt.Close()
-
-	for _, p := range prices {
-		if _, err := stmt.Exec(
-			p.ModelPattern,
-			p.InputPerMTok,
-			p.OutputPerMTok,
-			p.CacheCreationPerMTok,
-			p.CacheReadPerMTok,
-		); err != nil {
+	for i := 0; i < len(prices); i += pricingWriteBatch {
+		end := min(i+pricingWriteBatch, len(prices))
+		query, args := sqlitePricingUpsertStatement(prices[i:end])
+		if _, err := tx.Exec(query, args...); err != nil {
 			return fmt.Errorf(
-				"upserting pricing %q: %w",
-				p.ModelPattern, err,
+				"upserting pricing batch starting at %d: %w",
+				i, err,
 			)
 		}
 	}
@@ -121,28 +227,13 @@ func (db *DB) InsertMissingModelPricing(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	stmt, err := tx.Prepare(`
-		INSERT INTO model_pricing
-			(model_pattern, input_per_mtok, output_per_mtok,
-			 cache_creation_per_mtok, cache_read_per_mtok,
-			 updated_at)
-		VALUES (?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-		ON CONFLICT(model_pattern) DO NOTHING`)
-	if err != nil {
-		return fmt.Errorf("preparing pricing insert: %w", err)
-	}
-	defer stmt.Close()
-
-	for _, p := range prices {
-		if _, err := stmt.Exec(
-			p.ModelPattern,
-			p.InputPerMTok,
-			p.OutputPerMTok,
-			p.CacheCreationPerMTok,
-			p.CacheReadPerMTok,
-		); err != nil {
+	for i := 0; i < len(prices); i += pricingWriteBatch {
+		end := min(i+pricingWriteBatch, len(prices))
+		query, args := sqlitePricingInsertMissingStatement(prices[i:end])
+		if _, err := tx.Exec(query, args...); err != nil {
 			return fmt.Errorf(
-				"inserting pricing %q: %w", p.ModelPattern, err,
+				"inserting pricing batch starting at %d: %w",
+				i, err,
 			)
 		}
 	}

--- a/internal/db/pricing_list.go
+++ b/internal/db/pricing_list.go
@@ -10,6 +10,12 @@ import (
 func (db *DB) ListModelPricing(
 	ctx context.Context,
 ) ([]ModelPricing, error) {
+	return db.listModelPricing(ctx)
+}
+
+func (db *DB) listModelPricing(
+	ctx context.Context,
+) ([]ModelPricing, error) {
 	rows, err := db.getReader().QueryContext(
 		ctx,
 		`SELECT model_pattern, input_per_mtok,

--- a/internal/db/pricing_test.go
+++ b/internal/db/pricing_test.go
@@ -84,6 +84,81 @@ func TestUpsertModelPricingOverwrites(t *testing.T) {
 	assert.Equal(t, 1.00, got.CacheReadPerMTok)
 }
 
+func TestFilterChangedModelPricingIgnoresUpdatedAtOnlyDifferences(t *testing.T) {
+	existing := []ModelPricing{
+		{
+			ModelPattern:         "_fallback_version",
+			InputPerMTok:         0,
+			OutputPerMTok:        0,
+			CacheCreationPerMTok: 0,
+			CacheReadPerMTok:     0,
+			UpdatedAt:            "v1",
+		},
+		{
+			ModelPattern:         "same-model",
+			InputPerMTok:         1,
+			OutputPerMTok:        2,
+			CacheCreationPerMTok: 3,
+			CacheReadPerMTok:     4,
+			UpdatedAt:            "old",
+		},
+		{
+			ModelPattern:         "changed-model",
+			InputPerMTok:         1,
+			OutputPerMTok:        2,
+			CacheCreationPerMTok: 3,
+			CacheReadPerMTok:     4,
+			UpdatedAt:            "old",
+		},
+	}
+	desired := []ModelPricing{
+		{
+			ModelPattern:         "_fallback_version",
+			InputPerMTok:         0,
+			OutputPerMTok:        0,
+			CacheCreationPerMTok: 0,
+			CacheReadPerMTok:     0,
+			UpdatedAt:            "v2",
+		},
+		{
+			ModelPattern:         "same-model",
+			InputPerMTok:         1,
+			OutputPerMTok:        2,
+			CacheCreationPerMTok: 3,
+			CacheReadPerMTok:     4,
+			UpdatedAt:            "new",
+		},
+		{
+			ModelPattern:         "changed-model",
+			InputPerMTok:         1,
+			OutputPerMTok:        9,
+			CacheCreationPerMTok: 3,
+			CacheReadPerMTok:     4,
+			UpdatedAt:            "new",
+		},
+		{
+			ModelPattern:         "missing-model",
+			InputPerMTok:         5,
+			OutputPerMTok:        6,
+			CacheCreationPerMTok: 7,
+			CacheReadPerMTok:     8,
+			UpdatedAt:            "new",
+		},
+	}
+
+	gotSummary, gotRows := FilterChangedModelPricing(existing, desired)
+
+	assert.Equal(t, PricingChangeSummary{
+		Total:     4,
+		Missing:   1,
+		Changed:   1,
+		Unchanged: 2,
+	}, gotSummary)
+	require.Len(t, gotRows, 2)
+	assert.Equal(t, "changed-model", gotRows[0].ModelPattern)
+	assert.Equal(t, "missing-model", gotRows[1].ModelPattern)
+}
+
 func TestPricingMeta(t *testing.T) {
 	d := testDB(t)
 

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -119,6 +119,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_machine
     ON sessions(machine);
 CREATE INDEX IF NOT EXISTS idx_messages_session_ordinal
     ON messages(session_id, ordinal);
+CREATE INDEX IF NOT EXISTS idx_messages_velocity
+    ON messages(session_id, ordinal, role, timestamp, content_length);
 CREATE INDEX IF NOT EXISTS idx_messages_session_role
     ON messages(session_id, role);
 
@@ -188,6 +190,8 @@ CREATE TABLE IF NOT EXISTS tool_calls (
 
 CREATE INDEX IF NOT EXISTS idx_tool_calls_session
     ON tool_calls(session_id);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_session_category
+    ON tool_calls(session_id, category);
 -- idx_tool_calls_message backs the ON DELETE CASCADE from
 -- messages(id). Without it SQLite full-scans tool_calls per
 -- deleted message row, which makes ReplaceSessionMessages

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -39,69 +39,6 @@ type UsageFilter struct {
 	Breakdowns       bool   // populate Project/AgentBreakdowns per day
 }
 
-func (f UsageFilter) appendUsageRowFilterClauses(
-	query string, args []any,
-) (string, []any) {
-	appendCSV := func(
-		q string, a []any, col, csv string, include bool,
-	) (string, []any) {
-		if csv == "" {
-			return q, a
-		}
-		vals := strings.Split(csv, ",")
-		op := "IN"
-		if !include {
-			op = "NOT IN"
-		}
-		if len(vals) == 1 {
-			if include {
-				q += " AND " + col + " = ?"
-			} else {
-				q += " AND " + col + " != ?"
-			}
-			a = append(a, vals[0])
-		} else {
-			ph := make([]string, len(vals))
-			for i, v := range vals {
-				ph[i] = "?"
-				a = append(a, v)
-			}
-			q += " AND " + col + " " + op +
-				" (" + strings.Join(ph, ",") + ")"
-		}
-		return q, a
-	}
-
-	query, args = appendCSV(query, args, "u.agent", f.Agent, true)
-	query, args = appendCSV(query, args, "u.project", f.Project, true)
-	query, args = appendCSV(query, args, "u.machine", f.Machine, true)
-	query, args = appendCSV(query, args, "u.model", f.Model, true)
-
-	query, args = appendCSV(
-		query, args, "u.project", f.ExcludeProject, false)
-	query, args = appendCSV(
-		query, args, "u.agent", f.ExcludeAgent, false)
-	query, args = appendCSV(
-		query, args, "u.model", f.ExcludeModel, false)
-
-	if f.MinUserMessages > 0 {
-		query += " AND u.user_message_count >= ?"
-		args = append(args, f.MinUserMessages)
-	}
-	if f.ExcludeOneShot {
-		query += " AND u.user_message_count > 1"
-	}
-	if f.ExcludeAutomated {
-		query += " AND COALESCE(u.is_automated, 0) = 0"
-	}
-	if f.ActiveSince != "" {
-		query += " AND u.session_activity_at >= ?"
-		args = append(args, f.ActiveSince)
-	}
-
-	return query, args
-}
-
 func (f UsageFilter) appendUsageBranchFilterClauses(
 	where string, args []any, modelCol string,
 ) (string, []any) {
@@ -649,60 +586,6 @@ func appendUsageColumnBounds(
 	return where, args
 }
 
-func usageRowsSQLForBounds(b usageBounds) (string, []any) {
-	if !b.bounded() {
-		return usageRowsSQLWithWhere(
-			usageMessageEligibility,
-			usageEventEligibility,
-		), nil
-	}
-
-	messageTimestampWhere := usageMessageEligibility +
-		"\n\tAND m.timestamp IS NOT NULL"
-	var messageTimestampArgs []any
-	messageTimestampWhere, messageTimestampArgs = appendUsageColumnBounds(
-		messageTimestampWhere, "m.timestamp", b, messageTimestampArgs)
-
-	eventTimestampWhere := usageEventEligibility +
-		"\n\tAND ue.occurred_at IS NOT NULL"
-	var eventTimestampArgs []any
-	eventTimestampWhere, eventTimestampArgs = appendUsageColumnBounds(
-		eventTimestampWhere, "ue.occurred_at", b, eventTimestampArgs)
-
-	messageFallbackWhere := usageMessageEligibility +
-		"\n\tAND m.timestamp IS NULL"
-	var messageFallbackArgs []any
-	messageFallbackWhere, messageFallbackArgs = appendUsageColumnBounds(
-		messageFallbackWhere, "s.started_at", b, messageFallbackArgs)
-
-	eventFallbackWhere := usageEventEligibility +
-		"\n\tAND ue.occurred_at IS NULL"
-	var eventFallbackArgs []any
-	eventFallbackWhere, eventFallbackArgs = appendUsageColumnBounds(
-		eventFallbackWhere, "s.started_at", b, eventFallbackArgs)
-
-	rowsSQL := strings.Join([]string{
-		usageRowsSQLWithWhere(
-			messageTimestampWhere,
-			eventTimestampWhere,
-		),
-		usageRowsSQLWithWhere(
-			messageFallbackWhere,
-			eventFallbackWhere,
-		),
-	}, "\n\nUNION ALL\n\n")
-	args := make(
-		[]any, 0,
-		len(messageTimestampArgs)+len(eventTimestampArgs)+
-			len(messageFallbackArgs)+len(eventFallbackArgs),
-	)
-	args = append(args, messageTimestampArgs...)
-	args = append(args, eventTimestampArgs...)
-	args = append(args, messageFallbackArgs...)
-	args = append(args, eventFallbackArgs...)
-	return rowsSQL, args
-}
-
 func dailyUsageRowsSQLForBounds(
 	f UsageFilter, b usageBounds,
 ) (string, []any) {
@@ -797,13 +680,6 @@ func topSessionsUsageRowQuery(f UsageFilter) (string, []any) {
 	return usageRowQuery(f)
 }
 
-func usageFullRowQuery(f UsageFilter) (string, []any) {
-	rowsSQL, args := usageRowsSQLForBounds(usageBoundsForFilter(f))
-	query := usageRowSelectFromRows(rowsSQL)
-	query, args = f.appendUsageRowFilterClauses(query, args)
-	return query, args
-}
-
 func scanUsageRow(rows *sql.Rows) (usageScanRow, error) {
 	var r usageScanRow
 	err := rows.Scan(
@@ -857,42 +733,6 @@ func scanDailyUsageRow(rows *sql.Rows) (dailyUsageScanRow, error) {
 		&r.agent,
 	)
 	return r, err
-}
-
-func usageAmounts(
-	r usageScanRow, pricing map[string]modelRates,
-) (inputTok, outputTok, cacheCrTok, cacheRdTok int, cost, savings float64) {
-	if r.usageSource == "message" {
-		usage := gjson.Parse(r.tokenJSON)
-		inputTok = int(usage.Get("input_tokens").Int())
-		outputTok = int(usage.Get("output_tokens").Int())
-		cacheCrTok = int(
-			usage.Get("cache_creation_input_tokens").Int())
-		cacheRdTok = int(
-			usage.Get("cache_read_input_tokens").Int())
-	} else {
-		inputTok = r.inputTokens
-		outputTok = r.outputTokens
-		cacheCrTok = r.cacheCreationInputTokens
-		cacheRdTok = r.cacheReadInputTokens
-	}
-
-	rates, _ := lookupModelRates(pricing, r.model)
-	if r.costUSD.Valid {
-		cost = r.costUSD.Float64
-	} else {
-		cost = (float64(inputTok)*rates.input +
-			float64(outputTok)*rates.output +
-			float64(cacheCrTok)*rates.cacheCreation +
-			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
-	}
-
-	readDelta := float64(cacheRdTok) *
-		(rates.input - rates.cacheRead) / 1_000_000
-	crDelta := float64(cacheCrTok) *
-		(rates.input - rates.cacheCreation) / 1_000_000
-	savings = readDelta + crDelta
-	return
 }
 
 func dailyUsageAmounts(
@@ -1714,8 +1554,7 @@ type SessionUsage struct {
 
 // sessionRowCost computes one usage row's cost and reports whether
 // it was priced and whether it contributes to the estimate. A row
-// contributes when it carries an explicit cost or any tokens.
-// Unlike usageAmounts (which zero-fills missing pricing), this does
+// contributes when it carries an explicit cost or any tokens. It does
 // an explicit map lookup so callers can distinguish "unpriced" from
 // "$0".
 func sessionRowCost(

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -102,6 +102,109 @@ func (f UsageFilter) appendUsageRowFilterClauses(
 	return query, args
 }
 
+func (f UsageFilter) appendUsageBranchFilterClauses(
+	where string, args []any, modelCol string,
+) (string, []any) {
+	where, args = f.appendUsageSourceFilterClauses(where, args, modelCol)
+	return f.appendUsageSessionFilterClauses(where, args)
+}
+
+func (f UsageFilter) appendUsageSourceFilterClauses(
+	where string, args []any, modelCol string,
+) (string, []any) {
+	appendCSV := func(
+		q string, a []any, col, csv string, include bool,
+	) (string, []any) {
+		if csv == "" {
+			return q, a
+		}
+		vals := strings.Split(csv, ",")
+		op := "IN"
+		if !include {
+			op = "NOT IN"
+		}
+		if len(vals) == 1 {
+			if include {
+				q += "\n\tAND " + col + " = ?"
+			} else {
+				q += "\n\tAND " + col + " != ?"
+			}
+			a = append(a, vals[0])
+		} else {
+			ph := make([]string, len(vals))
+			for i, v := range vals {
+				ph[i] = "?"
+				a = append(a, v)
+			}
+			q += "\n\tAND " + col + " " + op +
+				" (" + strings.Join(ph, ",") + ")"
+		}
+		return q, a
+	}
+
+	where, args = appendCSV(where, args, modelCol, f.Model, true)
+	where, args = appendCSV(where, args, modelCol, f.ExcludeModel, false)
+
+	return where, args
+}
+
+func (f UsageFilter) appendUsageSessionFilterClauses(
+	where string, args []any,
+) (string, []any) {
+	appendCSV := func(
+		q string, a []any, col, csv string, include bool,
+	) (string, []any) {
+		if csv == "" {
+			return q, a
+		}
+		vals := strings.Split(csv, ",")
+		op := "IN"
+		if !include {
+			op = "NOT IN"
+		}
+		if len(vals) == 1 {
+			if include {
+				q += "\n\tAND " + col + " = ?"
+			} else {
+				q += "\n\tAND " + col + " != ?"
+			}
+			a = append(a, vals[0])
+		} else {
+			ph := make([]string, len(vals))
+			for i, v := range vals {
+				ph[i] = "?"
+				a = append(a, v)
+			}
+			q += "\n\tAND " + col + " " + op +
+				" (" + strings.Join(ph, ",") + ")"
+		}
+		return q, a
+	}
+
+	where, args = appendCSV(where, args, "s.agent", f.Agent, true)
+	where, args = appendCSV(where, args, "s.project", f.Project, true)
+	where, args = appendCSV(where, args, "s.machine", f.Machine, true)
+	where, args = appendCSV(where, args, "s.project", f.ExcludeProject, false)
+	where, args = appendCSV(where, args, "s.agent", f.ExcludeAgent, false)
+
+	if f.MinUserMessages > 0 {
+		where += "\n\tAND s.user_message_count >= ?"
+		args = append(args, f.MinUserMessages)
+	}
+	if f.ExcludeOneShot {
+		where += "\n\tAND s.user_message_count > 1"
+	}
+	if f.ExcludeAutomated {
+		where += "\n\tAND COALESCE(s.is_automated, 0) = 0"
+	}
+	if f.ActiveSince != "" {
+		where += "\n\tAND COALESCE(s.ended_at, s.started_at, s.created_at) >= ?"
+		args = append(args, f.ActiveSince)
+	}
+
+	return where, args
+}
+
 // location loads the timezone or returns the system local timezone.
 func (f UsageFilter) location() *time.Location {
 	if f.Timezone == "" {
@@ -134,7 +237,21 @@ const usageMessageEligibility = `
     AND m.model != '<synthetic>'
     AND s.deleted_at IS NULL`
 
-const usageRowsSQL = `
+const usageMessageSourceEligibility = `
+    m.token_usage != ''
+    AND m.model != ''
+    AND m.model != '<synthetic>'`
+
+const usageEventEligibility = `
+    ue.model != ''
+    AND s.deleted_at IS NULL`
+
+const usageEventSourceEligibility = `
+    ue.model != ''`
+
+const usageSessionEligibility = `s.deleted_at IS NULL`
+
+const usageRowsSQLTemplate = `
 SELECT
 	m.session_id,
 	m.ordinal AS message_ordinal,
@@ -163,7 +280,7 @@ SELECT
 	COALESCE(s.started_at, '') AS started_at
 FROM messages m
 JOIN sessions s ON m.session_id = s.id
-WHERE ` + usageMessageEligibility + `
+WHERE %s
 
 UNION ALL
 
@@ -198,8 +315,189 @@ SELECT
 	COALESCE(s.started_at, '') AS started_at
 FROM usage_events ue
 JOIN sessions s ON s.id = ue.session_id
-WHERE ue.model != ''
-  AND s.deleted_at IS NULL`
+WHERE %s`
+
+func usageRowsSQLWithWhere(
+	messageWhere, usageEventWhere string,
+) string {
+	return fmt.Sprintf(
+		usageRowsSQLTemplate,
+		messageWhere,
+		usageEventWhere,
+	)
+}
+
+const dailyUsageRowsSQLTemplate = `
+SELECT
+	m.session_id,
+	m.ordinal AS message_ordinal,
+	'message' AS usage_source,
+	COALESCE(m.timestamp, s.started_at) AS ts,
+	m.model,
+	m.token_usage,
+	0 AS input_tokens,
+	0 AS output_tokens,
+	0 AS cache_creation_input_tokens,
+	0 AS cache_read_input_tokens,
+	NULL AS cost_usd,
+	m.claude_message_id,
+	m.claude_request_id,
+	'' AS usage_dedup_key,
+	s.project,
+	s.agent
+FROM messages m
+JOIN sessions s ON m.session_id = s.id
+WHERE %s
+
+UNION ALL
+
+SELECT
+	ue.session_id,
+	ue.message_ordinal,
+	ue.source AS usage_source,
+	COALESCE(ue.occurred_at, s.started_at) AS ts,
+	ue.model,
+	'' AS token_usage,
+	ue.input_tokens,
+	ue.output_tokens,
+	ue.cache_creation_input_tokens,
+	ue.cache_read_input_tokens,
+	ue.cost_usd,
+	'' AS claude_message_id,
+	'' AS claude_request_id,
+	CASE
+		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
+		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
+	END AS usage_dedup_key,
+	s.project,
+	s.agent
+FROM usage_events ue
+JOIN sessions s ON s.id = ue.session_id
+WHERE %s`
+
+const dailyUsageMessageRowsSQLTemplate = `
+SELECT
+	m.session_id,
+	m.ordinal AS message_ordinal,
+	'message' AS usage_source,
+	COALESCE(m.timestamp, s.started_at) AS ts,
+	m.model,
+	m.token_usage,
+	0 AS input_tokens,
+	0 AS output_tokens,
+	0 AS cache_creation_input_tokens,
+	0 AS cache_read_input_tokens,
+	NULL AS cost_usd,
+	m.claude_message_id,
+	m.claude_request_id,
+	'' AS usage_dedup_key,
+	s.project,
+	s.agent
+FROM %s m
+JOIN sessions s ON m.session_id = s.id
+WHERE %s`
+
+const dailyUsageEventRowsSQLTemplate = `
+SELECT
+	ue.session_id,
+	ue.message_ordinal,
+	ue.source AS usage_source,
+	COALESCE(ue.occurred_at, s.started_at) AS ts,
+	ue.model,
+	'' AS token_usage,
+	ue.input_tokens,
+	ue.output_tokens,
+	ue.cache_creation_input_tokens,
+	ue.cache_read_input_tokens,
+	ue.cost_usd,
+	'' AS claude_message_id,
+	'' AS claude_request_id,
+	CASE
+		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
+		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
+	END AS usage_dedup_key,
+	s.project,
+	s.agent
+FROM %s ue
+JOIN sessions s ON s.id = ue.session_id
+WHERE %s`
+
+func dailyUsageRowsSQLWithWhere(
+	messageWhere, usageEventWhere string,
+) string {
+	return fmt.Sprintf(
+		dailyUsageRowsSQLTemplate,
+		messageWhere,
+		usageEventWhere,
+	)
+}
+
+func dailyUsageRowsSQLWithTimestampCTEs(
+	messageTimestampWhere, eventTimestampWhere string,
+	messageTimestampJoinWhere, eventTimestampJoinWhere string,
+	messageFallbackWhere, eventFallbackWhere string,
+) string {
+	return `
+WITH
+message_timestamp_rows AS MATERIALIZED (
+	SELECT
+		m.session_id,
+		m.ordinal,
+		m.timestamp,
+		m.model,
+		m.token_usage,
+		m.claude_message_id,
+		m.claude_request_id
+	FROM messages m
+	WHERE ` + messageTimestampWhere + `
+),
+usage_event_timestamp_rows AS MATERIALIZED (
+	SELECT
+		ue.id,
+		ue.session_id,
+		ue.message_ordinal,
+		ue.source,
+		ue.occurred_at,
+		ue.model,
+		ue.input_tokens,
+		ue.output_tokens,
+		ue.cache_creation_input_tokens,
+		ue.cache_read_input_tokens,
+		ue.cost_usd,
+		ue.dedup_key
+	FROM usage_events ue
+	WHERE ` + eventTimestampWhere + `
+)
+` + fmt.Sprintf(
+		dailyUsageMessageRowsSQLTemplate,
+		"message_timestamp_rows",
+		messageTimestampJoinWhere,
+	) + `
+
+UNION ALL
+
+` + fmt.Sprintf(
+		dailyUsageEventRowsSQLTemplate,
+		"usage_event_timestamp_rows",
+		eventTimestampJoinWhere,
+	) + `
+
+UNION ALL
+
+` + fmt.Sprintf(
+		dailyUsageMessageRowsSQLTemplate,
+		"messages",
+		messageFallbackWhere,
+	) + `
+
+UNION ALL
+
+` + fmt.Sprintf(
+		dailyUsageEventRowsSQLTemplate,
+		"usage_events",
+		eventFallbackWhere,
+	)
+}
 
 type usageScanRow struct {
 	sessionID                string
@@ -229,7 +527,33 @@ type usageScanRow struct {
 	startedAt                string
 }
 
-func usageRowSelect() string {
+type dailyUsageScanRow struct {
+	sessionID                string
+	messageOrdinal           sql.NullInt64
+	usageSource              string
+	ts                       string
+	model                    string
+	tokenJSON                string
+	inputTokens              int
+	outputTokens             int
+	cacheCreationInputTokens int
+	cacheReadInputTokens     int
+	costUSD                  sql.NullFloat64
+	claudeMessageID          string
+	claudeRequestID          string
+	usageDedupKey            string
+	project                  string
+	agent                    string
+}
+
+type topSessionMetadata struct {
+	displayName string
+	agent       string
+	project     string
+	startedAt   string
+}
+
+func usageRowSelectFromRows(rowsSQL string) string {
 	return `
 SELECT
 	u.session_id,
@@ -257,8 +581,227 @@ SELECT
 	u.session_activity_at,
 	u.display_name,
 	u.started_at
-FROM (` + usageRowsSQL + `) u
+FROM (` + rowsSQL + `) u
 WHERE 1=1`
+}
+
+func usageRowSelect() string {
+	return usageRowSelectFromRows(usageRowsSQLWithWhere(
+		usageMessageEligibility,
+		usageEventEligibility,
+	))
+}
+
+func dailyUsageRowSelectFromRows(rowsSQL string) string {
+	return `
+SELECT
+	u.session_id,
+	u.message_ordinal,
+	u.usage_source,
+	u.ts,
+	u.model,
+	u.token_usage,
+	u.input_tokens,
+	u.output_tokens,
+	u.cache_creation_input_tokens,
+	u.cache_read_input_tokens,
+	u.cost_usd,
+	u.claude_message_id,
+	u.claude_request_id,
+	u.usage_dedup_key,
+	u.project,
+	u.agent
+FROM (` + rowsSQL + `) u
+WHERE 1=1`
+}
+
+type usageBounds struct {
+	from string
+	to   string
+}
+
+func (b usageBounds) bounded() bool {
+	return b.from != "" || b.to != ""
+}
+
+func usageBoundsForFilter(f UsageFilter) usageBounds {
+	var b usageBounds
+	if f.From != "" {
+		b.from = paddedUTCBound(f.From+"T00:00:00Z", -14)
+	}
+	if f.To != "" {
+		b.to = paddedUTCBound(f.To+"T23:59:59Z", 14)
+	}
+	return b
+}
+
+func appendUsageColumnBounds(
+	where, col string, b usageBounds, args []any,
+) (string, []any) {
+	if b.from != "" {
+		where += "\n\tAND " + col + " >= ?"
+		args = append(args, b.from)
+	}
+	if b.to != "" {
+		where += "\n\tAND " + col + " <= ?"
+		args = append(args, b.to)
+	}
+	return where, args
+}
+
+func usageRowsSQLForBounds(b usageBounds) (string, []any) {
+	if !b.bounded() {
+		return usageRowsSQLWithWhere(
+			usageMessageEligibility,
+			usageEventEligibility,
+		), nil
+	}
+
+	messageTimestampWhere := usageMessageEligibility +
+		"\n\tAND m.timestamp IS NOT NULL"
+	var messageTimestampArgs []any
+	messageTimestampWhere, messageTimestampArgs = appendUsageColumnBounds(
+		messageTimestampWhere, "m.timestamp", b, messageTimestampArgs)
+
+	eventTimestampWhere := usageEventEligibility +
+		"\n\tAND ue.occurred_at IS NOT NULL"
+	var eventTimestampArgs []any
+	eventTimestampWhere, eventTimestampArgs = appendUsageColumnBounds(
+		eventTimestampWhere, "ue.occurred_at", b, eventTimestampArgs)
+
+	messageFallbackWhere := usageMessageEligibility +
+		"\n\tAND m.timestamp IS NULL"
+	var messageFallbackArgs []any
+	messageFallbackWhere, messageFallbackArgs = appendUsageColumnBounds(
+		messageFallbackWhere, "s.started_at", b, messageFallbackArgs)
+
+	eventFallbackWhere := usageEventEligibility +
+		"\n\tAND ue.occurred_at IS NULL"
+	var eventFallbackArgs []any
+	eventFallbackWhere, eventFallbackArgs = appendUsageColumnBounds(
+		eventFallbackWhere, "s.started_at", b, eventFallbackArgs)
+
+	rowsSQL := strings.Join([]string{
+		usageRowsSQLWithWhere(
+			messageTimestampWhere,
+			eventTimestampWhere,
+		),
+		usageRowsSQLWithWhere(
+			messageFallbackWhere,
+			eventFallbackWhere,
+		),
+	}, "\n\nUNION ALL\n\n")
+	args := make(
+		[]any, 0,
+		len(messageTimestampArgs)+len(eventTimestampArgs)+
+			len(messageFallbackArgs)+len(eventFallbackArgs),
+	)
+	args = append(args, messageTimestampArgs...)
+	args = append(args, eventTimestampArgs...)
+	args = append(args, messageFallbackArgs...)
+	args = append(args, eventFallbackArgs...)
+	return rowsSQL, args
+}
+
+func dailyUsageRowsSQLForBounds(
+	f UsageFilter, b usageBounds,
+) (string, []any) {
+	if !b.bounded() {
+		var messageArgs []any
+		messageWhere, messageArgs := f.appendUsageBranchFilterClauses(
+			usageMessageEligibility, messageArgs, "m.model")
+		var eventArgs []any
+		eventWhere, eventArgs := f.appendUsageBranchFilterClauses(
+			usageEventEligibility, eventArgs, "ue.model")
+		rowsSQL := dailyUsageRowsSQLWithWhere(messageWhere, eventWhere)
+		args := make([]any, 0, len(messageArgs)+len(eventArgs))
+		args = append(args, messageArgs...)
+		args = append(args, eventArgs...)
+		return rowsSQL, args
+	}
+
+	messageTimestampSourceWhere := usageMessageSourceEligibility +
+		"\n\tAND m.timestamp IS NOT NULL"
+	var messageTimestampArgs []any
+	messageTimestampSourceWhere, messageTimestampArgs =
+		f.appendUsageSourceFilterClauses(
+			messageTimestampSourceWhere, messageTimestampArgs, "m.model")
+	messageTimestampSourceWhere, messageTimestampArgs = appendUsageColumnBounds(
+		messageTimestampSourceWhere, "m.timestamp", b, messageTimestampArgs)
+	var messageTimestampJoinArgs []any
+	messageTimestampJoinWhere, messageTimestampJoinArgs :=
+		f.appendUsageSessionFilterClauses(
+			usageSessionEligibility, messageTimestampJoinArgs)
+
+	eventTimestampSourceWhere := usageEventSourceEligibility +
+		"\n\tAND ue.occurred_at IS NOT NULL"
+	var eventTimestampArgs []any
+	eventTimestampSourceWhere, eventTimestampArgs =
+		f.appendUsageSourceFilterClauses(
+			eventTimestampSourceWhere, eventTimestampArgs, "ue.model")
+	eventTimestampSourceWhere, eventTimestampArgs = appendUsageColumnBounds(
+		eventTimestampSourceWhere, "ue.occurred_at", b, eventTimestampArgs)
+	var eventTimestampJoinArgs []any
+	eventTimestampJoinWhere, eventTimestampJoinArgs :=
+		f.appendUsageSessionFilterClauses(
+			usageSessionEligibility, eventTimestampJoinArgs)
+
+	messageFallbackWhere := usageMessageEligibility +
+		"\n\tAND m.timestamp IS NULL"
+	var messageFallbackArgs []any
+	messageFallbackWhere, messageFallbackArgs =
+		f.appendUsageBranchFilterClauses(
+			messageFallbackWhere, messageFallbackArgs, "m.model")
+	messageFallbackWhere, messageFallbackArgs = appendUsageColumnBounds(
+		messageFallbackWhere, "s.started_at", b, messageFallbackArgs)
+
+	eventFallbackWhere := usageEventEligibility +
+		"\n\tAND ue.occurred_at IS NULL"
+	var eventFallbackArgs []any
+	eventFallbackWhere, eventFallbackArgs =
+		f.appendUsageBranchFilterClauses(
+			eventFallbackWhere, eventFallbackArgs, "ue.model")
+	eventFallbackWhere, eventFallbackArgs = appendUsageColumnBounds(
+		eventFallbackWhere, "s.started_at", b, eventFallbackArgs)
+
+	rowsSQL := dailyUsageRowsSQLWithTimestampCTEs(
+		messageTimestampSourceWhere,
+		eventTimestampSourceWhere,
+		messageTimestampJoinWhere,
+		eventTimestampJoinWhere,
+		messageFallbackWhere,
+		eventFallbackWhere,
+	)
+	args := make(
+		[]any, 0,
+		len(messageTimestampArgs)+len(eventTimestampArgs)+
+			len(messageTimestampJoinArgs)+len(eventTimestampJoinArgs)+
+			len(messageFallbackArgs)+len(eventFallbackArgs),
+	)
+	args = append(args, messageTimestampArgs...)
+	args = append(args, eventTimestampArgs...)
+	args = append(args, messageTimestampJoinArgs...)
+	args = append(args, eventTimestampJoinArgs...)
+	args = append(args, messageFallbackArgs...)
+	args = append(args, eventFallbackArgs...)
+	return rowsSQL, args
+}
+
+func usageRowQuery(f UsageFilter) (string, []any) {
+	rowsSQL, args := dailyUsageRowsSQLForBounds(f, usageBoundsForFilter(f))
+	query := dailyUsageRowSelectFromRows(rowsSQL)
+	return query, args
+}
+
+func topSessionsUsageRowQuery(f UsageFilter) (string, []any) {
+	return usageRowQuery(f)
+}
+
+func usageFullRowQuery(f UsageFilter) (string, []any) {
+	rowsSQL, args := usageRowsSQLForBounds(usageBoundsForFilter(f))
+	query := usageRowSelectFromRows(rowsSQL)
+	query, args = f.appendUsageRowFilterClauses(query, args)
+	return query, args
 }
 
 func scanUsageRow(rows *sql.Rows) (usageScanRow, error) {
@@ -289,6 +832,29 @@ func scanUsageRow(rows *sql.Rows) (usageScanRow, error) {
 		&r.sessionActivityAt,
 		&r.displayName,
 		&r.startedAt,
+	)
+	return r, err
+}
+
+func scanDailyUsageRow(rows *sql.Rows) (dailyUsageScanRow, error) {
+	var r dailyUsageScanRow
+	err := rows.Scan(
+		&r.sessionID,
+		&r.messageOrdinal,
+		&r.usageSource,
+		&r.ts,
+		&r.model,
+		&r.tokenJSON,
+		&r.inputTokens,
+		&r.outputTokens,
+		&r.cacheCreationInputTokens,
+		&r.cacheReadInputTokens,
+		&r.costUSD,
+		&r.claudeMessageID,
+		&r.claudeRequestID,
+		&r.usageDedupKey,
+		&r.project,
+		&r.agent,
 	)
 	return r, err
 }
@@ -327,6 +893,92 @@ func usageAmounts(
 		(rates.input - rates.cacheCreation) / 1_000_000
 	savings = readDelta + crDelta
 	return
+}
+
+func dailyUsageAmounts(
+	r dailyUsageScanRow, pricing map[string]modelRates,
+) (inputTok, outputTok, cacheCrTok, cacheRdTok int, cost, savings float64) {
+	if r.usageSource == "message" {
+		usage := gjson.Parse(r.tokenJSON)
+		inputTok = int(usage.Get("input_tokens").Int())
+		outputTok = int(usage.Get("output_tokens").Int())
+		cacheCrTok = int(
+			usage.Get("cache_creation_input_tokens").Int())
+		cacheRdTok = int(
+			usage.Get("cache_read_input_tokens").Int())
+	} else {
+		inputTok = r.inputTokens
+		outputTok = r.outputTokens
+		cacheCrTok = r.cacheCreationInputTokens
+		cacheRdTok = r.cacheReadInputTokens
+	}
+
+	rates, _ := lookupModelRates(pricing, r.model)
+	if r.costUSD.Valid {
+		cost = r.costUSD.Float64
+	} else {
+		cost = (float64(inputTok)*rates.input +
+			float64(outputTok)*rates.output +
+			float64(cacheCrTok)*rates.cacheCreation +
+			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
+	}
+
+	readDelta := float64(cacheRdTok) *
+		(rates.input - rates.cacheRead) / 1_000_000
+	crDelta := float64(cacheCrTok) *
+		(rates.input - rates.cacheCreation) / 1_000_000
+	savings = readDelta + crDelta
+	return
+}
+
+func (db *DB) loadTopSessionMetadata(
+	ctx context.Context, sessionIDs []string,
+) (map[string]topSessionMetadata, error) {
+	out := make(map[string]topSessionMetadata, len(sessionIDs))
+	if len(sessionIDs) == 0 {
+		return out, nil
+	}
+
+	placeholders := make([]string, len(sessionIDs))
+	args := make([]any, len(sessionIDs))
+	for i, id := range sessionIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `
+SELECT
+	id,
+	COALESCE(NULLIF(display_name, ''), NULLIF(first_message, ''), NULLIF(project, ''), id) AS display_name,
+	agent,
+	project,
+	COALESCE(started_at, '') AS started_at
+FROM sessions
+WHERE id IN (` + strings.Join(placeholders, ",") + `)`
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying top session metadata: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id string
+		var meta topSessionMetadata
+		if err := rows.Scan(
+			&id,
+			&meta.displayName,
+			&meta.agent,
+			&meta.project,
+			&meta.startedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scanning top session metadata: %w", err)
+		}
+		out[id] = meta
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating top session metadata: %w", err)
+	}
+	return out, nil
 }
 
 // DailyUsageEntry holds token counts and cost for one day.
@@ -392,8 +1044,9 @@ type UsageTotals struct {
 
 // DailyUsageResult wraps the daily entries and totals.
 type DailyUsageResult struct {
-	Daily  []DailyUsageEntry `json:"daily"`
-	Totals UsageTotals       `json:"totals"`
+	Daily         []DailyUsageEntry  `json:"daily"`
+	Totals        UsageTotals        `json:"totals"`
+	SessionCounts UsageSessionCounts `json:"sessionCounts,omitempty"`
 }
 
 // modelRates holds per-model pricing in rate-per-token form.
@@ -479,25 +1132,11 @@ func (db *DB) GetDailyUsage(
 			fmt.Errorf("loading pricing: %w", err)
 	}
 
-	query := usageRowSelect()
-
-	var args []any
-
 	// Filter on usage timestamp (not only session started_at) so
 	// long-lived sessions that span date boundaries are included.
-	// Pad by ±14h to cover all timezone offsets — the actual
+	// Pad by +/-14h to cover all timezone offsets; the actual
 	// date filtering happens post-query via localDate.
-	if f.From != "" {
-		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
-		query += " AND u.ts >= ?"
-		args = append(args, padded)
-	}
-	if f.To != "" {
-		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
-		query += " AND u.ts <= ?"
-		args = append(args, padded)
-	}
-	query, args = f.appendUsageRowFilterClauses(query, args)
+	query, args := usageRowQuery(f)
 	query += ` ORDER BY u.ts ASC, u.session_id ASC,
 		COALESCE(u.message_ordinal, -1) ASC`
 
@@ -529,6 +1168,7 @@ func (db *DB) GetDailyUsage(
 		msgID, reqID string
 	}
 	seen := make(map[dedupKey]struct{})
+	seenSessions := make(map[string]UsageSessionInfo)
 
 	// totalSavings is the running sum of per-message cache
 	// savings using each row's actual per-model rates. We sum
@@ -538,7 +1178,7 @@ func (db *DB) GetDailyUsage(
 	var totalSavings float64
 
 	for rows.Next() {
-		r, scanErr := scanUsageRow(rows)
+		r, scanErr := scanDailyUsageRow(rows)
 		if scanErr != nil {
 			return DailyUsageResult{},
 				fmt.Errorf("scanning daily usage row: %w", scanErr)
@@ -572,8 +1212,15 @@ func (db *DB) GetDailyUsage(
 			seen[key] = struct{}{}
 		}
 
+		if _, ok := seenSessions[r.sessionID]; !ok {
+			seenSessions[r.sessionID] = UsageSessionInfo{
+				Project: r.project,
+				Agent:   r.agent,
+			}
+		}
+
 		inputTok, outputTok, cacheCrTok, cacheRdTok, cost, savings :=
-			usageAmounts(r, pricing)
+			dailyUsageAmounts(r, pricing)
 		totalSavings += savings
 
 		key := accumKey{
@@ -715,9 +1362,11 @@ func (db *DB) GetDailyUsage(
 			daily = []DailyUsageEntry{}
 		}
 		totals.CacheSavings = totalSavings
+		sessionCounts := NewUsageSessionCounts(seenSessions)
 		return DailyUsageResult{
-			Daily:  daily,
-			Totals: totals,
+			Daily:         daily,
+			Totals:        totals,
+			SessionCounts: sessionCounts,
 		}, nil
 	}
 
@@ -875,9 +1524,11 @@ func (db *DB) GetDailyUsage(
 	}
 
 	totals.CacheSavings = totalSavings
+	sessionCounts := NewUsageSessionCounts(seenSessions)
 	return DailyUsageResult{
-		Daily:  daily,
-		Totals: totals,
+		Daily:         daily,
+		Totals:        totals,
+		SessionCounts: sessionCounts,
 	}, nil
 }
 
@@ -910,21 +1561,7 @@ func (db *DB) GetTopSessionsByCost(
 			fmt.Errorf("loading pricing: %w", err)
 	}
 
-	query := usageRowSelect()
-
-	var args []any
-
-	if f.From != "" {
-		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
-		query += " AND u.ts >= ?"
-		args = append(args, padded)
-	}
-	if f.To != "" {
-		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
-		query += " AND u.ts <= ?"
-		args = append(args, padded)
-	}
-	query, args = f.appendUsageRowFilterClauses(query, args)
+	query, args := topSessionsUsageRowQuery(f)
 	// Deterministic order so the dedup "winner" (the session
 	// that gets credit for a duplicate message.id + request.id
 	// pair) is stable across runs: earliest timestamp wins,
@@ -942,10 +1579,6 @@ func (db *DB) GetTopSessionsByCost(
 	loc := f.location()
 
 	type sessAccum struct {
-		displayName string
-		agent       string
-		project     string
-		startedAt   string
 		totalTokens int
 		cost        float64
 	}
@@ -963,7 +1596,7 @@ func (db *DB) GetTopSessionsByCost(
 	seen := make(map[dedupKey]struct{})
 
 	for rows.Next() {
-		r, err := scanUsageRow(rows)
+		r, err := scanDailyUsageRow(rows)
 		if err != nil {
 			return nil,
 				fmt.Errorf("scanning top sessions row: %w", err)
@@ -999,16 +1632,11 @@ func (db *DB) GetTopSessionsByCost(
 		}
 
 		inputTok, outputTok, cacheCrTok, cacheRdTok, cost, _ :=
-			usageAmounts(r, pricing)
+			dailyUsageAmounts(r, pricing)
 
 		sa, ok := accum[r.sessionID]
 		if !ok {
-			sa = &sessAccum{
-				displayName: r.displayName,
-				agent:       r.agent,
-				project:     r.project,
-				startedAt:   r.startedAt,
-			}
+			sa = &sessAccum{}
 			accum[r.sessionID] = sa
 			order = append(order, r.sessionID)
 		}
@@ -1029,10 +1657,7 @@ func (db *DB) GetTopSessionsByCost(
 		}
 		result = append(result, TopSessionEntry{
 			SessionID:   id,
-			DisplayName: sa.displayName,
-			Agent:       sa.agent,
-			Project:     sa.project,
-			StartedAt:   sa.startedAt,
+			DisplayName: id,
 			TotalTokens: sa.totalTokens,
 			Cost:        sa.cost,
 		})
@@ -1047,6 +1672,23 @@ func (db *DB) GetTopSessionsByCost(
 
 	if len(result) > limit {
 		result = result[:limit]
+	}
+
+	sessionIDs := make([]string, len(result))
+	for i := range result {
+		sessionIDs[i] = result[i].SessionID
+	}
+	metadata, err := db.loadTopSessionMetadata(ctx, sessionIDs)
+	if err != nil {
+		return nil, err
+	}
+	for i := range result {
+		if meta, ok := metadata[result[i].SessionID]; ok {
+			result[i].DisplayName = meta.displayName
+			result[i].Agent = meta.agent
+			result[i].Project = meta.project
+			result[i].StartedAt = meta.startedAt
+		}
 	}
 
 	return result, nil
@@ -1226,6 +1868,26 @@ type UsageSessionCounts struct {
 	ByAgent   map[string]int `json:"byAgent"`
 }
 
+type UsageSessionInfo struct {
+	Project string
+	Agent   string
+}
+
+func NewUsageSessionCounts(
+	seen map[string]UsageSessionInfo,
+) UsageSessionCounts {
+	out := UsageSessionCounts{
+		Total:     len(seen),
+		ByProject: make(map[string]int),
+		ByAgent:   make(map[string]int),
+	}
+	for _, info := range seen {
+		out.ByProject[info.Project]++
+		out.ByAgent[info.Agent]++
+	}
+	return out
+}
+
 // GetUsageSessionCounts returns distinct session counts grouped
 // by project and agent. Sessions spanning multiple days count
 // once. Soft-deleted sessions are excluded via
@@ -1237,21 +1899,7 @@ type UsageSessionCounts struct {
 func (db *DB) GetUsageSessionCounts(
 	ctx context.Context, f UsageFilter,
 ) (UsageSessionCounts, error) {
-	query := usageRowSelect()
-
-	var args []any
-
-	if f.From != "" {
-		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
-		query += " AND u.ts >= ?"
-		args = append(args, padded)
-	}
-	if f.To != "" {
-		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
-		query += " AND u.ts <= ?"
-		args = append(args, padded)
-	}
-	query, args = f.appendUsageRowFilterClauses(query, args)
+	query, args := usageRowQuery(f)
 	// Deterministic ordering so the Claude dedup winner — the
 	// session that "owns" a shared message — is stable across
 	// runs. Matches GetDailyUsage / GetTopSessionsByCost so all
@@ -1290,7 +1938,7 @@ func (db *DB) GetUsageSessionCounts(
 	dedup := make(map[dedupKey]struct{})
 
 	for rows.Next() {
-		r, err := scanUsageRow(rows)
+		r, err := scanDailyUsageRow(rows)
 		if err != nil {
 			return UsageSessionCounts{},
 				fmt.Errorf("scanning session counts: %w", err)

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"math"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,90 @@ func TestGetDailyUsageEmpty(t *testing.T) {
 	require.NotNil(t, result.Daily, "Daily should be non-nil empty slice")
 	assert.Len(t, result.Daily, 0, "got")
 	assert.Equal(t, 0.0, result.Totals.TotalCost, "TotalCost")
+}
+
+func TestUsageRowQueryPushesDateBoundsIntoUnion(t *testing.T) {
+	query, args := usageRowQuery(UsageFilter{
+		From:             "2024-06-01",
+		To:               "2024-06-30",
+		ExcludeAutomated: true,
+	})
+
+	normalized := strings.ToLower(query)
+	assert.NotContains(t, normalized, "and u.ts >=")
+	assert.NotContains(t, normalized, "and u.ts <=")
+	assert.NotContains(t, normalized, " or ")
+	assert.NotContains(t, normalized, "display_name")
+	assert.NotContains(t, normalized, "first_message")
+	assert.NotContains(t, normalized, "cost_status")
+	assert.NotContains(t, normalized, "cost_source")
+	assert.NotContains(t, normalized, "reasoning_tokens")
+	assert.NotContains(t, normalized, "user_message_count")
+	assert.NotContains(t, normalized, "session_activity_at")
+	assert.NotContains(t, normalized, " as started_at")
+	assert.NotContains(t, normalized, "u.machine")
+	assert.Contains(t, normalized, "message_timestamp_rows as materialized")
+	assert.Contains(t, normalized, "usage_event_timestamp_rows as materialized")
+	assert.Contains(t, normalized, "from message_timestamp_rows m\njoin sessions s")
+	assert.Contains(t, normalized, "from usage_event_timestamp_rows ue\njoin sessions s")
+	assert.Contains(t, normalized, "m.timestamp is not null")
+	assert.Contains(t, normalized, "ue.occurred_at is not null")
+	assert.Contains(t, normalized, "m.timestamp is null")
+	assert.Contains(t, normalized, "ue.occurred_at is null")
+	assert.Contains(t, normalized, "m.timestamp >= ?")
+	assert.Contains(t, normalized, "ue.occurred_at >= ?")
+	assert.Contains(t, normalized, "s.started_at >= ?")
+	assert.Contains(t, normalized, "m.timestamp <= ?")
+	assert.Contains(t, normalized, "ue.occurred_at <= ?")
+	assert.Contains(t, normalized, "s.started_at <= ?")
+	require.Len(t, args, 8)
+	assert.Equal(t, "2024-05-31T10:00:00Z", args[0])
+	assert.Equal(t, "2024-07-01T13:59:59Z", args[1])
+	assert.Equal(t, "2024-05-31T10:00:00Z", args[2])
+	assert.Equal(t, "2024-07-01T13:59:59Z", args[3])
+	assert.Equal(t, "2024-05-31T10:00:00Z", args[4])
+	assert.Equal(t, "2024-07-01T13:59:59Z", args[5])
+	assert.Equal(t, "2024-05-31T10:00:00Z", args[6])
+	assert.Equal(t, "2024-07-01T13:59:59Z", args[7])
+}
+
+func TestTopSessionsUsageRowQueryUsesNarrowScan(t *testing.T) {
+	query, args := topSessionsUsageRowQuery(UsageFilter{
+		From: "2024-06-01",
+		To:   "2024-06-30",
+	})
+
+	normalized := strings.ToLower(query)
+	assert.NotContains(t, normalized, "display_name")
+	assert.NotContains(t, normalized, "first_message")
+	assert.NotContains(t, normalized, "cost_status")
+	assert.NotContains(t, normalized, "cost_source")
+	assert.NotContains(t, normalized, "reasoning_tokens")
+	assert.NotContains(t, normalized, "user_message_count")
+	assert.NotContains(t, normalized, "session_activity_at")
+	assert.NotContains(t, normalized, " as started_at")
+	assert.NotContains(t, normalized, "u.machine")
+	assert.Contains(t, normalized, "m.timestamp is not null")
+	assert.Contains(t, normalized, "ue.occurred_at is not null")
+	assert.Contains(t, normalized, "m.timestamp is null")
+	assert.Contains(t, normalized, "ue.occurred_at is null")
+	assert.Contains(t, normalized, "m.timestamp >= ?")
+	assert.Contains(t, normalized, "ue.occurred_at >= ?")
+	assert.Contains(t, normalized,
+		"m.timestamp is null\n\tand s.started_at >= ?")
+	assert.Contains(t, normalized,
+		"ue.occurred_at is null\n\tand s.started_at >= ?")
+	assert.Contains(t, normalized, "m.timestamp <= ?")
+	assert.Contains(t, normalized, "ue.occurred_at <= ?")
+	require.Len(t, args, 8)
+	assert.Equal(t, "2024-05-31T10:00:00Z", args[0])
+	assert.Equal(t, "2024-07-01T13:59:59Z", args[1])
+	assert.Equal(t, "2024-05-31T10:00:00Z", args[2])
+	assert.Equal(t, "2024-07-01T13:59:59Z", args[3])
+	assert.Equal(t, "2024-05-31T10:00:00Z", args[4])
+	assert.Equal(t, "2024-07-01T13:59:59Z", args[5])
+	assert.Equal(t, "2024-05-31T10:00:00Z", args[6])
+	assert.Equal(t, "2024-07-01T13:59:59Z", args[7])
 }
 
 func TestUsageEventsReplaceAndList(t *testing.T) {
@@ -1386,6 +1471,31 @@ func TestGetUsageSessionCounts(t *testing.T) {
 	assert.Equal(t, 1, counts.ByProject["proj-b"], "ByProject[proj-b]")
 	assert.Equal(t, 2, counts.ByAgent["claude"], "ByAgent[claude]")
 	assert.Equal(t, 1, counts.ByAgent["codex"], "ByAgent[codex]")
+
+	daily, err := d.GetDailyUsage(ctx, UsageFilter{
+		From: "2024-06-01",
+		To:   "2024-06-30",
+	})
+	requireNoError(t, err, "GetDailyUsage")
+	assert.Equal(t, counts, daily.SessionCounts)
+}
+
+func TestNewUsageSessionCounts(t *testing.T) {
+	counts := NewUsageSessionCounts(map[string]UsageSessionInfo{
+		"s1": {Project: "proj-a", Agent: "claude"},
+		"s2": {Project: "proj-a", Agent: "codex"},
+		"s3": {Project: "proj-b", Agent: "claude"},
+	})
+
+	assert.Equal(t, 3, counts.Total, "Total")
+	assert.Equal(t, map[string]int{
+		"proj-a": 2,
+		"proj-b": 1,
+	}, counts.ByProject, "ByProject")
+	assert.Equal(t, map[string]int{
+		"claude": 2,
+		"codex":  1,
+	}, counts.ByAgent, "ByAgent")
 }
 
 // TestGetUsageSessionCounts_DedupesByClaudeMessageAndRequestID

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -1468,6 +1468,7 @@ func (s *Store) GetAnalyticsTools(
 	type toolRow struct {
 		sessionID string
 		category  string
+		count     int
 	}
 	var toolRows []toolRow
 
@@ -1475,9 +1476,10 @@ func (s *Store) GetAnalyticsTools(
 		func(chunk []string) error {
 			chunkPB := &paramBuilder{}
 			ph := pgInPlaceholders(chunk, chunkPB)
-			q := `SELECT session_id, category
+			q := `SELECT session_id, category, COUNT(*)
 				FROM tool_calls
-				WHERE session_id IN ` + ph
+				WHERE session_id IN ` + ph + `
+				GROUP BY session_id, category`
 			rows, qErr := s.pg.QueryContext(
 				ctx, q, chunkPB.args...,
 			)
@@ -1489,13 +1491,18 @@ func (s *Store) GetAnalyticsTools(
 			defer rows.Close()
 			for rows.Next() {
 				var sid, cat string
-				if err := rows.Scan(&sid, &cat); err != nil {
+				var count int
+				if err := rows.Scan(
+					&sid, &cat, &count,
+				); err != nil {
 					return fmt.Errorf(
 						"scanning tool_call: %w", err,
 					)
 				}
 				toolRows = append(toolRows, toolRow{
-					sessionID: sid, category: cat,
+					sessionID: sid,
+					category:  cat,
+					count:     count,
 				})
 			}
 			return rows.Err()
@@ -1514,21 +1521,23 @@ func (s *Store) GetAnalyticsTools(
 
 	for _, tr := range toolRows {
 		info := sessionMap[tr.sessionID]
-		catCounts[tr.category]++
+		catCounts[tr.category] += tr.count
 
 		if agentCats[info.agent] == nil {
 			agentCats[info.agent] = make(map[string]int)
 		}
-		agentCats[info.agent][tr.category]++
+		agentCats[info.agent][tr.category] += tr.count
 
 		week := bucketDate(info.date, "week")
 		if trendBuckets[week] == nil {
 			trendBuckets[week] = make(map[string]int)
 		}
-		trendBuckets[week][tr.category]++
+		trendBuckets[week][tr.category] += tr.count
 	}
 
-	resp.TotalCalls = len(toolRows)
+	for _, count := range catCounts {
+		resp.TotalCalls += count
+	}
 
 	resp.ByCategory = make(
 		[]db.ToolCategoryCount, 0, len(catCounts),
@@ -1629,8 +1638,7 @@ func (s *Store) queryVelocityMsgs(
 	pb := &paramBuilder{}
 	ph := pgInPlaceholders(chunk, pb)
 	q := `SELECT session_id, ordinal, role,
-		TO_CHAR(timestamp AT TIME ZONE 'UTC',
-			'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+		timestamp,
 		content_length
 		FROM messages
 		WHERE session_id IN ` + ph + `
@@ -1648,7 +1656,7 @@ func (s *Store) queryVelocityMsgs(
 		var sid string
 		var ordinal int
 		var role string
-		var ts *string
+		var ts *time.Time
 		var cl int
 		if err := rows.Scan(
 			&sid, &ordinal, &role, &ts, &cl,
@@ -1657,11 +1665,12 @@ func (s *Store) queryVelocityMsgs(
 				"scanning velocity msg: %w", err,
 			)
 		}
-		tsStr := ""
+		t := time.Time{}
+		ok := false
 		if ts != nil {
-			tsStr = *ts
+			t = ts.In(loc)
+			ok = true
 		}
-		t, ok := localTime(tsStr, loc)
 		sessionMsgs[sid] = append(sessionMsgs[sid],
 			velocityMsg{
 				role: role, ts: t, valid: ok,

--- a/internal/postgres/analytics_unit_test.go
+++ b/internal/postgres/analytics_unit_test.go
@@ -1,0 +1,191 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+type analyticsProbeDriver struct{}
+
+type analyticsProbeConn struct {
+	state *analyticsProbeState
+}
+
+type analyticsProbeRows struct {
+	columns []string
+	values  [][]driver.Value
+	next    int
+}
+
+type analyticsProbeState struct {
+	mu      sync.Mutex
+	queries []string
+}
+
+var (
+	analyticsProbeRegisterOnce sync.Once
+	analyticsProbeStatesMu     sync.Mutex
+	analyticsProbeStates       = map[string]*analyticsProbeState{}
+)
+
+func newAnalyticsProbeDB(
+	t *testing.T, state *analyticsProbeState,
+) *sql.DB {
+	t.Helper()
+	analyticsProbeRegisterOnce.Do(func() {
+		sql.Register("agentsview_analytics_probe", analyticsProbeDriver{})
+	})
+	name := t.Name()
+	analyticsProbeStatesMu.Lock()
+	analyticsProbeStates[name] = state
+	analyticsProbeStatesMu.Unlock()
+	t.Cleanup(func() {
+		analyticsProbeStatesMu.Lock()
+		delete(analyticsProbeStates, name)
+		analyticsProbeStatesMu.Unlock()
+	})
+
+	pg, err := sql.Open("agentsview_analytics_probe", name)
+	require.NoError(t, err, "open analytics probe db")
+	t.Cleanup(func() { pg.Close() })
+	return pg
+}
+
+func (analyticsProbeDriver) Open(name string) (driver.Conn, error) {
+	analyticsProbeStatesMu.Lock()
+	state := analyticsProbeStates[name]
+	analyticsProbeStatesMu.Unlock()
+	return &analyticsProbeConn{state: state}, nil
+}
+
+func (c *analyticsProbeConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not implemented")
+}
+
+func (c *analyticsProbeConn) Close() error { return nil }
+
+func (c *analyticsProbeConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("begin not implemented")
+}
+
+func (c *analyticsProbeConn) QueryContext(
+	_ context.Context, query string, _ []driver.NamedValue,
+) (driver.Rows, error) {
+	c.state.mu.Lock()
+	c.state.queries = append(c.state.queries, query)
+	c.state.mu.Unlock()
+
+	normalized := strings.ToLower(query)
+	switch {
+	case strings.Contains(normalized, "from sessions"):
+		return &analyticsProbeRows{
+			columns: []string{"id", "date", "agent"},
+			values: [][]driver.Value{
+				{"s1", time.Date(2024, 6, 3, 9, 0, 0, 0, time.UTC), "claude"},
+				{"s2", time.Date(2024, 6, 4, 9, 0, 0, 0, time.UTC), "codex"},
+			},
+		}, nil
+	case strings.Contains(normalized, "from tool_calls"):
+		if !strings.Contains(normalized, "group by session_id, category") {
+			return nil, errors.New("tool call query must group by session_id, category")
+		}
+		return &analyticsProbeRows{
+			columns: []string{"session_id", "category", "count"},
+			values: [][]driver.Value{
+				{"s1", "Read", int64(2)},
+				{"s1", "Bash", int64(1)},
+				{"s2", "Read", int64(1)},
+			},
+		}, nil
+	case strings.Contains(normalized, "from messages"):
+		if strings.Contains(normalized, "to_char") {
+			return nil, errors.New("velocity query must scan native timestamps")
+		}
+		return &analyticsProbeRows{
+			columns: []string{
+				"session_id", "ordinal", "role",
+				"timestamp", "content_length",
+			},
+			values: [][]driver.Value{
+				{
+					"s1", int64(0), "user",
+					time.Date(2024, 6, 3, 9, 0, 0, 0, time.UTC),
+					int64(2),
+				},
+				{
+					"s1", int64(1), "assistant",
+					time.Date(2024, 6, 3, 9, 0, 10, 0, time.UTC),
+					int64(5),
+				},
+			},
+		}, nil
+	default:
+		return nil, errors.New("unexpected analytics query")
+	}
+}
+
+func (r *analyticsProbeRows) Columns() []string { return r.columns }
+
+func (r *analyticsProbeRows) Close() error { return nil }
+
+func (r *analyticsProbeRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.next])
+	r.next++
+	return nil
+}
+
+func TestGetAnalyticsToolsAggregatesToolCallsInSQL(t *testing.T) {
+	store := &Store{
+		pg: newAnalyticsProbeDB(t, &analyticsProbeState{}),
+	}
+
+	resp, err := store.GetAnalyticsTools(
+		context.Background(),
+		db.AnalyticsFilter{
+			From: "2024-06-01",
+			To:   "2024-06-30",
+		},
+	)
+	require.NoError(t, err, "GetAnalyticsTools")
+
+	assert.Equal(t, 4, resp.TotalCalls)
+	require.NotEmpty(t, resp.ByCategory)
+	assert.Equal(t, "Read", resp.ByCategory[0].Category)
+	assert.Equal(t, 3, resp.ByCategory[0].Count)
+}
+
+func TestQueryVelocityMsgsScansNativeTimestamps(t *testing.T) {
+	store := &Store{
+		pg: newAnalyticsProbeDB(t, &analyticsProbeState{}),
+	}
+	sessionMsgs := map[string][]velocityMsg{}
+
+	err := store.queryVelocityMsgs(
+		context.Background(),
+		[]string{"s1"},
+		time.UTC,
+		sessionMsgs,
+	)
+	require.NoError(t, err, "queryVelocityMsgs")
+
+	require.Len(t, sessionMsgs["s1"], 2)
+	assert.Equal(t, "assistant", sessionMsgs["s1"][1].role)
+	assert.True(t, sessionMsgs["s1"][1].valid)
+	assert.Equal(t, 10.0,
+		sessionMsgs["s1"][1].ts.Sub(sessionMsgs["s1"][0].ts).Seconds())
+}

--- a/internal/postgres/pricing.go
+++ b/internal/postgres/pricing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -16,6 +17,14 @@ type modelRates struct {
 	output        float64
 	cacheCreation float64
 	cacheRead     float64
+}
+
+type pricingLoad struct {
+	done    chan struct{}
+	cancel  context.CancelFunc
+	waiters int
+	prices  map[string]modelRates
+	err     error
 }
 
 func lookupModelRates(
@@ -59,15 +68,87 @@ func fallbackPricingMap() map[string]modelRates {
 	return pricingRowsToMap(fallbackPricingRows())
 }
 
+func clonePricingMap(in map[string]modelRates) map[string]modelRates {
+	out := make(map[string]modelRates, len(in))
+	maps.Copy(out, in)
+	return out
+}
+
 func (s *Store) loadPricingMap(
 	ctx context.Context,
 ) (map[string]modelRates, error) {
-	out := fallbackPricingMap()
-	if err := s.mergeDBPricing(ctx, out); err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	s.applyCustomPricing(out)
-	return out, nil
+	load := s.startPricingLoad()
+	defer s.leavePricingLoad(load)
+
+	select {
+	case <-load.done:
+		if load.err != nil {
+			return nil, load.err
+		}
+		return clonePricingMap(load.prices), nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *Store) startPricingLoad() *pricingLoad {
+	s.pricingLoadMu.Lock()
+	defer s.pricingLoadMu.Unlock()
+	if s.pricingLoad != nil {
+		s.pricingLoad.waiters++
+		return s.pricingLoad
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	load := &pricingLoad{
+		done:    make(chan struct{}),
+		cancel:  cancel,
+		waiters: 1,
+	}
+	s.pricingLoad = load
+	go s.runPricingLoad(ctx, load)
+	return load
+}
+
+func (s *Store) runPricingLoad(ctx context.Context, load *pricingLoad) {
+	out := fallbackPricingMap()
+	err := s.mergeDBPricing(ctx, out)
+	load.cancel()
+
+	var prices map[string]modelRates
+	if err == nil {
+		s.pricingMu.Lock()
+		s.applyCustomPricing(out)
+		s.pricingMu.Unlock()
+		prices = clonePricingMap(out)
+	}
+
+	s.pricingLoadMu.Lock()
+	defer s.pricingLoadMu.Unlock()
+	load.err = err
+	load.prices = prices
+	if s.pricingLoad == load {
+		s.pricingLoad = nil
+	}
+	close(load.done)
+}
+
+func (s *Store) leavePricingLoad(load *pricingLoad) {
+	s.pricingLoadMu.Lock()
+	defer s.pricingLoadMu.Unlock()
+	load.waiters--
+	if load.waiters == 0 && s.pricingLoad == load {
+		load.cancel()
+	}
+}
+
+func (s *Store) forgetPricingLoad() {
+	s.pricingLoadMu.Lock()
+	defer s.pricingLoadMu.Unlock()
+	s.pricingLoad = nil
 }
 
 // mergeDBPricing layers rows from the PG model_pricing table onto
@@ -135,6 +216,94 @@ func (s *Store) applyCustomPricing(out map[string]modelRates) {
 	}
 }
 
+const pricingUpsertBatch = 100
+
+func pgPricingUpsertStatement(
+	prices []db.ModelPricing, defaultUpdatedAt string,
+) (string, []any) {
+	var b strings.Builder
+	b.WriteString(`INSERT INTO model_pricing
+		(model_pattern, input_per_mtok, output_per_mtok,
+		 cache_creation_per_mtok, cache_read_per_mtok,
+		 updated_at)
+	VALUES `)
+	args := make([]any, 0, len(prices)*6)
+	for i, p := range prices {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		base := i*6 + 1
+		fmt.Fprintf(
+			&b,
+			"($%d, $%d, $%d, $%d, $%d, $%d)",
+			base, base+1, base+2, base+3, base+4, base+5,
+		)
+		updatedAt := p.UpdatedAt
+		if updatedAt == "" {
+			updatedAt = defaultUpdatedAt
+		}
+		args = append(args,
+			sanitizePG(p.ModelPattern),
+			p.InputPerMTok,
+			p.OutputPerMTok,
+			p.CacheCreationPerMTok,
+			p.CacheReadPerMTok,
+			sanitizePG(updatedAt),
+		)
+	}
+	b.WriteString(`
+	ON CONFLICT (model_pattern) DO UPDATE SET
+		input_per_mtok = EXCLUDED.input_per_mtok,
+		output_per_mtok = EXCLUDED.output_per_mtok,
+		cache_creation_per_mtok = EXCLUDED.cache_creation_per_mtok,
+		cache_read_per_mtok = EXCLUDED.cache_read_per_mtok,
+		updated_at = EXCLUDED.updated_at
+	WHERE model_pricing.input_per_mtok IS DISTINCT FROM
+			EXCLUDED.input_per_mtok
+		OR model_pricing.output_per_mtok IS DISTINCT FROM
+			EXCLUDED.output_per_mtok
+		OR model_pricing.cache_creation_per_mtok IS DISTINCT FROM
+			EXCLUDED.cache_creation_per_mtok
+		OR model_pricing.cache_read_per_mtok IS DISTINCT FROM
+			EXCLUDED.cache_read_per_mtok`)
+	return b.String(), args
+}
+
+func listPGModelPricing(
+	ctx context.Context, pg *sql.DB,
+) ([]db.ModelPricing, error) {
+	rows, err := pg.QueryContext(ctx,
+		`SELECT model_pattern, input_per_mtok,
+			output_per_mtok, cache_creation_per_mtok,
+			cache_read_per_mtok, updated_at
+		 FROM model_pricing`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing pg pricing: %w", err)
+	}
+	defer rows.Close()
+
+	var out []db.ModelPricing
+	for rows.Next() {
+		var p db.ModelPricing
+		if err := rows.Scan(
+			&p.ModelPattern,
+			&p.InputPerMTok,
+			&p.OutputPerMTok,
+			&p.CacheCreationPerMTok,
+			&p.CacheReadPerMTok,
+			&p.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scanning pg pricing: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating pg pricing: %w", err)
+	}
+	return out, nil
+}
+
 func upsertModelPricing(
 	ctx context.Context, pg *sql.DB, prices []db.ModelPricing,
 ) error {
@@ -148,40 +317,16 @@ func upsertModelPricing(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	stmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO model_pricing
-			(model_pattern, input_per_mtok, output_per_mtok,
-			 cache_creation_per_mtok, cache_read_per_mtok,
-			 updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (model_pattern) DO UPDATE SET
-			input_per_mtok = EXCLUDED.input_per_mtok,
-			output_per_mtok = EXCLUDED.output_per_mtok,
-			cache_creation_per_mtok = EXCLUDED.cache_creation_per_mtok,
-			cache_read_per_mtok = EXCLUDED.cache_read_per_mtok,
-			updated_at = EXCLUDED.updated_at`)
-	if err != nil {
-		return fmt.Errorf("preparing pg pricing upsert: %w", err)
-	}
-	defer stmt.Close()
-
-	for _, p := range prices {
-		updatedAt := p.UpdatedAt
-		if updatedAt == "" {
-			updatedAt = time.Now().UTC().Format(time.RFC3339Nano)
-		}
-		if _, err := stmt.ExecContext(
-			ctx,
-			sanitizePG(p.ModelPattern),
-			p.InputPerMTok,
-			p.OutputPerMTok,
-			p.CacheCreationPerMTok,
-			p.CacheReadPerMTok,
-			sanitizePG(updatedAt),
-		); err != nil {
+	defaultUpdatedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	for i := 0; i < len(prices); i += pricingUpsertBatch {
+		end := min(i+pricingUpsertBatch, len(prices))
+		query, args := pgPricingUpsertStatement(
+			prices[i:end], defaultUpdatedAt,
+		)
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 			return fmt.Errorf(
-				"upserting pg pricing %q: %w",
-				p.ModelPattern, err,
+				"upserting pg pricing batch starting at %d: %w",
+				i, err,
 			)
 		}
 	}
@@ -200,7 +345,17 @@ func (s *Sync) syncModelPricing(ctx context.Context) error {
 	if len(prices) == 0 {
 		prices = fallbackPricingRows()
 	}
-	if err := upsertModelPricing(ctx, s.pg, prices); err != nil {
+	existing, err := listPGModelPricing(ctx, s.pg)
+	if err != nil {
+		return fmt.Errorf("listing pg model pricing: %w", err)
+	}
+	_, changedPrices := db.FilterChangedModelPricing(
+		existing, prices,
+	)
+	if len(changedPrices) == 0 {
+		return nil
+	}
+	if err := upsertModelPricing(ctx, s.pg, changedPrices); err != nil {
 		return fmt.Errorf("syncing model pricing to pg: %w", err)
 	}
 	return nil

--- a/internal/postgres/pricing.go
+++ b/internal/postgres/pricing.go
@@ -137,11 +137,16 @@ func (s *Store) runPricingLoad(ctx context.Context, load *pricingLoad) {
 }
 
 func (s *Store) leavePricingLoad(load *pricingLoad) {
+	var cancel context.CancelFunc
 	s.pricingLoadMu.Lock()
-	defer s.pricingLoadMu.Unlock()
 	load.waiters--
 	if load.waiters == 0 && s.pricingLoad == load {
-		load.cancel()
+		s.pricingLoad = nil
+		cancel = load.cancel
+	}
+	s.pricingLoadMu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
 }
 

--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -1,7 +1,14 @@
 package postgres
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -9,6 +16,136 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 )
+
+type pricingProbeDriver struct{}
+
+type pricingProbeConn struct {
+	state *pricingProbeState
+}
+
+type pricingProbeRows struct {
+	columns []string
+	values  [][]driver.Value
+	next    int
+}
+
+type pricingProbeState struct {
+	mu       sync.Mutex
+	doneOnce sync.Once
+	queries  int
+	err      error
+	rows     [][]driver.Value
+	block    <-chan struct{}
+	done     chan struct{}
+}
+
+var (
+	pricingProbeRegisterOnce sync.Once
+	pricingProbeStatesMu     sync.Mutex
+	pricingProbeStates       = map[string]*pricingProbeState{}
+)
+
+func newPricingProbeDB(
+	t *testing.T, state *pricingProbeState,
+) *sql.DB {
+	t.Helper()
+	pricingProbeRegisterOnce.Do(func() {
+		sql.Register("agentsview_pricing_probe", pricingProbeDriver{})
+	})
+	name := t.Name()
+	pricingProbeStatesMu.Lock()
+	pricingProbeStates[name] = state
+	pricingProbeStatesMu.Unlock()
+	t.Cleanup(func() {
+		pricingProbeStatesMu.Lock()
+		delete(pricingProbeStates, name)
+		pricingProbeStatesMu.Unlock()
+	})
+
+	pg, err := sql.Open("agentsview_pricing_probe", name)
+	require.NoError(t, err, "open pricing probe db")
+	t.Cleanup(func() { pg.Close() })
+	return pg
+}
+
+func (pricingProbeDriver) Open(name string) (driver.Conn, error) {
+	pricingProbeStatesMu.Lock()
+	state := pricingProbeStates[name]
+	pricingProbeStatesMu.Unlock()
+	return &pricingProbeConn{state: state}, nil
+}
+
+func (c *pricingProbeConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not implemented")
+}
+
+func (c *pricingProbeConn) Close() error { return nil }
+
+func (c *pricingProbeConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("begin not implemented")
+}
+
+func (c *pricingProbeConn) QueryContext(
+	ctx context.Context, query string, _ []driver.NamedValue,
+) (driver.Rows, error) {
+	defer func() {
+		if c.state.done != nil {
+			c.state.doneOnce.Do(func() { close(c.state.done) })
+		}
+	}()
+	c.state.mu.Lock()
+	c.state.queries++
+	err := c.state.err
+	values := append([][]driver.Value(nil), c.state.rows...)
+	block := c.state.block
+	c.state.mu.Unlock()
+	if block != nil {
+		select {
+		case <-block:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &pricingProbeRows{
+		columns: []string{
+			"model_pattern",
+			"input_per_mtok",
+			"output_per_mtok",
+			"cache_creation_per_mtok",
+			"cache_read_per_mtok",
+			"updated_at",
+		},
+		values: values,
+	}, nil
+}
+
+func (r *pricingProbeRows) Columns() []string { return r.columns }
+
+func (r *pricingProbeRows) Close() error { return nil }
+
+func (r *pricingProbeRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.next])
+	r.next++
+	return nil
+}
+
+func (s *pricingProbeState) queryCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.queries
+}
+
+func (s *pricingProbeState) setRows(rows [][]driver.Value) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rows = rows
+}
 
 func TestCustomPricingOverridesPricingMap(t *testing.T) {
 	tests := []struct {
@@ -57,4 +194,340 @@ func TestCustomPricingOverridesPricingMap(t *testing.T) {
 			assert.InDelta(t, tt.wantInput, got.input, 0.001)
 		})
 	}
+}
+
+func TestLoadPricingMapSharesConcurrentDBRows(t *testing.T) {
+	block := make(chan struct{})
+	state := &pricingProbeState{
+		rows: [][]driver.Value{{
+			"db-model", 1.0, 2.0, 3.0, 4.0, "2026-06-08",
+		}},
+		block: block,
+	}
+	pg := newPricingProbeDB(t, state)
+	store := &Store{pg: pg}
+
+	type result struct {
+		prices map[string]modelRates
+		err    error
+	}
+	results := make(chan result, 2)
+	go func() {
+		prices, err := store.loadPricingMap(context.Background())
+		results <- result{prices: prices, err: err}
+	}()
+	require.Eventually(t, func() bool {
+		return state.queryCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	go func() {
+		prices, err := store.loadPricingMap(context.Background())
+		results <- result{prices: prices, err: err}
+	}()
+	require.Never(t, func() bool {
+		return state.queryCount() > 1
+	}, 50*time.Millisecond, 10*time.Millisecond)
+	close(block)
+
+	first := <-results
+	second := <-results
+	require.NoError(t, first.err, "first loadPricingMap")
+	require.NoError(t, second.err, "second loadPricingMap")
+	require.Equal(t, 1, state.queryCount(), "pricing queries")
+	first.prices["db-model"] = modelRates{input: 99.0}
+	assert.InDelta(t, 1.0, second.prices["db-model"].input, 0.001)
+}
+
+func TestLoadPricingMapKeepsSharedDBRowsForActiveCaller(t *testing.T) {
+	block := make(chan struct{})
+	var unblockOnce sync.Once
+	unblock := func() { unblockOnce.Do(func() { close(block) }) }
+	defer unblock()
+	state := &pricingProbeState{
+		rows: [][]driver.Value{{
+			"db-model", 1.0, 2.0, 3.0, 4.0, "2026-06-08",
+		}},
+		block: block,
+	}
+	pg := newPricingProbeDB(t, state)
+	store := &Store{pg: pg}
+
+	type result struct {
+		prices map[string]modelRates
+		err    error
+	}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstResult := make(chan result, 1)
+	go func() {
+		prices, err := store.loadPricingMap(firstCtx)
+		firstResult <- result{prices: prices, err: err}
+	}()
+	require.Eventually(t, func() bool {
+		return state.queryCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	secondResult := make(chan result, 1)
+	go func() {
+		prices, err := store.loadPricingMap(context.Background())
+		secondResult <- result{prices: prices, err: err}
+	}()
+	require.Never(t, func() bool {
+		return state.queryCount() > 1
+	}, 50*time.Millisecond, 10*time.Millisecond)
+
+	cancelFirst()
+
+	first := <-firstResult
+	require.ErrorIs(t, first.err, context.Canceled)
+
+	unblock()
+	second := <-secondResult
+	require.NoError(t, second.err, "second loadPricingMap")
+	assert.InDelta(t, 1.0, second.prices["db-model"].input, 0.001)
+	assert.Equal(t, 1, state.queryCount(), "pricing queries")
+}
+
+func TestLoadPricingMapCancelsDBRowsWithCaller(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	state := &pricingProbeState{
+		rows: [][]driver.Value{{
+			"db-model", 1.0, 2.0, 3.0, 4.0, "2026-06-08",
+		}},
+		block: block,
+		done:  make(chan struct{}),
+	}
+	pg := newPricingProbeDB(t, state)
+	store := &Store{pg: pg}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := store.loadPricingMap(ctx)
+		result <- err
+	}()
+	require.Eventually(t, func() bool {
+		return state.queryCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-state.done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.ErrorIs(t, <-result, context.Canceled)
+}
+
+func TestSetCustomPricingForgetsInFlightPricingLoad(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	state := &pricingProbeState{
+		rows: [][]driver.Value{{
+			"db-model", 1.0, 2.0, 3.0, 4.0, "2026-06-08",
+		}},
+		block: block,
+	}
+	pg := newPricingProbeDB(t, state)
+	store := &Store{pg: pg}
+
+	type result struct {
+		prices map[string]modelRates
+		err    error
+	}
+	results := make(chan result, 2)
+	go func() {
+		prices, err := store.loadPricingMap(context.Background())
+		results <- result{prices: prices, err: err}
+	}()
+	require.Eventually(t, func() bool {
+		return state.queryCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	store.SetCustomPricing(map[string]config.CustomModelRate{
+		"custom-model": {Input: 9.0},
+	})
+	go func() {
+		prices, err := store.loadPricingMap(context.Background())
+		results <- result{prices: prices, err: err}
+	}()
+
+	require.Eventually(t, func() bool {
+		return state.queryCount() == 2
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestLoadPricingMapReloadsAfterCompletedDBRows(t *testing.T) {
+	state := &pricingProbeState{
+		rows: [][]driver.Value{{
+			"db-model", 1.0, 2.0, 3.0, 4.0, "2026-06-08",
+		}},
+	}
+	pg := newPricingProbeDB(t, state)
+	store := &Store{pg: pg}
+
+	first, err := store.loadPricingMap(context.Background())
+	require.NoError(t, err, "first loadPricingMap")
+	state.setRows([][]driver.Value{{
+		"db-model", 7.0, 2.0, 3.0, 4.0, "2026-06-08",
+	}})
+	second, err := store.loadPricingMap(context.Background())
+	require.NoError(t, err, "second loadPricingMap")
+
+	require.Equal(t, 2, state.queryCount(), "pricing queries")
+	assert.InDelta(t, 1.0, first["db-model"].input, 0.001)
+	assert.InDelta(t, 7.0, second["db-model"].input, 0.001)
+}
+
+func TestLoadPricingMapDoesNotCacheMissingTableFallback(t *testing.T) {
+	state := &pricingProbeState{
+		err: errors.New(`relation "model_pricing" does not exist (SQLSTATE 42P01)`),
+	}
+	pg := newPricingProbeDB(t, state)
+	store := &Store{pg: pg}
+
+	_, err := store.loadPricingMap(context.Background())
+	require.NoError(t, err, "first loadPricingMap")
+	_, err = store.loadPricingMap(context.Background())
+	require.NoError(t, err, "second loadPricingMap")
+
+	assert.Equal(t, 2, state.queryCount(), "pricing queries")
+}
+
+func TestPGPricingUpsertStatementBatchesRows(t *testing.T) {
+	query, args := pgPricingUpsertStatement([]db.ModelPricing{
+		{
+			ModelPattern:         "model-a",
+			InputPerMTok:         1,
+			OutputPerMTok:        2,
+			CacheCreationPerMTok: 3,
+			CacheReadPerMTok:     4,
+		},
+		{
+			ModelPattern:         "model-b",
+			InputPerMTok:         5,
+			OutputPerMTok:        6,
+			CacheCreationPerMTok: 7,
+			CacheReadPerMTok:     8,
+			UpdatedAt:            "source-time",
+		},
+	}, "call-time")
+
+	assert.Contains(t, query,
+		"VALUES ($1, $2, $3, $4, $5, $6), "+
+			"($7, $8, $9, $10, $11, $12)")
+	assert.Contains(t, query,
+		"model_pricing.input_per_mtok IS DISTINCT FROM")
+	assert.Contains(t, query, "EXCLUDED.input_per_mtok")
+	assert.NotContains(t, query,
+		"model_pricing.updated_at IS DISTINCT FROM")
+	require.Len(t, args, 12)
+	assert.Equal(t, "model-a", args[0])
+	assert.Equal(t, "call-time", args[5])
+	assert.Equal(t, "model-b", args[6])
+	assert.Equal(t, "source-time", args[11])
+}
+
+func TestPGPricingFilterMatchesUpsertSemantics(t *testing.T) {
+	existing := []db.ModelPricing{
+		{
+			ModelPattern:         "_fallback_version",
+			InputPerMTok:         0,
+			OutputPerMTok:        0,
+			CacheCreationPerMTok: 0,
+			CacheReadPerMTok:     0,
+			UpdatedAt:            "v1",
+		},
+		{
+			ModelPattern:         "same-model",
+			InputPerMTok:         1,
+			OutputPerMTok:        2,
+			CacheCreationPerMTok: 3,
+			CacheReadPerMTok:     4,
+			UpdatedAt:            "old",
+		},
+		{
+			ModelPattern:         "changed-model",
+			InputPerMTok:         1,
+			OutputPerMTok:        2,
+			CacheCreationPerMTok: 3,
+			CacheReadPerMTok:     4,
+			UpdatedAt:            "old",
+		},
+	}
+	desired := []db.ModelPricing{
+		{
+			ModelPattern:         "_fallback_version",
+			InputPerMTok:         0,
+			OutputPerMTok:        0,
+			CacheCreationPerMTok: 0,
+			CacheReadPerMTok:     0,
+			UpdatedAt:            "v2",
+		},
+		{
+			ModelPattern:         "same-model",
+			InputPerMTok:         1,
+			OutputPerMTok:        2,
+			CacheCreationPerMTok: 3,
+			CacheReadPerMTok:     4,
+			UpdatedAt:            "new",
+		},
+		{
+			ModelPattern:         "changed-model",
+			InputPerMTok:         1,
+			OutputPerMTok:        9,
+			CacheCreationPerMTok: 3,
+			CacheReadPerMTok:     4,
+			UpdatedAt:            "new",
+		},
+		{
+			ModelPattern:         "missing-model",
+			InputPerMTok:         5,
+			OutputPerMTok:        6,
+			CacheCreationPerMTok: 7,
+			CacheReadPerMTok:     8,
+			UpdatedAt:            "new",
+		},
+	}
+
+	got, changedRows := db.FilterChangedModelPricing(existing, desired)
+
+	assert.Equal(t, db.PricingChangeSummary{
+		Total:     4,
+		Missing:   1,
+		Changed:   1,
+		Unchanged: 2,
+	}, got)
+	require.Len(t, changedRows, 2)
+	assert.Equal(t, "changed-model", changedRows[0].ModelPattern)
+	assert.Equal(t, "missing-model", changedRows[1].ModelPattern)
+}
+
+func TestSyncModelPricingSkipsWriteWhenRemoteRowsUnchanged(t *testing.T) {
+	ctx := context.Background()
+	local, err := db.Open(t.TempDir() + "/local.db")
+	require.NoError(t, err, "open local db")
+	t.Cleanup(func() { local.Close() })
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern:         "same-model",
+		InputPerMTok:         1,
+		OutputPerMTok:        2,
+		CacheCreationPerMTok: 3,
+		CacheReadPerMTok:     4,
+	}}), "seed local pricing")
+
+	state := &pricingProbeState{
+		rows: [][]driver.Value{{
+			"same-model", 1.0, 2.0, 3.0, 4.0, "old",
+		}},
+	}
+	pg := newPricingProbeDB(t, state)
+	sync := &Sync{pg: pg, local: local}
+
+	require.NoError(t, sync.syncModelPricing(ctx))
+	assert.Equal(t, 1, state.queryCount(), "pg pricing reads")
 }

--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -30,13 +30,14 @@ type pricingProbeRows struct {
 }
 
 type pricingProbeState struct {
-	mu       sync.Mutex
-	doneOnce sync.Once
-	queries  int
-	err      error
-	rows     [][]driver.Value
-	block    <-chan struct{}
-	done     chan struct{}
+	mu               sync.Mutex
+	doneOnce         sync.Once
+	queries          int
+	err              error
+	rows             [][]driver.Value
+	block            <-chan struct{}
+	afterCancelBlock <-chan struct{}
+	done             chan struct{}
 }
 
 var (
@@ -98,11 +99,15 @@ func (c *pricingProbeConn) QueryContext(
 	err := c.state.err
 	values := append([][]driver.Value(nil), c.state.rows...)
 	block := c.state.block
+	afterCancelBlock := c.state.afterCancelBlock
 	c.state.mu.Unlock()
 	if block != nil {
 		select {
 		case <-block:
 		case <-ctx.Done():
+			if afterCancelBlock != nil {
+				<-afterCancelBlock
+			}
 			return nil, ctx.Err()
 		}
 	}
@@ -145,6 +150,13 @@ func (s *pricingProbeState) setRows(rows [][]driver.Value) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.rows = rows
+}
+
+func (s *pricingProbeState) unblockNextQuery() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.block = nil
+	s.afterCancelBlock = nil
 }
 
 func TestCustomPricingOverridesPricingMap(t *testing.T) {
@@ -321,6 +333,46 @@ func TestLoadPricingMapCancelsDBRowsWithCaller(t *testing.T) {
 		}
 	}, time.Second, 10*time.Millisecond)
 	require.ErrorIs(t, <-result, context.Canceled)
+}
+
+func TestLoadPricingMapStartsFreshLoadAfterAllWaitersCancel(t *testing.T) {
+	block := make(chan struct{})
+	releaseCanceledQuery := make(chan struct{})
+	defer close(releaseCanceledQuery)
+	state := &pricingProbeState{
+		rows: [][]driver.Value{{
+			"db-model", 1.0, 2.0, 3.0, 4.0, "2026-06-08",
+		}},
+		block:            block,
+		afterCancelBlock: releaseCanceledQuery,
+	}
+	pg := newPricingProbeDB(t, state)
+	store := &Store{pg: pg}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := store.loadPricingMap(ctx)
+		firstResult <- err
+	}()
+	require.Eventually(t, func() bool {
+		return state.queryCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.ErrorIs(t, <-firstResult, context.Canceled)
+	state.unblockNextQuery()
+
+	secondResult := make(chan error, 1)
+	go func() {
+		_, err := store.loadPricingMap(context.Background())
+		secondResult <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		return state.queryCount() == 2
+	}, time.Second, 10*time.Millisecond)
+	require.NoError(t, <-secondResult, "second loadPricingMap")
 }
 
 func TestSetCustomPricingForgetsInFlightPricingLoad(t *testing.T) {

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -70,6 +70,10 @@ CREATE TABLE IF NOT EXISTS sessions (
     updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+CREATE INDEX IF NOT EXISTS idx_sessions_parent
+    ON sessions (parent_session_id)
+    WHERE parent_session_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS messages (
     session_id     TEXT NOT NULL,
     ordinal        INT NOT NULL,
@@ -99,6 +103,9 @@ CREATE TABLE IF NOT EXISTS messages (
     FOREIGN KEY (session_id)
         REFERENCES sessions(id) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_messages_velocity
+    ON messages (session_id, ordinal, role, timestamp, content_length);
 
 CREATE TABLE IF NOT EXISTS usage_events (
     id BIGSERIAL PRIMARY KEY,
@@ -191,6 +198,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_tool_calls_dedup
 
 CREATE INDEX IF NOT EXISTS idx_tool_calls_session
     ON tool_calls (session_id);
+
+CREATE INDEX IF NOT EXISTS idx_tool_calls_session_category
+    ON tool_calls (session_id, category);
 
 CREATE TABLE IF NOT EXISTS tool_result_events (
     id                        BIGSERIAL PRIMARY KEY,
@@ -644,6 +654,11 @@ func createPartialIndexesPG(ctx context.Context, db *sql.DB) error {
 		 ON messages(session_id) WHERE is_sidechain = TRUE`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_source_uuid
 		 ON messages(source_uuid) WHERE source_uuid != ''`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_usage_timestamp
+		 ON messages(timestamp, session_id, ordinal)
+		 WHERE token_usage != ''
+		   AND model != ''
+		   AND model != '<synthetic>'`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_has_secret
 		 ON sessions(secret_leak_count) WHERE secret_leak_count > 0`,
 	}

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -28,6 +28,7 @@ type schemaProbeRows struct {
 type schemaProbeState struct {
 	mu                  sync.Mutex
 	informationQueries  int
+	execs               []string
 	alterTableExecs     []string
 	currentSchema       string
 	existingColumnNames map[string][]string
@@ -93,6 +94,9 @@ func (c *schemaProbeConn) Begin() (driver.Tx, error) {
 func (c *schemaProbeConn) ExecContext(
 	_ context.Context, query string, _ []driver.NamedValue,
 ) (driver.Result, error) {
+	c.state.mu.Lock()
+	c.state.execs = append(c.state.execs, query)
+	c.state.mu.Unlock()
 	if strings.Contains(strings.ToLower(query), "alter table") {
 		c.state.mu.Lock()
 		c.state.alterTableExecs = append(
@@ -141,6 +145,12 @@ func (c *schemaProbeConn) QueryContext(
 				"user_message_count", "is_automated",
 			},
 		}, nil
+	case strings.Contains(normalized, "select exists") &&
+		strings.Contains(normalized, "from sync_metadata"):
+		return &schemaProbeRows{
+			columns: []string{"exists"},
+			values:  [][]driver.Value{{true}},
+		}, nil
 	case strings.Contains(normalized, "select exists"):
 		return &schemaProbeRows{
 			columns: []string{"exists"},
@@ -174,6 +184,12 @@ func (s *schemaProbeState) alterTableExecCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.alterTableExecs)
+}
+
+func (s *schemaProbeState) executedSQL() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return strings.Join(s.execs, "\n")
 }
 
 func TestEnsureSchemaBatchesColumnIntrospection(t *testing.T) {
@@ -215,6 +231,51 @@ func TestEnsureSchemaBatchesColumnIntrospection(t *testing.T) {
 
 	assert.Equal(t, 1, state.informationQueryCount(),
 		"information_schema.columns queries")
+}
+
+func TestEnsureSchemaCreatesAnalyticsCoveringIndexes(t *testing.T) {
+	db, state := newSchemaProbeDB(t, map[string][]string{
+		"sessions": {
+			"total_output_tokens", "peak_context_tokens",
+			"has_total_output_tokens",
+			"has_peak_context_tokens",
+		},
+		"messages": {
+			"context_tokens", "output_tokens",
+			"has_context_tokens", "has_output_tokens",
+		},
+		"tool_calls": {},
+	})
+
+	require.NoError(t, EnsureSchema(context.Background(), db, "agentsview"))
+
+	sql := state.executedSQL()
+	assert.Contains(t, sql,
+		"CREATE INDEX IF NOT EXISTS idx_tool_calls_session_category")
+	assert.Contains(t, sql,
+		"CREATE INDEX IF NOT EXISTS idx_messages_velocity")
+	assert.Contains(t, sql,
+		"CREATE INDEX IF NOT EXISTS idx_messages_usage_timestamp")
+}
+
+func TestEnsureSchemaCreatesSessionTraversalIndex(t *testing.T) {
+	db, state := newSchemaProbeDB(t, map[string][]string{
+		"sessions": {
+			"total_output_tokens", "peak_context_tokens",
+			"has_total_output_tokens",
+			"has_peak_context_tokens",
+		},
+		"messages": {
+			"context_tokens", "output_tokens",
+			"has_context_tokens", "has_output_tokens",
+		},
+		"tool_calls": {},
+	})
+
+	require.NoError(t, EnsureSchema(context.Background(), db, "agentsview"))
+
+	assert.Contains(t, state.executedSQL(),
+		"CREATE INDEX IF NOT EXISTS idx_sessions_parent")
 }
 
 func TestEnsureSchemaGroupsMissingColumnMigrationsByTable(t *testing.T) {

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -23,6 +23,9 @@ type Store struct {
 	cursorMu     sync.RWMutex
 	cursorSecret []byte
 
+	pricingMu     sync.Mutex
+	pricingLoadMu sync.Mutex
+	pricingLoad   *pricingLoad
 	customPricing map[string]config.CustomModelRate
 }
 

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -36,7 +36,10 @@ func (s *Store) Close() error {
 }
 
 func (s *Store) SetCustomPricing(p map[string]config.CustomModelRate) {
+	s.pricingMu.Lock()
+	defer s.pricingMu.Unlock()
 	s.customPricing = p
+	s.forgetPricingLoad()
 }
 
 // SetCursorSecret sets the HMAC key used for cursor signing.

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -51,57 +51,6 @@ func paddedUTCBound(ts string, hours int) string {
 	return t.Add(time.Duration(hours) * time.Hour).Format(time.RFC3339)
 }
 
-func appendPGUsageRowFilterClauses(
-	query string, pb *paramBuilder, f db.UsageFilter,
-) (string, []any) {
-	appendCSV := func(q, col, csv string, include bool) string {
-		if csv == "" {
-			return q
-		}
-		vals := strings.Split(csv, ",")
-		op := "IN"
-		if !include {
-			op = "NOT IN"
-		}
-		if len(vals) == 1 {
-			if include {
-				return q + " AND " + col + " = " + pb.add(vals[0])
-			}
-			return q + " AND " + col + " != " + pb.add(vals[0])
-		}
-		placeholders := make([]string, len(vals))
-		for i, v := range vals {
-			placeholders[i] = pb.add(v)
-		}
-		return q + " AND " + col + " " + op + " (" +
-			strings.Join(placeholders, ",") + ")"
-	}
-
-	query = appendCSV(query, "u.agent", f.Agent, true)
-	query = appendCSV(query, "u.project", f.Project, true)
-	query = appendCSV(query, "u.machine", f.Machine, true)
-	query = appendCSV(query, "u.model", f.Model, true)
-	query = appendCSV(query, "u.project", f.ExcludeProject, false)
-	query = appendCSV(query, "u.agent", f.ExcludeAgent, false)
-	query = appendCSV(query, "u.model", f.ExcludeModel, false)
-
-	if f.MinUserMessages > 0 {
-		query += " AND u.user_message_count >= " + pb.add(f.MinUserMessages)
-	}
-	if f.ExcludeOneShot {
-		query += " AND u.user_message_count > 1"
-	}
-	if f.ExcludeAutomated {
-		query += " AND COALESCE(u.is_automated, false) = false"
-	}
-	if f.ActiveSince != "" {
-		query += " AND u.session_activity_at >= " +
-			pb.add(f.ActiveSince) + "::timestamptz"
-	}
-
-	return query, pb.args
-}
-
 func appendPGUsageBranchFilterClauses(
 	where string, pb *paramBuilder, f db.UsageFilter, modelCol string,
 ) string {
@@ -591,44 +540,6 @@ func appendPGUsageColumnBounds(
 	return where
 }
 
-func pgUsageRowsSQLForBounds(b pgUsageBounds) string {
-	if !b.bounded() {
-		return pgUsageRowsSQLWithWhere(
-			pgUsageMessageEligibility,
-			pgUsageEventEligibility,
-		)
-	}
-
-	messageTimestampWhere := pgUsageMessageEligibility +
-		"\n\tAND m.timestamp IS NOT NULL"
-	messageTimestampWhere = appendPGUsageColumnBounds(
-		messageTimestampWhere, "m.timestamp", b)
-	eventTimestampWhere := pgUsageEventEligibility +
-		"\n\tAND ue.occurred_at IS NOT NULL"
-	eventTimestampWhere = appendPGUsageColumnBounds(
-		eventTimestampWhere, "ue.occurred_at", b)
-
-	messageFallbackWhere := pgUsageMessageEligibility +
-		"\n\tAND m.timestamp IS NULL"
-	messageFallbackWhere = appendPGUsageColumnBounds(
-		messageFallbackWhere, "s.started_at", b)
-	eventFallbackWhere := pgUsageEventEligibility +
-		"\n\tAND ue.occurred_at IS NULL"
-	eventFallbackWhere = appendPGUsageColumnBounds(
-		eventFallbackWhere, "s.started_at", b)
-
-	return strings.Join([]string{
-		pgUsageRowsSQLWithWhere(
-			messageTimestampWhere,
-			eventTimestampWhere,
-		),
-		pgUsageRowsSQLWithWhere(
-			messageFallbackWhere,
-			eventFallbackWhere,
-		),
-	}, "\n\nUNION ALL\n\n")
-}
-
 func pgDailyUsageRowsSQLForBounds(
 	pb *paramBuilder, f db.UsageFilter, b pgUsageBounds,
 ) string {
@@ -693,13 +604,6 @@ func pgTopSessionsUsageRowQuery(pb *paramBuilder, f db.UsageFilter) string {
 	return pgUsageRowQuery(pb, f)
 }
 
-func pgUsageFullRowQuery(pb *paramBuilder, f db.UsageFilter) string {
-	bounds := pgUsageBoundsForFilter(pb, f)
-	query := pgUsageRowSelectFromRows(pgUsageRowsSQLForBounds(bounds))
-	query, _ = appendPGUsageRowFilterClauses(query, pb, f)
-	return query
-}
-
 func scanPGUsageRow(rows *sql.Rows) (pgUsageScanRow, error) {
 	var r pgUsageScanRow
 	err := rows.Scan(
@@ -753,39 +657,6 @@ func scanPGDailyUsageRow(rows *sql.Rows) (pgDailyUsageScanRow, error) {
 		&r.agent,
 	)
 	return r, err
-}
-
-func pgUsageAmounts(
-	r pgUsageScanRow, pricing map[string]modelRates,
-) (inputTok, outputTok, cacheCrTok, cacheRdTok int, cost, savings float64) {
-	if r.usageSource == "message" {
-		usage := gjson.Parse(r.tokenJSON)
-		inputTok = int(usage.Get("input_tokens").Int())
-		outputTok = int(usage.Get("output_tokens").Int())
-		cacheCrTok = int(usage.Get("cache_creation_input_tokens").Int())
-		cacheRdTok = int(usage.Get("cache_read_input_tokens").Int())
-	} else {
-		inputTok = r.inputTokens
-		outputTok = r.outputTokens
-		cacheCrTok = r.cacheCreationInputTokens
-		cacheRdTok = r.cacheReadInputTokens
-	}
-
-	rates, _ := lookupModelRates(pricing, r.model)
-	if r.costUSD.Valid {
-		cost = r.costUSD.Float64
-	} else {
-		cost = (float64(inputTok)*rates.input +
-			float64(outputTok)*rates.output +
-			float64(cacheCrTok)*rates.cacheCreation +
-			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
-	}
-	readDelta := float64(cacheRdTok) *
-		(rates.input - rates.cacheRead) / 1_000_000
-	createDelta := float64(cacheCrTok) *
-		(rates.input - rates.cacheCreation) / 1_000_000
-	savings = readDelta + createDelta
-	return
 }
 
 func pgDailyUsageAmounts(

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -18,6 +18,20 @@ const pgUsageMessageEligibility = `
 	AND m.model != '<synthetic>'
 	AND s.deleted_at IS NULL`
 
+const pgUsageMessageSourceEligibility = `
+	m.token_usage != ''
+	AND m.model != ''
+	AND m.model != '<synthetic>'`
+
+const pgUsageEventEligibility = `
+	ue.model != ''
+	AND s.deleted_at IS NULL`
+
+const pgUsageEventSourceEligibility = `
+	ue.model != ''`
+
+const pgUsageSessionEligibility = `s.deleted_at IS NULL`
+
 func usageLocation(f db.UsageFilter) *time.Location {
 	if f.Timezone == "" {
 		return time.Local
@@ -88,7 +102,96 @@ func appendPGUsageRowFilterClauses(
 	return query, pb.args
 }
 
-const pgUsageRowsSQL = `
+func appendPGUsageBranchFilterClauses(
+	where string, pb *paramBuilder, f db.UsageFilter, modelCol string,
+) string {
+	where = appendPGUsageSourceFilterClauses(where, pb, f, modelCol)
+	return appendPGUsageSessionFilterClauses(where, pb, f)
+}
+
+func appendPGUsageSourceFilterClauses(
+	where string, pb *paramBuilder, f db.UsageFilter, modelCol string,
+) string {
+	appendCSV := func(q, col, csv string, include bool) string {
+		if csv == "" {
+			return q
+		}
+		vals := strings.Split(csv, ",")
+		op := "IN"
+		if !include {
+			op = "NOT IN"
+		}
+		if len(vals) == 1 {
+			if include {
+				return q + "\n\tAND " + col + " = " + pb.add(vals[0])
+			}
+			return q + "\n\tAND " + col + " != " + pb.add(vals[0])
+		}
+		placeholders := make([]string, len(vals))
+		for i, v := range vals {
+			placeholders[i] = pb.add(v)
+		}
+		return q + "\n\tAND " + col + " " + op + " (" +
+			strings.Join(placeholders, ",") + ")"
+	}
+
+	where = appendCSV(where, modelCol, f.Model, true)
+	where = appendCSV(where, modelCol, f.ExcludeModel, false)
+
+	return where
+}
+
+func appendPGUsageSessionFilterClauses(
+	where string, pb *paramBuilder, f db.UsageFilter,
+) string {
+	appendCSV := func(q, col, csv string, include bool) string {
+		if csv == "" {
+			return q
+		}
+		vals := strings.Split(csv, ",")
+		op := "IN"
+		if !include {
+			op = "NOT IN"
+		}
+		if len(vals) == 1 {
+			if include {
+				return q + "\n\tAND " + col + " = " + pb.add(vals[0])
+			}
+			return q + "\n\tAND " + col + " != " + pb.add(vals[0])
+		}
+		placeholders := make([]string, len(vals))
+		for i, v := range vals {
+			placeholders[i] = pb.add(v)
+		}
+		return q + "\n\tAND " + col + " " + op + " (" +
+			strings.Join(placeholders, ",") + ")"
+	}
+
+	where = appendCSV(where, "s.agent", f.Agent, true)
+	where = appendCSV(where, "s.project", f.Project, true)
+	where = appendCSV(where, "s.machine", f.Machine, true)
+	where = appendCSV(where, "s.project", f.ExcludeProject, false)
+	where = appendCSV(where, "s.agent", f.ExcludeAgent, false)
+
+	if f.MinUserMessages > 0 {
+		where += "\n\tAND s.user_message_count >= " +
+			pb.add(f.MinUserMessages)
+	}
+	if f.ExcludeOneShot {
+		where += "\n\tAND s.user_message_count > 1"
+	}
+	if f.ExcludeAutomated {
+		where += "\n\tAND COALESCE(s.is_automated, false) = false"
+	}
+	if f.ActiveSince != "" {
+		where += "\n\tAND COALESCE(s.ended_at, s.started_at, s.created_at) >= " +
+			pb.add(f.ActiveSince) + "::timestamptz"
+	}
+
+	return where
+}
+
+const pgUsageRowsSQLTemplate = `
 SELECT
 	m.session_id,
 	m.ordinal AS message_ordinal,
@@ -117,7 +220,7 @@ SELECT
 	s.started_at
 FROM messages m
 JOIN sessions s ON m.session_id = s.id
-WHERE ` + pgUsageMessageEligibility + `
+WHERE %s
 
 UNION ALL
 
@@ -152,8 +255,189 @@ SELECT
 	s.started_at
 FROM usage_events ue
 JOIN sessions s ON s.id = ue.session_id
-WHERE ue.model != ''
-  AND s.deleted_at IS NULL`
+WHERE %s`
+
+func pgUsageRowsSQLWithWhere(
+	messageWhere, usageEventWhere string,
+) string {
+	return fmt.Sprintf(
+		pgUsageRowsSQLTemplate,
+		messageWhere,
+		usageEventWhere,
+	)
+}
+
+const pgDailyUsageRowsSQLTemplate = `
+SELECT
+	m.session_id,
+	m.ordinal AS message_ordinal,
+	'message' AS usage_source,
+	COALESCE(m.timestamp, s.started_at) AS ts,
+	m.model,
+	m.token_usage,
+	0 AS input_tokens,
+	0 AS output_tokens,
+	0 AS cache_creation_input_tokens,
+	0 AS cache_read_input_tokens,
+	NULL::double precision AS cost_usd,
+	m.claude_message_id,
+	m.claude_request_id,
+	'' AS usage_dedup_key,
+	s.project,
+	s.agent
+FROM messages m
+JOIN sessions s ON m.session_id = s.id
+WHERE %s
+
+UNION ALL
+
+SELECT
+	ue.session_id,
+	ue.message_ordinal,
+	ue.source AS usage_source,
+	COALESCE(ue.occurred_at, s.started_at) AS ts,
+	ue.model,
+	'' AS token_usage,
+	ue.input_tokens,
+	ue.output_tokens,
+	ue.cache_creation_input_tokens,
+	ue.cache_read_input_tokens,
+	ue.cost_usd,
+	'' AS claude_message_id,
+	'' AS claude_request_id,
+	CASE
+		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
+		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
+	END AS usage_dedup_key,
+	s.project,
+	s.agent
+FROM usage_events ue
+JOIN sessions s ON s.id = ue.session_id
+WHERE %s`
+
+const pgDailyUsageMessageRowsSQLTemplate = `
+SELECT
+	m.session_id,
+	m.ordinal AS message_ordinal,
+	'message' AS usage_source,
+	COALESCE(m.timestamp, s.started_at) AS ts,
+	m.model,
+	m.token_usage,
+	0 AS input_tokens,
+	0 AS output_tokens,
+	0 AS cache_creation_input_tokens,
+	0 AS cache_read_input_tokens,
+	NULL::double precision AS cost_usd,
+	m.claude_message_id,
+	m.claude_request_id,
+	'' AS usage_dedup_key,
+	s.project,
+	s.agent
+FROM %s m
+JOIN sessions s ON m.session_id = s.id
+WHERE %s`
+
+const pgDailyUsageEventRowsSQLTemplate = `
+SELECT
+	ue.session_id,
+	ue.message_ordinal,
+	ue.source AS usage_source,
+	COALESCE(ue.occurred_at, s.started_at) AS ts,
+	ue.model,
+	'' AS token_usage,
+	ue.input_tokens,
+	ue.output_tokens,
+	ue.cache_creation_input_tokens,
+	ue.cache_read_input_tokens,
+	ue.cost_usd,
+	'' AS claude_message_id,
+	'' AS claude_request_id,
+	CASE
+		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
+		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
+	END AS usage_dedup_key,
+	s.project,
+	s.agent
+FROM %s ue
+JOIN sessions s ON s.id = ue.session_id
+WHERE %s`
+
+func pgDailyUsageRowsSQLWithWhere(
+	messageWhere, usageEventWhere string,
+) string {
+	return fmt.Sprintf(
+		pgDailyUsageRowsSQLTemplate,
+		messageWhere,
+		usageEventWhere,
+	)
+}
+
+func pgDailyUsageRowsSQLWithTimestampCTEs(
+	messageTimestampWhere, eventTimestampWhere string,
+	messageTimestampJoinWhere, eventTimestampJoinWhere string,
+	messageFallbackWhere, eventFallbackWhere string,
+) string {
+	return `
+WITH
+message_timestamp_rows AS MATERIALIZED (
+	SELECT
+		m.session_id,
+		m.ordinal,
+		m.timestamp,
+		m.model,
+		m.token_usage,
+		m.claude_message_id,
+		m.claude_request_id
+	FROM messages m
+	WHERE ` + messageTimestampWhere + `
+),
+usage_event_timestamp_rows AS MATERIALIZED (
+	SELECT
+		ue.id,
+		ue.session_id,
+		ue.message_ordinal,
+		ue.source,
+		ue.occurred_at,
+		ue.model,
+		ue.input_tokens,
+		ue.output_tokens,
+		ue.cache_creation_input_tokens,
+		ue.cache_read_input_tokens,
+		ue.cost_usd,
+		ue.dedup_key
+	FROM usage_events ue
+	WHERE ` + eventTimestampWhere + `
+)
+` + fmt.Sprintf(
+		pgDailyUsageMessageRowsSQLTemplate,
+		"message_timestamp_rows",
+		messageTimestampJoinWhere,
+	) + `
+
+UNION ALL
+
+` + fmt.Sprintf(
+		pgDailyUsageEventRowsSQLTemplate,
+		"usage_event_timestamp_rows",
+		eventTimestampJoinWhere,
+	) + `
+
+UNION ALL
+
+` + fmt.Sprintf(
+		pgDailyUsageMessageRowsSQLTemplate,
+		"messages",
+		messageFallbackWhere,
+	) + `
+
+UNION ALL
+
+` + fmt.Sprintf(
+		pgDailyUsageEventRowsSQLTemplate,
+		"usage_events",
+		eventFallbackWhere,
+	)
+}
 
 type pgUsageScanRow struct {
 	sessionID                string
@@ -183,7 +467,33 @@ type pgUsageScanRow struct {
 	startedAt                sql.NullTime
 }
 
-func pgUsageRowSelect() string {
+type pgDailyUsageScanRow struct {
+	sessionID                string
+	messageOrdinal           sql.NullInt64
+	usageSource              string
+	ts                       sql.NullTime
+	model                    string
+	tokenJSON                string
+	inputTokens              int
+	outputTokens             int
+	cacheCreationInputTokens int
+	cacheReadInputTokens     int
+	costUSD                  sql.NullFloat64
+	claudeMessageID          string
+	claudeRequestID          string
+	usageDedupKey            string
+	project                  string
+	agent                    string
+}
+
+type pgTopSessionMetadata struct {
+	displayName string
+	agent       string
+	project     string
+	startedAt   string
+}
+
+func pgUsageRowSelectFromRows(rowsSQL string) string {
 	return `
 SELECT
 	u.session_id,
@@ -211,8 +521,183 @@ SELECT
 	u.session_activity_at,
 	u.display_name,
 	u.started_at
-FROM (` + pgUsageRowsSQL + `) u
+FROM (` + rowsSQL + `) u
 WHERE 1=1`
+}
+
+func pgUsageRowSelect() string {
+	return pgUsageRowSelectFromRows(pgUsageRowsSQLWithWhere(
+		pgUsageMessageEligibility,
+		pgUsageEventEligibility,
+	))
+}
+
+func pgDailyUsageRowSelectFromRows(rowsSQL string) string {
+	return `
+SELECT
+	u.session_id,
+	u.message_ordinal,
+	u.usage_source,
+	u.ts,
+	u.model,
+	u.token_usage,
+	u.input_tokens,
+	u.output_tokens,
+	u.cache_creation_input_tokens,
+	u.cache_read_input_tokens,
+	u.cost_usd,
+	u.claude_message_id,
+	u.claude_request_id,
+	u.usage_dedup_key,
+	u.project,
+	u.agent
+FROM (` + rowsSQL + `) u
+WHERE 1=1`
+}
+
+type pgUsageBounds struct {
+	from string
+	to   string
+}
+
+func (b pgUsageBounds) bounded() bool {
+	return b.from != "" || b.to != ""
+}
+
+func pgUsageBoundsForFilter(
+	pb *paramBuilder, f db.UsageFilter,
+) pgUsageBounds {
+	var b pgUsageBounds
+	if f.From != "" {
+		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
+		b.from = pb.add(padded)
+	}
+	if f.To != "" {
+		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
+		b.to = pb.add(padded)
+	}
+	return b
+}
+
+func appendPGUsageColumnBounds(
+	where, col string, b pgUsageBounds,
+) string {
+	if b.from != "" {
+		where += "\n\tAND " + col + " >= " + b.from + "::timestamptz"
+	}
+	if b.to != "" {
+		where += "\n\tAND " + col + " <= " + b.to + "::timestamptz"
+	}
+	return where
+}
+
+func pgUsageRowsSQLForBounds(b pgUsageBounds) string {
+	if !b.bounded() {
+		return pgUsageRowsSQLWithWhere(
+			pgUsageMessageEligibility,
+			pgUsageEventEligibility,
+		)
+	}
+
+	messageTimestampWhere := pgUsageMessageEligibility +
+		"\n\tAND m.timestamp IS NOT NULL"
+	messageTimestampWhere = appendPGUsageColumnBounds(
+		messageTimestampWhere, "m.timestamp", b)
+	eventTimestampWhere := pgUsageEventEligibility +
+		"\n\tAND ue.occurred_at IS NOT NULL"
+	eventTimestampWhere = appendPGUsageColumnBounds(
+		eventTimestampWhere, "ue.occurred_at", b)
+
+	messageFallbackWhere := pgUsageMessageEligibility +
+		"\n\tAND m.timestamp IS NULL"
+	messageFallbackWhere = appendPGUsageColumnBounds(
+		messageFallbackWhere, "s.started_at", b)
+	eventFallbackWhere := pgUsageEventEligibility +
+		"\n\tAND ue.occurred_at IS NULL"
+	eventFallbackWhere = appendPGUsageColumnBounds(
+		eventFallbackWhere, "s.started_at", b)
+
+	return strings.Join([]string{
+		pgUsageRowsSQLWithWhere(
+			messageTimestampWhere,
+			eventTimestampWhere,
+		),
+		pgUsageRowsSQLWithWhere(
+			messageFallbackWhere,
+			eventFallbackWhere,
+		),
+	}, "\n\nUNION ALL\n\n")
+}
+
+func pgDailyUsageRowsSQLForBounds(
+	pb *paramBuilder, f db.UsageFilter, b pgUsageBounds,
+) string {
+	if !b.bounded() {
+		messageWhere := appendPGUsageBranchFilterClauses(
+			pgUsageMessageEligibility, pb, f, "m.model")
+		eventWhere := appendPGUsageBranchFilterClauses(
+			pgUsageEventEligibility, pb, f, "ue.model")
+		return pgDailyUsageRowsSQLWithWhere(messageWhere, eventWhere)
+	}
+
+	messageTimestampSourceWhere := pgUsageMessageSourceEligibility +
+		"\n\tAND m.timestamp IS NOT NULL"
+	messageTimestampSourceWhere = appendPGUsageSourceFilterClauses(
+		messageTimestampSourceWhere, pb, f, "m.model")
+	messageTimestampSourceWhere = appendPGUsageColumnBounds(
+		messageTimestampSourceWhere, "m.timestamp", b)
+
+	eventTimestampSourceWhere := pgUsageEventSourceEligibility +
+		"\n\tAND ue.occurred_at IS NOT NULL"
+	eventTimestampSourceWhere = appendPGUsageSourceFilterClauses(
+		eventTimestampSourceWhere, pb, f, "ue.model")
+	eventTimestampSourceWhere = appendPGUsageColumnBounds(
+		eventTimestampSourceWhere, "ue.occurred_at", b)
+
+	messageTimestampJoinWhere := appendPGUsageSessionFilterClauses(
+		pgUsageSessionEligibility, pb, f)
+	eventTimestampJoinWhere := appendPGUsageSessionFilterClauses(
+		pgUsageSessionEligibility, pb, f)
+
+	messageFallbackWhere := pgUsageMessageEligibility +
+		"\n\tAND m.timestamp IS NULL"
+	messageFallbackWhere = appendPGUsageBranchFilterClauses(
+		messageFallbackWhere, pb, f, "m.model")
+	messageFallbackWhere = appendPGUsageColumnBounds(
+		messageFallbackWhere, "s.started_at", b)
+	eventFallbackWhere := pgUsageEventEligibility +
+		"\n\tAND ue.occurred_at IS NULL"
+	eventFallbackWhere = appendPGUsageBranchFilterClauses(
+		eventFallbackWhere, pb, f, "ue.model")
+	eventFallbackWhere = appendPGUsageColumnBounds(
+		eventFallbackWhere, "s.started_at", b)
+
+	return pgDailyUsageRowsSQLWithTimestampCTEs(
+		messageTimestampSourceWhere,
+		eventTimestampSourceWhere,
+		messageTimestampJoinWhere,
+		eventTimestampJoinWhere,
+		messageFallbackWhere,
+		eventFallbackWhere,
+	)
+}
+
+func pgUsageRowQuery(pb *paramBuilder, f db.UsageFilter) string {
+	bounds := pgUsageBoundsForFilter(pb, f)
+	return pgDailyUsageRowSelectFromRows(pgDailyUsageRowsSQLForBounds(
+		pb, f, bounds,
+	))
+}
+
+func pgTopSessionsUsageRowQuery(pb *paramBuilder, f db.UsageFilter) string {
+	return pgUsageRowQuery(pb, f)
+}
+
+func pgUsageFullRowQuery(pb *paramBuilder, f db.UsageFilter) string {
+	bounds := pgUsageBoundsForFilter(pb, f)
+	query := pgUsageRowSelectFromRows(pgUsageRowsSQLForBounds(bounds))
+	query, _ = appendPGUsageRowFilterClauses(query, pb, f)
+	return query
 }
 
 func scanPGUsageRow(rows *sql.Rows) (pgUsageScanRow, error) {
@@ -247,8 +732,64 @@ func scanPGUsageRow(rows *sql.Rows) (pgUsageScanRow, error) {
 	return r, err
 }
 
+func scanPGDailyUsageRow(rows *sql.Rows) (pgDailyUsageScanRow, error) {
+	var r pgDailyUsageScanRow
+	err := rows.Scan(
+		&r.sessionID,
+		&r.messageOrdinal,
+		&r.usageSource,
+		&r.ts,
+		&r.model,
+		&r.tokenJSON,
+		&r.inputTokens,
+		&r.outputTokens,
+		&r.cacheCreationInputTokens,
+		&r.cacheReadInputTokens,
+		&r.costUSD,
+		&r.claudeMessageID,
+		&r.claudeRequestID,
+		&r.usageDedupKey,
+		&r.project,
+		&r.agent,
+	)
+	return r, err
+}
+
 func pgUsageAmounts(
 	r pgUsageScanRow, pricing map[string]modelRates,
+) (inputTok, outputTok, cacheCrTok, cacheRdTok int, cost, savings float64) {
+	if r.usageSource == "message" {
+		usage := gjson.Parse(r.tokenJSON)
+		inputTok = int(usage.Get("input_tokens").Int())
+		outputTok = int(usage.Get("output_tokens").Int())
+		cacheCrTok = int(usage.Get("cache_creation_input_tokens").Int())
+		cacheRdTok = int(usage.Get("cache_read_input_tokens").Int())
+	} else {
+		inputTok = r.inputTokens
+		outputTok = r.outputTokens
+		cacheCrTok = r.cacheCreationInputTokens
+		cacheRdTok = r.cacheReadInputTokens
+	}
+
+	rates, _ := lookupModelRates(pricing, r.model)
+	if r.costUSD.Valid {
+		cost = r.costUSD.Float64
+	} else {
+		cost = (float64(inputTok)*rates.input +
+			float64(outputTok)*rates.output +
+			float64(cacheCrTok)*rates.cacheCreation +
+			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
+	}
+	readDelta := float64(cacheRdTok) *
+		(rates.input - rates.cacheRead) / 1_000_000
+	createDelta := float64(cacheCrTok) *
+		(rates.input - rates.cacheCreation) / 1_000_000
+	savings = readDelta + createDelta
+	return
+}
+
+func pgDailyUsageAmounts(
+	r pgDailyUsageScanRow, pricing map[string]modelRates,
 ) (inputTok, outputTok, cacheCrTok, cacheRdTok int, cost, savings float64) {
 	if r.usageSource == "message" {
 		usage := gjson.Parse(r.tokenJSON)
@@ -326,6 +867,58 @@ func startedAtString(ts sql.NullTime) string {
 		return ""
 	}
 	return FormatISO8601(ts.Time)
+}
+
+func (s *Store) loadPGTopSessionMetadata(
+	ctx context.Context, sessionIDs []string,
+) (map[string]pgTopSessionMetadata, error) {
+	out := make(map[string]pgTopSessionMetadata, len(sessionIDs))
+	if len(sessionIDs) == 0 {
+		return out, nil
+	}
+
+	pb := &paramBuilder{}
+	placeholders := make([]string, 0, len(sessionIDs))
+	for _, id := range sessionIDs {
+		placeholders = append(placeholders, pb.add(id))
+	}
+	query := `
+SELECT
+	id,
+	COALESCE(NULLIF(display_name, ''), NULLIF(first_message, ''), NULLIF(project, ''), id) AS display_name,
+	agent,
+	project,
+	started_at
+FROM sessions
+WHERE id IN (` + strings.Join(placeholders, ",") + `)`
+	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying pg top session metadata: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id string
+		var meta pgTopSessionMetadata
+		var startedAt sql.NullTime
+		if err := rows.Scan(
+			&id,
+			&meta.displayName,
+			&meta.agent,
+			&meta.project,
+			&startedAt,
+		); err != nil {
+			return nil,
+				fmt.Errorf("scanning pg top session metadata: %w", err)
+		}
+		meta.startedAt = startedAtString(startedAt)
+		out[id] = meta
+	}
+	if err := rows.Err(); err != nil {
+		return nil,
+			fmt.Errorf("iterating pg top session metadata: %w", err)
+	}
+	return out, nil
 }
 
 // GetSessionUsage returns one session's token totals and cost
@@ -452,17 +1045,8 @@ func (s *Store) GetDailyUsage(
 			fmt.Errorf("loading pg pricing: %w", err)
 	}
 
-	query := pgUsageRowSelect()
 	pb := &paramBuilder{}
-	if f.From != "" {
-		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
-		query += " AND u.ts >= " + pb.add(padded) + "::timestamptz"
-	}
-	if f.To != "" {
-		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
-		query += " AND u.ts <= " + pb.add(padded) + "::timestamptz"
-	}
-	query, _ = appendPGUsageRowFilterClauses(query, pb, f)
+	query := pgUsageRowQuery(pb, f)
 	query += ` ORDER BY u.ts ASC, u.session_id ASC,
 		COALESCE(u.message_ordinal, -1) ASC`
 
@@ -493,10 +1077,11 @@ func (s *Store) GetDailyUsage(
 
 	accum := make(map[accumKey]*bucket)
 	seen := make(map[dedupKey]struct{})
+	seenSessions := make(map[string]db.UsageSessionInfo)
 	var totalSavings float64
 
 	for rows.Next() {
-		r, scanErr := scanPGUsageRow(rows)
+		r, scanErr := scanPGDailyUsageRow(rows)
 		if scanErr != nil {
 			return db.DailyUsageResult{},
 				fmt.Errorf("scanning daily usage row: %w", scanErr)
@@ -524,8 +1109,15 @@ func (s *Store) GetDailyUsage(
 			seen[key] = struct{}{}
 		}
 
+		if _, ok := seenSessions[r.sessionID]; !ok {
+			seenSessions[r.sessionID] = db.UsageSessionInfo{
+				Project: r.project,
+				Agent:   r.agent,
+			}
+		}
+
 		inputTok, outputTok, cacheCrTok, cacheRdTok, cost, savings :=
-			pgUsageAmounts(r, pricing)
+			pgDailyUsageAmounts(r, pricing)
 		totalSavings += savings
 
 		key := accumKey{
@@ -651,7 +1243,12 @@ func (s *Store) GetDailyUsage(
 			daily = []db.DailyUsageEntry{}
 		}
 		totals.CacheSavings = totalSavings
-		return db.DailyUsageResult{Daily: daily, Totals: totals}, nil
+		sessionCounts := db.NewUsageSessionCounts(seenSessions)
+		return db.DailyUsageResult{
+			Daily:         daily,
+			Totals:        totals,
+			SessionCounts: sessionCounts,
+		}, nil
 	}
 
 	type dayMaps struct {
@@ -793,7 +1390,12 @@ func (s *Store) GetDailyUsage(
 		daily = []db.DailyUsageEntry{}
 	}
 	totals.CacheSavings = totalSavings
-	return db.DailyUsageResult{Daily: daily, Totals: totals}, nil
+	sessionCounts := db.NewUsageSessionCounts(seenSessions)
+	return db.DailyUsageResult{
+		Daily:         daily,
+		Totals:        totals,
+		SessionCounts: sessionCounts,
+	}, nil
 }
 
 // GetTopSessionsByCost returns sessions ranked by total cost.
@@ -812,17 +1414,8 @@ func (s *Store) GetTopSessionsByCost(
 		return nil, fmt.Errorf("loading pg pricing: %w", err)
 	}
 
-	query := pgUsageRowSelect()
 	pb := &paramBuilder{}
-	if f.From != "" {
-		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
-		query += " AND u.ts >= " + pb.add(padded) + "::timestamptz"
-	}
-	if f.To != "" {
-		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
-		query += " AND u.ts <= " + pb.add(padded) + "::timestamptz"
-	}
-	query, _ = appendPGUsageRowFilterClauses(query, pb, f)
+	query := pgTopSessionsUsageRowQuery(pb, f)
 	query += ` ORDER BY u.ts ASC, u.session_id ASC,
 		COALESCE(u.message_ordinal, -1) ASC`
 
@@ -834,10 +1427,6 @@ func (s *Store) GetTopSessionsByCost(
 
 	loc := usageLocation(f)
 	type sessAccum struct {
-		displayName string
-		agent       string
-		project     string
-		startedAt   string
 		totalTokens int
 		cost        float64
 	}
@@ -851,7 +1440,7 @@ func (s *Store) GetTopSessionsByCost(
 	seen := make(map[dedupKey]struct{})
 
 	for rows.Next() {
-		r, err := scanPGUsageRow(rows)
+		r, err := scanPGDailyUsageRow(rows)
 		if err != nil {
 			return nil,
 				fmt.Errorf("scanning top sessions row: %w", err)
@@ -880,16 +1469,11 @@ func (s *Store) GetTopSessionsByCost(
 		}
 
 		inputTok, outputTok, cacheCrTok, cacheRdTok, cost, _ :=
-			pgUsageAmounts(r, pricing)
+			pgDailyUsageAmounts(r, pricing)
 
 		sa, ok := accum[r.sessionID]
 		if !ok {
-			sa = &sessAccum{
-				displayName: r.displayName,
-				agent:       r.agent,
-				project:     r.project,
-				startedAt:   startedAtString(r.startedAt),
-			}
+			sa = &sessAccum{}
 			accum[r.sessionID] = sa
 			order = append(order, r.sessionID)
 		}
@@ -909,10 +1493,7 @@ func (s *Store) GetTopSessionsByCost(
 		}
 		result = append(result, db.TopSessionEntry{
 			SessionID:   id,
-			DisplayName: sa.displayName,
-			Agent:       sa.agent,
-			Project:     sa.project,
-			StartedAt:   sa.startedAt,
+			DisplayName: id,
 			TotalTokens: sa.totalTokens,
 			Cost:        sa.cost,
 		})
@@ -927,6 +1508,23 @@ func (s *Store) GetTopSessionsByCost(
 	if len(result) > limit {
 		result = result[:limit]
 	}
+
+	sessionIDs := make([]string, len(result))
+	for i := range result {
+		sessionIDs[i] = result[i].SessionID
+	}
+	metadata, err := s.loadPGTopSessionMetadata(ctx, sessionIDs)
+	if err != nil {
+		return nil, err
+	}
+	for i := range result {
+		if meta, ok := metadata[result[i].SessionID]; ok {
+			result[i].DisplayName = meta.displayName
+			result[i].Agent = meta.agent
+			result[i].Project = meta.project
+			result[i].StartedAt = meta.startedAt
+		}
+	}
 	return result, nil
 }
 
@@ -934,17 +1532,8 @@ func (s *Store) GetTopSessionsByCost(
 func (s *Store) GetUsageSessionCounts(
 	ctx context.Context, f db.UsageFilter,
 ) (db.UsageSessionCounts, error) {
-	query := pgUsageRowSelect()
 	pb := &paramBuilder{}
-	if f.From != "" {
-		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
-		query += " AND u.ts >= " + pb.add(padded) + "::timestamptz"
-	}
-	if f.To != "" {
-		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
-		query += " AND u.ts <= " + pb.add(padded) + "::timestamptz"
-	}
-	query, _ = appendPGUsageRowFilterClauses(query, pb, f)
+	query := pgUsageRowQuery(pb, f)
 	query += ` ORDER BY u.ts ASC, u.session_id ASC,
 		COALESCE(u.message_ordinal, -1) ASC`
 
@@ -969,7 +1558,7 @@ func (s *Store) GetUsageSessionCounts(
 	dedup := make(map[dedupKey]struct{})
 
 	for rows.Next() {
-		r, err := scanPGUsageRow(rows)
+		r, err := scanPGDailyUsageRow(rows)
 		if err != nil {
 			return db.UsageSessionCounts{},
 				fmt.Errorf("scanning session counts: %w", err)

--- a/internal/postgres/usage_unit_test.go
+++ b/internal/postgres/usage_unit_test.go
@@ -1,0 +1,263 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+type usageProbeDriver struct{}
+
+type usageProbeConn struct {
+	state *usageProbeState
+}
+
+type usageProbeRows struct {
+	columns []string
+	values  [][]driver.Value
+	next    int
+}
+
+type usageProbeState struct {
+	mu      sync.Mutex
+	queries []string
+}
+
+var (
+	usageProbeRegisterOnce sync.Once
+	usageProbeStatesMu     sync.Mutex
+	usageProbeStates       = map[string]*usageProbeState{}
+)
+
+func newUsageProbeDB(
+	t *testing.T, state *usageProbeState,
+) *sql.DB {
+	t.Helper()
+	usageProbeRegisterOnce.Do(func() {
+		sql.Register("agentsview_usage_probe", usageProbeDriver{})
+	})
+	name := t.Name()
+	usageProbeStatesMu.Lock()
+	usageProbeStates[name] = state
+	usageProbeStatesMu.Unlock()
+	t.Cleanup(func() {
+		usageProbeStatesMu.Lock()
+		delete(usageProbeStates, name)
+		usageProbeStatesMu.Unlock()
+	})
+
+	pg, err := sql.Open("agentsview_usage_probe", name)
+	require.NoError(t, err, "open usage probe db")
+	t.Cleanup(func() { pg.Close() })
+	return pg
+}
+
+func (usageProbeDriver) Open(name string) (driver.Conn, error) {
+	usageProbeStatesMu.Lock()
+	state := usageProbeStates[name]
+	usageProbeStatesMu.Unlock()
+	return &usageProbeConn{state: state}, nil
+}
+
+func (c *usageProbeConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not implemented")
+}
+
+func (c *usageProbeConn) Close() error { return nil }
+
+func (c *usageProbeConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("begin not implemented")
+}
+
+func (c *usageProbeConn) QueryContext(
+	_ context.Context, query string, _ []driver.NamedValue,
+) (driver.Rows, error) {
+	c.state.mu.Lock()
+	c.state.queries = append(c.state.queries, query)
+	c.state.mu.Unlock()
+
+	normalized := strings.ToLower(query)
+	if strings.Contains(normalized, "from model_pricing") {
+		return &usageProbeRows{
+			columns: []string{
+				"model_pattern",
+				"input_per_mtok",
+				"output_per_mtok",
+				"cache_creation_per_mtok",
+				"cache_read_per_mtok",
+				"updated_at",
+			},
+			values: [][]driver.Value{{
+				"claude-sonnet", 3.0, 15.0, 3.75, 0.3, "2026-06-08",
+			}},
+		}, nil
+	}
+	if strings.Contains(normalized, "from (") &&
+		strings.Contains(normalized, "from messages") {
+		ts := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)
+		return &usageProbeRows{
+			columns: []string{
+				"session_id",
+				"message_ordinal",
+				"usage_source",
+				"ts",
+				"model",
+				"token_usage",
+				"input_tokens",
+				"output_tokens",
+				"cache_creation_input_tokens",
+				"cache_read_input_tokens",
+				"cost_usd",
+				"claude_message_id",
+				"claude_request_id",
+				"usage_dedup_key",
+				"project",
+				"agent",
+			},
+			values: [][]driver.Value{
+				usageProbeUsageRow("s-parent", "proj-a", "claude", ts),
+				usageProbeUsageRow("s-fork", "proj-b", "codex", ts.Add(time.Minute)),
+			},
+		}, nil
+	}
+	return nil, errors.New("unexpected usage query")
+}
+
+func usageProbeUsageRow(
+	sessionID, project, agent string, ts time.Time,
+) []driver.Value {
+	return []driver.Value{
+		sessionID,
+		int64(0),
+		"message",
+		ts,
+		"claude-sonnet",
+		`{"input_tokens":100,"output_tokens":50}`,
+		int64(0),
+		int64(0),
+		int64(0),
+		int64(0),
+		nil,
+		"msg-dup",
+		"req-dup",
+		"",
+		project,
+		agent,
+	}
+}
+
+func (r *usageProbeRows) Columns() []string { return r.columns }
+
+func (r *usageProbeRows) Close() error { return nil }
+
+func (r *usageProbeRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.next])
+	r.next++
+	return nil
+}
+
+func TestPGGetDailyUsageReturnsDedupedSessionCounts(t *testing.T) {
+	store := &Store{
+		pg: newUsageProbeDB(t, &usageProbeState{}),
+	}
+
+	result, err := store.GetDailyUsage(context.Background(), db.UsageFilter{
+		From: "2024-06-15",
+		To:   "2024-06-15",
+	})
+	require.NoError(t, err, "GetDailyUsage")
+
+	assert.Equal(t, 1, result.SessionCounts.Total)
+	assert.Equal(t, 1, result.SessionCounts.ByProject["proj-a"])
+	assert.Equal(t, 1, result.SessionCounts.ByAgent["claude"])
+	assert.Zero(t, result.SessionCounts.ByProject["proj-b"])
+	assert.Zero(t, result.SessionCounts.ByAgent["codex"])
+}
+
+func TestPGUsageRowQueryPushesDateBoundsIntoUnion(t *testing.T) {
+	pb := &paramBuilder{}
+	query := pgUsageRowQuery(pb, db.UsageFilter{
+		From:             "2024-06-01",
+		To:               "2024-06-30",
+		ExcludeAutomated: true,
+	})
+
+	normalized := strings.ToLower(query)
+	assert.NotContains(t, normalized, "and u.ts >=")
+	assert.NotContains(t, normalized, "and u.ts <=")
+	assert.NotContains(t, normalized, " or ")
+	assert.NotContains(t, normalized, "display_name")
+	assert.NotContains(t, normalized, "first_message")
+	assert.NotContains(t, normalized, "cost_status")
+	assert.NotContains(t, normalized, "cost_source")
+	assert.NotContains(t, normalized, "reasoning_tokens")
+	assert.NotContains(t, normalized, "user_message_count")
+	assert.NotContains(t, normalized, "session_activity_at")
+	assert.NotContains(t, normalized, " as started_at")
+	assert.NotContains(t, normalized, "u.machine")
+	assert.Contains(t, normalized, "message_timestamp_rows as materialized")
+	assert.Contains(t, normalized, "usage_event_timestamp_rows as materialized")
+	assert.Contains(t, normalized, "from message_timestamp_rows m\njoin sessions s")
+	assert.Contains(t, normalized, "from usage_event_timestamp_rows ue\njoin sessions s")
+	assert.Contains(t, normalized, "m.timestamp is not null")
+	assert.Contains(t, normalized, "ue.occurred_at is not null")
+	assert.Contains(t, normalized, "m.timestamp is null")
+	assert.Contains(t, normalized, "ue.occurred_at is null")
+	assert.Contains(t, normalized, "m.timestamp >= $1::timestamptz")
+	assert.Contains(t, normalized, "ue.occurred_at >= $1::timestamptz")
+	assert.Contains(t, normalized, "s.started_at >= $1::timestamptz")
+	assert.Contains(t, normalized, "m.timestamp <= $2::timestamptz")
+	assert.Contains(t, normalized, "ue.occurred_at <= $2::timestamptz")
+	assert.Contains(t, normalized, "s.started_at <= $2::timestamptz")
+	require.Len(t, pb.args, 2)
+	assert.Equal(t, "2024-05-31T10:00:00Z", pb.args[0])
+	assert.Equal(t, "2024-07-01T13:59:59Z", pb.args[1])
+}
+
+func TestPGTopSessionsUsageRowQueryUsesNarrowScan(t *testing.T) {
+	pb := &paramBuilder{}
+	query := pgTopSessionsUsageRowQuery(pb, db.UsageFilter{
+		From: "2024-06-01",
+		To:   "2024-06-30",
+	})
+
+	normalized := strings.ToLower(query)
+	assert.NotContains(t, normalized, "display_name")
+	assert.NotContains(t, normalized, "first_message")
+	assert.NotContains(t, normalized, "cost_status")
+	assert.NotContains(t, normalized, "cost_source")
+	assert.NotContains(t, normalized, "reasoning_tokens")
+	assert.NotContains(t, normalized, "user_message_count")
+	assert.NotContains(t, normalized, "session_activity_at")
+	assert.NotContains(t, normalized, " as started_at")
+	assert.NotContains(t, normalized, "u.machine")
+	assert.Contains(t, normalized, "m.timestamp is not null")
+	assert.Contains(t, normalized, "ue.occurred_at is not null")
+	assert.Contains(t, normalized, "m.timestamp is null")
+	assert.Contains(t, normalized, "ue.occurred_at is null")
+	assert.Contains(t, normalized, "m.timestamp >= $1::timestamptz")
+	assert.Contains(t, normalized, "ue.occurred_at >= $1::timestamptz")
+	assert.Contains(t, normalized,
+		"m.timestamp is null\n\tand s.started_at >= $1::timestamptz")
+	assert.Contains(t, normalized,
+		"ue.occurred_at is null\n\tand s.started_at >= $1::timestamptz")
+	assert.Contains(t, normalized, "m.timestamp <= $2::timestamptz")
+	assert.Contains(t, normalized, "ue.occurred_at <= $2::timestamptz")
+	require.Len(t, pb.args, 2)
+	assert.Equal(t, "2024-05-31T10:00:00Z", pb.args[0])
+	assert.Equal(t, "2024-07-01T13:59:59Z", pb.args[1])
+}

--- a/internal/server/huma_routes_usage.go
+++ b/internal/server/huma_routes_usage.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"time"
 
@@ -14,6 +13,7 @@ func (s *Server) registerUsageRoutes() {
 	group := newRouteGroup(s.api, "/api/v1/usage", "Usage")
 
 	get(s, group, "/summary", "Get usage summary", s.humaUsageSummary)
+	get(s, group, "/comparison", "Get usage comparison", s.humaUsageComparison)
 	get(s, group, "/top-sessions", "Get top usage sessions", s.humaUsageTopSessions)
 }
 
@@ -37,6 +37,11 @@ type UsageFilterInput struct {
 type usageTopSessionsInput struct {
 	UsageFilterInput
 	Limit int `query:"limit" minimum:"0" maximum:"100" default:"20" doc:"Maximum number of sessions"`
+}
+
+type usageComparisonInput struct {
+	UsageFilterInput
+	CurrentCost float64 `query:"current_cost" required:"true" doc:"Current period total cost"`
 }
 
 func usageFilterFromInput(in UsageFilterInput) (db.UsageFilter, error) {
@@ -94,18 +99,6 @@ func (s *Server) humaUsageSummary(
 		}
 		return nil, internalError("usage summary error", err)
 	}
-	scFilter := f
-	scFilter.Breakdowns = false
-	sessionCounts, err := s.db.GetUsageSessionCounts(ctx, scFilter)
-	if err != nil {
-		if handled := handleHumaContextError(err); handled != nil {
-			return nil, handled
-		}
-		if handled := handleHumaReadOnly(err); handled != nil {
-			return nil, handled
-		}
-		return nil, internalError("usage session counts error", err)
-	}
 	resp := UsageSummaryResponse{
 		From:          f.From,
 		To:            f.To,
@@ -114,25 +107,45 @@ func (s *Server) humaUsageSummary(
 		ProjectTotals: foldProjectTotals(result.Daily),
 		ModelTotals:   foldModelTotals(result.Daily),
 		AgentTotals:   foldAgentTotals(result.Daily),
-		SessionCounts: sessionCounts,
+		SessionCounts: result.SessionCounts,
 		CacheStats:    computeCacheStats(result.Totals),
-		Comparison:    s.computeUsageComparison(ctx, f, result.Totals.TotalCost),
 	}
 	return &jsonOutput[UsageSummaryResponse]{Body: resp}, nil
+}
+
+func (s *Server) humaUsageComparison(
+	ctx context.Context,
+	in *usageComparisonInput,
+) (*jsonOutput[Comparison], error) {
+	f, err := usageFilterFromInput(in.UsageFilterInput)
+	if err != nil {
+		return nil, err
+	}
+	comparison, err := s.computeUsageComparison(ctx, f, in.CurrentCost)
+	if err != nil {
+		if handled := handleHumaContextError(err); handled != nil {
+			return nil, handled
+		}
+		if handled := handleHumaReadOnly(err); handled != nil {
+			return nil, handled
+		}
+		return nil, internalError("usage comparison error", err)
+	}
+	return &jsonOutput[Comparison]{Body: *comparison}, nil
 }
 
 func (s *Server) computeUsageComparison(
 	ctx context.Context,
 	f db.UsageFilter,
 	currentCost float64,
-) *Comparison {
+) (*Comparison, error) {
 	fromT, err := time.Parse("2006-01-02", f.From)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	toT, err := time.Parse("2006-01-02", f.To)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	days := int(toT.Sub(fromT).Hours()/24) + 1
 	priorTo := fromT.AddDate(0, 0, -1)
@@ -156,8 +169,7 @@ func (s *Server) computeUsageComparison(
 	}
 	priorResult, err := s.db.GetDailyUsage(ctx, priorFilter)
 	if err != nil {
-		log.Printf("usage comparison error: %v", err)
-		return nil
+		return nil, err
 	}
 	c := &Comparison{
 		PriorFrom:      priorFilter.From,
@@ -167,7 +179,7 @@ func (s *Server) computeUsageComparison(
 	if c.PriorTotalCost > 0 {
 		c.DeltaPct = (currentCost - c.PriorTotalCost) / c.PriorTotalCost
 	}
-	return c
+	return c, nil
 }
 
 func (s *Server) humaUsageTopSessions(

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -1,12 +1,144 @@
 package server
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 )
+
+type usageSummaryCountsSpy struct {
+	db.Store
+	dailyCalls  int
+	countsCalls int
+}
+
+func (s *usageSummaryCountsSpy) GetDailyUsage(
+	_ context.Context, _ db.UsageFilter,
+) (db.DailyUsageResult, error) {
+	s.dailyCalls++
+	return db.DailyUsageResult{
+		Daily: []db.DailyUsageEntry{{
+			Date:      "2024-06-01",
+			TotalCost: 1,
+		}},
+		Totals: db.UsageTotals{TotalCost: 1},
+		SessionCounts: db.UsageSessionCounts{
+			Total:     1,
+			ByProject: map[string]int{"proj": 1},
+			ByAgent:   map[string]int{"claude": 1},
+		},
+	}, nil
+}
+
+func (s *usageSummaryCountsSpy) GetUsageSessionCounts(
+	_ context.Context, _ db.UsageFilter,
+) (db.UsageSessionCounts, error) {
+	s.countsCalls++
+	return db.UsageSessionCounts{}, nil
+}
+
+func TestUsageSummaryScansCurrentPeriodOnly(t *testing.T) {
+	spy := &usageSummaryCountsSpy{}
+	s := &Server{
+		cfg: config.Config{Host: "127.0.0.1"},
+		db:  spy,
+		mux: http.NewServeMux(),
+	}
+	s.routes()
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/usage/summary?from=2024-06-01&to=2024-06-01",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	assert.Equal(t, 1, spy.dailyCalls, "current summary only")
+	assert.Zero(t, spy.countsCalls)
+}
+
+func TestUsageComparisonScansPriorPeriodOnly(t *testing.T) {
+	spy := &usageSummaryCountsSpy{}
+	s := &Server{
+		cfg: config.Config{Host: "127.0.0.1"},
+		db:  spy,
+		mux: http.NewServeMux(),
+	}
+	s.routes()
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/usage/comparison?from=2024-06-01&to=2024-06-01&current_cost=3",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	assert.Equal(t, 1, spy.dailyCalls, "prior comparison only")
+	assert.Zero(t, spy.countsCalls)
+
+	var out Comparison
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.Equal(t, "2024-05-31", out.PriorFrom)
+	assert.Equal(t, "2024-05-31", out.PriorTo)
+	assert.Equal(t, 1.0, out.PriorTotalCost)
+	assert.Equal(t, 2.0, out.DeltaPct)
+}
+
+func TestUsageComparisonRequiresCurrentCost(t *testing.T) {
+	spy := &usageSummaryCountsSpy{}
+	s := &Server{
+		cfg: config.Config{Host: "127.0.0.1"},
+		db:  spy,
+		mux: http.NewServeMux(),
+	}
+	s.routes()
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/usage/comparison?from=2024-06-01&to=2024-06-01",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	assert.Zero(t, spy.dailyCalls)
+	assert.Zero(t, spy.countsCalls)
+}
+
+func TestUsageComparisonAllowsZeroCurrentCost(t *testing.T) {
+	spy := &usageSummaryCountsSpy{}
+	s := &Server{
+		cfg: config.Config{Host: "127.0.0.1"},
+		db:  spy,
+		mux: http.NewServeMux(),
+	}
+	s.routes()
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/usage/comparison?from=2024-06-01&to=2024-06-01&current_cost=0",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Equal(t, 1, spy.dailyCalls, "prior comparison only")
+	assert.Zero(t, spy.countsCalls)
+}
 
 func TestComputeCacheStats_SavingsPassThrough(t *testing.T) {
 	// SavingsVsUncached is now computed per-model in the DB

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -24,20 +24,20 @@ import (
 )
 
 type testEnv struct {
-	claudeDir   string
-	codexDir    string
-	cursorDir   string
-	geminiDir   string
-	opencodeDir string
-	forgeDir    string
-	piebaldDir  string
-	iflowDir    string
-	ampDir      string
-	piDir       string
-	kiroDir     string
+	claudeDir         string
+	codexDir          string
+	cursorDir         string
+	geminiDir         string
+	opencodeDir       string
+	forgeDir          string
+	piebaldDir        string
+	iflowDir          string
+	ampDir            string
+	piDir             string
+	kiroDir           string
 	antigravityCLIDir string
-	db          *db.DB
-	engine      *sync.Engine
+	db                *db.DB
+	engine            *sync.Engine
 }
 
 type testEnvOpts struct {
@@ -151,17 +151,17 @@ func setupTestEnv(t *testing.T, opts ...TestEnvOption) *testEnv {
 
 	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
-			parser.AgentClaude:          claudeDirs,
-			parser.AgentCodex:           codexDirs,
-			parser.AgentCursor:          cursorDirs,
-			parser.AgentGemini:          {env.geminiDir},
-			parser.AgentOpenCode:        opencodeDirs,
-			parser.AgentForge:           {env.forgeDir},
-			parser.AgentPiebald:         {env.piebaldDir},
-			parser.AgentIflow:           {env.iflowDir},
-			parser.AgentAmp:             {env.ampDir},
-			parser.AgentPi:              {env.piDir},
-			parser.AgentKiro:            kiroDirs,
+			parser.AgentClaude:         claudeDirs,
+			parser.AgentCodex:          codexDirs,
+			parser.AgentCursor:         cursorDirs,
+			parser.AgentGemini:         {env.geminiDir},
+			parser.AgentOpenCode:       opencodeDirs,
+			parser.AgentForge:          {env.forgeDir},
+			parser.AgentPiebald:        {env.piebaldDir},
+			parser.AgentIflow:          {env.iflowDir},
+			parser.AgentAmp:            {env.ampDir},
+			parser.AgentPi:             {env.piDir},
+			parser.AgentKiro:           kiroDirs,
 			parser.AgentAntigravityCLI: {env.antigravityCLIDir},
 		},
 		Machine: "local",
@@ -1928,7 +1928,7 @@ func TestSyncPathsGeminiRejectsWrongStructure(t *testing.T) {
 	sess, _ := env.db.GetSession(
 		context.Background(), "gemini:"+sessionID,
 	)
-	assert.Nil(t, sess, "Gemini file outside tmp/<hash>/chats " + "should be ignored")
+	assert.Nil(t, sess, "Gemini file outside tmp/<hash>/chats "+"should be ignored")
 }
 
 func TestSyncPathsAmp(t *testing.T) {
@@ -2322,7 +2322,7 @@ func TestSyncPathsClaudeRejectsNonAgentInSubagents(t *testing.T) {
 	sess, _ := env.db.GetSession(
 		context.Background(), "not-agent",
 	)
-	assert.Nil(t, sess, "non-agent file in subagents dir " + "should be rejected")
+	assert.Nil(t, sess, "non-agent file in subagents dir "+"should be rejected")
 }
 
 func TestSyncPathsClaudeRejectsNested(t *testing.T) {
@@ -2344,7 +2344,7 @@ func TestSyncPathsClaudeRejectsNested(t *testing.T) {
 	sess, _ := env.db.GetSession(
 		context.Background(), "nested",
 	)
-	assert.Nil(t, sess, "nested Claude path should be rejected " + "(only <project>/<session>.jsonl allowed)")
+	assert.Nil(t, sess, "nested Claude path should be rejected "+"(only <project>/<session>.jsonl allowed)")
 }
 
 // TestSyncEngineOpenCodeBulkSync verifies that SyncAll
@@ -3253,7 +3253,7 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 		timeCreated,
 	)
 	sqlite.updateSessionTime(t, sessionID, timeUpdated+2000)
-	require.NoError(t, env.engine.SyncSingleSession("opencode:" + sessionID), "SyncSingleSession")
+	require.NoError(t, env.engine.SyncSingleSession("opencode:"+sessionID), "SyncSingleSession")
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
 		"updated by single sync",
@@ -4405,7 +4405,7 @@ func TestSyncEngineMultiCursorDir(t *testing.T) {
 
 	// FindSourceFile should work across directories.
 	src := env.engine.FindSourceFile("cursor:sess2")
-	assert.NotEmpty(t, src, "FindSourceFile failed for cursor:sess2 " + "in second directory")
+	assert.NotEmpty(t, src, "FindSourceFile failed for cursor:sess2 "+"in second directory")
 }
 
 func TestSyncPathsCursorNestedLayout(t *testing.T) {
@@ -4929,7 +4929,7 @@ func TestResyncAllAbortsWithForkAndFailures(t *testing.T) {
 			hasAbortWarning = true
 		}
 	}
-	assert.True(t, hasAbortWarning, "expected abort: Failed(2) > filesOK(1) " + "should trigger even though Failed == Synced")
+	assert.True(t, hasAbortWarning, "expected abort: Failed(2) > filesOK(1) "+"should trigger even though Failed == Synced")
 
 	// Original data preserved.
 	assertSessionMessageCount(t, env.db, "forked", 10)
@@ -5108,7 +5108,7 @@ func TestResyncAllAbortsOnEmptyDiscovery(t *testing.T) {
 			hasAbortWarning = true
 		}
 	}
-	assert.True(t, hasAbortWarning, "expected abort when discovery returns zero files " + "but old DB has sessions")
+	assert.True(t, hasAbortWarning, "expected abort when discovery returns zero files "+"but old DB has sessions")
 
 	// Original data must be preserved.
 	assertSessionMessageCount(t, env.db, "keep", 2)
@@ -5158,7 +5158,7 @@ func TestResyncAllOpenCodeOnly(t *testing.T) {
 	stats := env.engine.ResyncAll(context.Background(), nil)
 
 	for _, w := range stats.Warnings {
-		require.False(t, strings.Contains(w, "resync aborted"), "ResyncAll aborted for OpenCode-only "+ "dataset: %s", w)
+		require.False(t, strings.Contains(w, "resync aborted"), "ResyncAll aborted for OpenCode-only "+"dataset: %s", w)
 	}
 	require.NotZero(t, stats.Synced, "expected OpenCode sessions to be synced")
 
@@ -5485,7 +5485,7 @@ func TestResyncAllAbortsMixedSourceEmptyFiles(t *testing.T) {
 			hasAbortWarning = true
 		}
 	}
-	assert.True(t, hasAbortWarning, "expected abort when file dirs are empty " + "but old DB has file-backed sessions")
+	assert.True(t, hasAbortWarning, "expected abort when file dirs are empty "+"but old DB has file-backed sessions")
 
 	// Both file-backed and OpenCode data preserved.
 	assertSessionMessageCount(t, env.db, "mixed-file", 2)
@@ -6371,7 +6371,7 @@ func TestSyncAllOpenCodeExcludedNotCountedAsFailed(
 	// Sync again — the excluded session should not be
 	// counted as a failure.
 	stats := env.engine.SyncAll(context.Background(), nil)
-	assert.LessOrEqual(t, stats.Failed, 0, "Failed = %d, want 0 (excluded session "+ "should not count as failure)", stats.Failed)
+	assert.LessOrEqual(t, stats.Failed, 0, "Failed = %d, want 0 (excluded session "+"should not count as failure)", stats.Failed)
 }
 
 // TestSyncSingleSessionExcludedIsNoOp verifies that
@@ -6489,7 +6489,7 @@ func TestSyncSingleSessionTrashedIsNoOp(t *testing.T) {
 
 	require.NoError(t, env.db.SoftDeleteSession("trashed-single"), "SoftDeleteSession")
 
-	require.NoError(t, env.engine.SyncSingleSession("trashed-single"), "SyncSingleSession on trashed session "+ "returned error")
+	require.NoError(t, env.engine.SyncSingleSession("trashed-single"), "SyncSingleSession on trashed session "+"returned error")
 }
 
 // TestSyncSingleSessionOpenCodeExcludedIsNoOp verifies that


### PR DESCRIPTION
## What changed

- Tightened Cockroach/PostgreSQL usage queries and added matching SQLite indexes where the same access pattern exists.
- Pushed usage window bounds into `messages` and `usage_events`, split nullable timestamp fallbacks into separate branches, and narrowed summary/top-session scan projections so large usage reads move less data.
- Kept prior-period comparison as a separate cancellable request while preventing stale summary, comparison, and top-session requests from overwriting current usage-tab state.
- Aggregated tool-call category counts in SQL for both PostgreSQL/Cockroach and SQLite without changing the report semantics.
- Batched `model_pricing` writes, skipped rows whose pricing fields are unchanged before opening write transactions, and shared concurrent PostgreSQL pricing loads with per-waiter cancellation.
- Documented that backend query/index behavior should stay in parity unless a change is explicitly scoped to one backend.

## Why this is valid

The usage changes preserve the existing Go aggregation path: deduplication, model-pricing resolution, local-date filtering, session-count semantics, and deterministic ordering are unchanged. The SQL changes move equivalent filters closer to source tables, avoid planner-hostile nullable timestamp predicates, and reduce row width for aggregate paths without adding replacement queries.

Tool-call aggregation is safe because each `tool_calls` row belongs to exactly one session and category for this report. Usage session counts are still computed from one global `session_id` set after the same local-date filtering and deduplication used for daily totals, then grouped by each session's single project and agent.

Pricing sync still writes missing rows and rows with changed pricing values. It intentionally ignores `updated_at`-only differences, matching the existing upsert conflict predicate, so stable syncs avoid Cockroach lock contention entirely instead of entering `ON CONFLICT` for no-op writes.

## Where to look

- `internal/postgres/usage.go` and `internal/db/usage.go` for usage query shape changes.
- `internal/postgres/schema.go` and `internal/db/db.go` for matching usage timestamp indexes.
- `internal/postgres/analytics.go` and `internal/db/analytics.go` for SQL-side tool-call aggregation.
- `internal/server/huma_routes_usage.go` and `frontend/src/lib/stores/usage.svelte.ts` for usage-tab request behavior.
- `internal/postgres/pricing.go` and `internal/db/pricing.go` for pricing-load coordination and unchanged-row write filtering.
