### PR TITLE
feat(frontend): show session cost in the session header

### DIFF
--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -24,7 +24,7 @@
   import { configureGeneratedClient } from "../../api/runtime.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
   import { agentColor, agentLabel } from "../../utils/agents.js";
-  import { formatTokenUsage } from "../../utils/format.js";
+  import { formatCost, formatTokenUsage } from "../../utils/format.js";
   import { normalizeMessagePreview } from "../../utils/messages.js";
   import { getGradeStyle, getGradeLabel } from "../../utils/grade.js";
   import SignalPanel from "../content/SignalPanel.svelte";
@@ -106,6 +106,48 @@
         // session refresh retries the lookup.
       });
   });
+
+  let sessionCost = $state<number | null>(null);
+  // Key of the last successful usage fetch:
+  // id \n outputTokens \n messageCount \n endedAt.
+  let costFetchKey: string | null = null;
+  let costSessionId: string | null = null;
+  let costRequestSeq = 0;
+  $effect(() => {
+    if (!session) {
+      sessionCost = null;
+      costFetchKey = null;
+      costSessionId = null;
+      costRequestSeq++;
+      return;
+    }
+    const id = session.id;
+    const key = [
+      id,
+      session.total_output_tokens ?? 0,
+      session.message_count ?? 0,
+      session.ended_at ?? "",
+    ].join("\n");
+    if (key === costFetchKey) return;
+    if (id !== costSessionId) sessionCost = null;
+    costSessionId = id;
+    const seq = ++costRequestSeq;
+    configureGeneratedClient();
+    SessionsService.getApiV1SessionsIdUsage({ id })
+      .then((res) => {
+        if (seq !== costRequestSeq) return;
+        costFetchKey = key;
+        sessionCost = res.has_cost ? res.cost_usd : null;
+      })
+      .catch(() => {
+        // Leave the fetch key unset so the next
+        // session refresh retries the lookup.
+      });
+  });
+
+  let sessionCostLabel = $derived(
+    sessionCost !== null ? formatCost(sessionCost) : null,
+  );
 
   let sessionContextTokens = $derived(session?.peak_context_tokens ?? 0);
   let sessionOutputTokens = $derived(session?.total_output_tokens ?? 0);
@@ -610,6 +652,11 @@
           {sessionTokenSummary}
         </span>
       {/if}
+      {#if sessionCostLabel}
+        <span class="cost-badge" title="Estimated session cost">
+          {sessionCostLabel}
+        </span>
+      {/if}
       {#if mainModel}
         <span class="model-badge" title={mainModel}>{mainModel}</span>
       {/if}
@@ -908,6 +955,17 @@
   .token-badge--mobile {
     display: none;
     white-space: nowrap;
+  }
+
+  .cost-badge {
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-muted);
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: var(--bg-tertiary);
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 
   .model-badge {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -108,8 +108,10 @@
   });
 
   let sessionCost = $state<number | null>(null);
-  // Key of the last successful usage fetch:
-  // id \n outputTokens \n messageCount \n endedAt.
+  // Key of the last successful usage fetch. Cost depends on more
+  // than output tokens (input/cache tokens and explicit usage-event
+  // costs), so the key includes every cost-affecting session field,
+  // with file mtime/size catching resyncs that change none of them.
   let costFetchKey: string | null = null;
   let costSessionId: string | null = null;
   let costRequestSeq = 0;
@@ -125,8 +127,13 @@
     const key = [
       id,
       session.total_output_tokens ?? 0,
+      session.peak_context_tokens ?? 0,
+      session.has_total_output_tokens ?? "",
+      session.has_peak_context_tokens ?? "",
       session.message_count ?? 0,
       session.ended_at ?? "",
+      session.file_mtime ?? "",
+      session.file_size ?? "",
     ].join("\n");
     if (id !== costSessionId) {
       // Entering a different session invalidates both the displayed

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -110,8 +110,11 @@
   let sessionCost = $state<number | null>(null);
   // Key of the last successful usage fetch. Cost depends on more
   // than output tokens (input/cache tokens and explicit usage-event
-  // costs), so the key includes every cost-affecting session field,
-  // with file mtime/size catching resyncs that change none of them.
+  // costs), so the key includes every cost-affecting field present
+  // in API session responses. A resync that changes none of these
+  // (e.g. a cost-only usage event) keeps a stale cost until the
+  // next keyed field moves; closing that would need a freshness
+  // marker in the session API.
   let costFetchKey: string | null = null;
   let costSessionId: string | null = null;
   let costRequestSeq = 0;
@@ -132,8 +135,6 @@
       session.has_peak_context_tokens ?? "",
       session.message_count ?? 0,
       session.ended_at ?? "",
-      session.file_mtime ?? "",
-      session.file_size ?? "",
     ].join("\n");
     if (id !== costSessionId) {
       // Entering a different session invalidates both the displayed

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -128,8 +128,15 @@
       session.message_count ?? 0,
       session.ended_at ?? "",
     ].join("\n");
+    if (id !== costSessionId) {
+      // Entering a different session invalidates both the displayed
+      // cost and the fetch cache; the cached key must never satisfy
+      // the early return below while another session's request is
+      // still in flight.
+      sessionCost = null;
+      costFetchKey = null;
+    }
     if (key === costFetchKey) return;
-    if (id !== costSessionId) sessionCost = null;
     costSessionId = id;
     const seq = ++costRequestSeq;
     configureGeneratedClient();

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -8,9 +8,15 @@ import {
   afterEach,
 } from "vitest";
 import { mount, unmount, tick } from "svelte";
+import { createClassComponent } from "svelte/legacy";
 // @ts-ignore
 import SessionBreadcrumb from "./SessionBreadcrumb.svelte";
-import type { Session } from "../../api/types.js";
+import type { Message, Session } from "../../api/types.js";
+import {
+  OpenersService,
+  SessionsService,
+} from "../../api/generated/index";
+import { messages } from "../../stores/messages.svelte.js";
 
 vi.mock("../../api/client.js", () => ({
   listOpeners: vi.fn().mockResolvedValue({ openers: [] }),
@@ -24,6 +30,32 @@ vi.mock("../../api/client.js", () => ({
 vi.mock("../../utils/clipboard.js", () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }));
+
+vi.mock("../../api/generated/index", async (importOriginal) => {
+  const orig =
+    await importOriginal<typeof import("../../api/generated/index")>();
+  return {
+    ...orig,
+    OpenersService: {
+      getApiV1Openers: vi.fn(),
+    },
+    SessionsService: {
+      getApiV1SessionsIdDirectory: vi.fn(),
+      getApiV1SessionsIdUsage: vi.fn(),
+      postApiV1SessionsIdResume: vi.fn(),
+      postApiV1SessionsIdOpen: vi.fn(),
+    },
+  };
+});
+
+const openersService = OpenersService as unknown as {
+  getApiV1Openers: ReturnType<typeof vi.fn>;
+};
+
+const sessionsService = SessionsService as unknown as {
+  getApiV1SessionsIdDirectory: ReturnType<typeof vi.fn>;
+  getApiV1SessionsIdUsage: ReturnType<typeof vi.fn>;
+};
 
 type SessionWithTokenFlags = Session & {
   has_peak_context_tokens?: boolean;
@@ -51,6 +83,86 @@ function makeSession(
     ...overrides,
   };
 }
+
+interface SessionUsage {
+  session_id: string;
+  agent: string;
+  project: string;
+  total_output_tokens: number;
+  peak_context_tokens: number;
+  has_token_data: boolean;
+  cost_usd: number;
+  has_cost: boolean;
+  models: string[];
+  unpriced_models: string[];
+  server_running: boolean;
+}
+
+function makeUsage(
+  overrides: Partial<SessionUsage> = {},
+): SessionUsage {
+  return {
+    session_id: "run:123456789abcdef",
+    agent: "claude",
+    project: "proj-a",
+    total_output_tokens: 0,
+    peak_context_tokens: 0,
+    has_token_data: false,
+    cost_usd: 0,
+    has_cost: false,
+    models: [],
+    unpriced_models: [],
+    server_running: true,
+    ...overrides,
+  };
+}
+
+function makeAssistantMessage(model: string): Message {
+  return {
+    id: 1,
+    session_id: "run:123456789abcdef",
+    ordinal: 0,
+    role: "assistant",
+    content: "hi",
+    timestamp: "2026-02-20T12:30:30Z",
+    has_thinking: false,
+    thinking_text: "",
+    has_tool_use: false,
+    content_length: 2,
+    model,
+    token_usage: null,
+    context_tokens: 0,
+    output_tokens: 0,
+    has_context_tokens: false,
+    has_output_tokens: false,
+    is_system: false,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await tick();
+}
+
+beforeEach(() => {
+  openersService.getApiV1Openers
+    .mockReset()
+    .mockResolvedValue({ openers: [] });
+  sessionsService.getApiV1SessionsIdDirectory
+    .mockReset()
+    .mockResolvedValue({ path: "" });
+  sessionsService.getApiV1SessionsIdUsage
+    .mockReset()
+    .mockResolvedValue(makeUsage());
+});
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -247,6 +359,221 @@ describe("SessionBreadcrumb", () => {
     expect(resumeBtn).toBeNull();
 
     unmount(component);
+  });
+
+  describe("cost badge", () => {
+    afterEach(() => {
+      messages.clear();
+      messages.sessionId = null;
+    });
+
+    it("renders the session cost when usage reports a priced cost", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
+        makeUsage({ has_cost: true, cost_usd: 1.234 }),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude"),
+          onBack: () => {},
+        },
+      });
+
+      await vi.waitFor(() => {
+        const badge = document.querySelector(".cost-badge");
+        expect(badge?.textContent?.trim()).toBe("$1.23");
+      });
+
+      unmount(component);
+    });
+
+    it("renders the cost badge between the token badges and the model badge", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
+        makeUsage({ has_cost: true, cost_usd: 4.12 }),
+      );
+      messages.sessionId = "run:123456789abcdef";
+      messages.messages = [makeAssistantMessage("claude-opus-4-8")];
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude", {
+            peak_context_tokens: 2400,
+            total_output_tokens: 180,
+            has_peak_context_tokens: true,
+            has_total_output_tokens: true,
+          }),
+          onBack: () => {},
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(document.querySelector(".cost-badge")).toBeTruthy();
+      });
+
+      const meta = document.querySelector(".breadcrumb-meta");
+      expect(meta).toBeTruthy();
+      const children = Array.from(meta!.children);
+      const desktopTokenIdx = children.findIndex((el) =>
+        el.classList.contains("token-badge--desktop"),
+      );
+      const mobileTokenIdx = children.findIndex((el) =>
+        el.classList.contains("token-badge--mobile"),
+      );
+      const costIdx = children.findIndex((el) =>
+        el.classList.contains("cost-badge"),
+      );
+      const modelIdx = children.findIndex((el) =>
+        el.classList.contains("model-badge"),
+      );
+
+      expect(desktopTokenIdx).toBeGreaterThanOrEqual(0);
+      expect(mobileTokenIdx).toBeGreaterThan(desktopTokenIdx);
+      expect(costIdx).toBeGreaterThan(mobileTokenIdx);
+      expect(modelIdx).toBeGreaterThan(costIdx);
+
+      unmount(component);
+    });
+
+    it("renders no cost badge when the session has no priced cost", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
+        makeUsage({ has_cost: false, cost_usd: 0 }),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude"),
+          onBack: () => {},
+        },
+      });
+
+      await flushPromises();
+      await vi.waitFor(() => {
+        expect(
+          sessionsService.getApiV1SessionsIdUsage,
+        ).toHaveBeenCalled();
+      });
+      await flushPromises();
+      expect(document.querySelector(".cost-badge")).toBeNull();
+
+      unmount(component);
+    });
+
+    it("renders no cost badge when the usage request fails", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockRejectedValue(
+        new Error("boom"),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude"),
+          onBack: () => {},
+        },
+      });
+
+      await flushPromises();
+      await vi.waitFor(() => {
+        expect(
+          sessionsService.getApiV1SessionsIdUsage,
+        ).toHaveBeenCalled();
+      });
+      await flushPromises();
+      expect(document.querySelector(".cost-badge")).toBeNull();
+
+      unmount(component);
+    });
+
+    it("ignores a stale usage response after switching sessions", async () => {
+      const first = deferred<SessionUsage>();
+      sessionsService.getApiV1SessionsIdUsage
+        .mockReturnValueOnce(first.promise)
+        .mockResolvedValueOnce(
+          makeUsage({
+            session_id: "run:bbb",
+            has_cost: true,
+            cost_usd: 2,
+          }),
+        );
+
+      const component = createClassComponent({
+        component: SessionBreadcrumb,
+        target: document.body,
+        props: {
+          session: makeSession("claude", { id: "run:aaa" }),
+          onBack: () => {},
+        },
+      });
+      await flushPromises();
+
+      component.$set({
+        session: makeSession("claude", { id: "run:bbb" }),
+      });
+      await vi.waitFor(() => {
+        const badge = document.querySelector(".cost-badge");
+        expect(badge?.textContent?.trim()).toBe("$2.00");
+      });
+
+      // The first session's response arrives late and must not
+      // overwrite the newer session's cost.
+      first.resolve(
+        makeUsage({
+          session_id: "run:aaa",
+          has_cost: true,
+          cost_usd: 9.99,
+        }),
+      );
+      await flushPromises();
+      expect(
+        document.querySelector(".cost-badge")?.textContent?.trim(),
+      ).toBe("$2.00");
+
+      component.$destroy();
+    });
+
+    it("keeps the newer cost when same-session responses resolve out of order", async () => {
+      const first = deferred<SessionUsage>();
+      const second = deferred<SessionUsage>();
+      sessionsService.getApiV1SessionsIdUsage
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise);
+
+      const component = createClassComponent({
+        component: SessionBreadcrumb,
+        target: document.body,
+        props: {
+          session: makeSession("claude", { message_count: 2 }),
+          onBack: () => {},
+        },
+      });
+      await flushPromises();
+
+      // A live-session update bumps message_count and triggers a
+      // second fetch while the first is still in flight.
+      component.$set({
+        session: makeSession("claude", { message_count: 3 }),
+      });
+      await flushPromises();
+      expect(
+        sessionsService.getApiV1SessionsIdUsage,
+      ).toHaveBeenCalledTimes(2);
+
+      second.resolve(makeUsage({ has_cost: true, cost_usd: 3.5 }));
+      await vi.waitFor(() => {
+        const badge = document.querySelector(".cost-badge");
+        expect(badge?.textContent?.trim()).toBe("$3.50");
+      });
+
+      first.resolve(makeUsage({ has_cost: true, cost_usd: 1 }));
+      await flushPromises();
+      expect(
+        document.querySelector(".cost-badge")?.textContent?.trim(),
+      ).toBe("$3.50");
+
+      component.$destroy();
+    });
   });
 
 });

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -533,7 +533,7 @@ describe("SessionBreadcrumb", () => {
       component.$destroy();
     });
 
-    it("refetches when a resync changes file metadata without token movement", async () => {
+    it("refetches when a resync changes context tokens without output movement", async () => {
       sessionsService.getApiV1SessionsIdUsage
         .mockResolvedValueOnce(
           makeUsage({ has_cost: true, cost_usd: 1 }),
@@ -546,7 +546,7 @@ describe("SessionBreadcrumb", () => {
         component: SessionBreadcrumb,
         target: document.body,
         props: {
-          session: makeSession("claude", { file_mtime: 1000 }),
+          session: makeSession("claude", { peak_context_tokens: 1000 }),
           onBack: () => {},
         },
       });
@@ -555,10 +555,10 @@ describe("SessionBreadcrumb", () => {
         expect(badge?.textContent?.trim()).toBe("$1.00");
       });
 
-      // A cost-only usage event arrives via resync: same message
-      // count and output tokens, only the file mtime moves.
+      // A resync grows context tokens in place: same message count
+      // and output tokens, only peak context moves.
       component.$set({
-        session: makeSession("claude", { file_mtime: 2000 }),
+        session: makeSession("claude", { peak_context_tokens: 2000 }),
       });
       await vi.waitFor(() => {
         const badge = document.querySelector(".cost-badge");

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -533,6 +533,44 @@ describe("SessionBreadcrumb", () => {
       component.$destroy();
     });
 
+    it("refetches when a resync changes file metadata without token movement", async () => {
+      sessionsService.getApiV1SessionsIdUsage
+        .mockResolvedValueOnce(
+          makeUsage({ has_cost: true, cost_usd: 1 }),
+        )
+        .mockResolvedValueOnce(
+          makeUsage({ has_cost: true, cost_usd: 1.75 }),
+        );
+
+      const component = createClassComponent({
+        component: SessionBreadcrumb,
+        target: document.body,
+        props: {
+          session: makeSession("claude", { file_mtime: 1000 }),
+          onBack: () => {},
+        },
+      });
+      await vi.waitFor(() => {
+        const badge = document.querySelector(".cost-badge");
+        expect(badge?.textContent?.trim()).toBe("$1.00");
+      });
+
+      // A cost-only usage event arrives via resync: same message
+      // count and output tokens, only the file mtime moves.
+      component.$set({
+        session: makeSession("claude", { file_mtime: 2000 }),
+      });
+      await vi.waitFor(() => {
+        const badge = document.querySelector(".cost-badge");
+        expect(badge?.textContent?.trim()).toBe("$1.75");
+      });
+      expect(
+        sessionsService.getApiV1SessionsIdUsage,
+      ).toHaveBeenCalledTimes(2);
+
+      component.$destroy();
+    });
+
     it("refetches on return navigation and rejects the other session's late response", async () => {
       const bRequest = deferred<SessionUsage>();
       const aRefetch = deferred<SessionUsage>();

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -533,6 +533,74 @@ describe("SessionBreadcrumb", () => {
       component.$destroy();
     });
 
+    it("refetches on return navigation and rejects the other session's late response", async () => {
+      const bRequest = deferred<SessionUsage>();
+      const aRefetch = deferred<SessionUsage>();
+      sessionsService.getApiV1SessionsIdUsage
+        .mockResolvedValueOnce(
+          makeUsage({
+            session_id: "run:aaa",
+            has_cost: true,
+            cost_usd: 1.5,
+          }),
+        )
+        .mockReturnValueOnce(bRequest.promise)
+        .mockReturnValueOnce(aRefetch.promise);
+
+      const component = createClassComponent({
+        component: SessionBreadcrumb,
+        target: document.body,
+        props: {
+          session: makeSession("claude", { id: "run:aaa" }),
+          onBack: () => {},
+        },
+      });
+      await vi.waitFor(() => {
+        const badge = document.querySelector(".cost-badge");
+        expect(badge?.textContent?.trim()).toBe("$1.50");
+      });
+
+      // Switch to B (request stays in flight), then back to A
+      // before B resolves.
+      component.$set({
+        session: makeSession("claude", { id: "run:bbb" }),
+      });
+      await flushPromises();
+      component.$set({
+        session: makeSession("claude", { id: "run:aaa" }),
+      });
+      await flushPromises();
+      expect(
+        sessionsService.getApiV1SessionsIdUsage,
+      ).toHaveBeenCalledTimes(3);
+
+      // B's late response must not be shown on A.
+      bRequest.resolve(
+        makeUsage({
+          session_id: "run:bbb",
+          has_cost: true,
+          cost_usd: 9.99,
+        }),
+      );
+      await flushPromises();
+      expect(document.querySelector(".cost-badge")).toBeNull();
+
+      // A's refetch lands and restores A's cost.
+      aRefetch.resolve(
+        makeUsage({
+          session_id: "run:aaa",
+          has_cost: true,
+          cost_usd: 1.5,
+        }),
+      );
+      await vi.waitFor(() => {
+        const badge = document.querySelector(".cost-badge");
+        expect(badge?.textContent?.trim()).toBe("$1.50");
+      });
+
+      component.$destroy();
+    });
+
     it("keeps the newer cost when same-session responses resolve out of order", async () => {
       const first = deferred<SessionUsage>();
       const second = deferred<SessionUsage>();

--- a/frontend/src/lib/utils/format.test.ts
+++ b/frontend/src/lib/utils/format.test.ts
@@ -2,9 +2,25 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   sanitizeSnippet,
   _resetNonceCounter,
+  formatCost,
   formatTokenCount,
   formatTokenUsage,
 } from "./format.js";
+
+describe("formatCost", () => {
+  it.each([
+    [0, "$0.00"],
+    [0.004, "<$0.01"],
+    [0.01, "$0.01"],
+    [0.42, "$0.42"],
+    [12.345, "$12.35"],
+    [99.994, "$99.99"],
+    [100, "$100"],
+    [1234.5, "$1235"],
+  ])("formats %d as %s", (value, expected) => {
+    expect(formatCost(value)).toBe(expected);
+  });
+});
 
 describe("sanitizeSnippet", () => {
   beforeEach(() => {

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -86,6 +86,13 @@ export function formatTokenUsage(
   return `${contextLabel} / ${outputLabel}`;
 }
 
+/** Formats a USD cost as a compact string (e.g. $0.42, $12.34, $123) */
+export function formatCost(v: number): string {
+  if (v > 0 && v < 0.01) return "<$0.01";
+  if (v >= 100) return `$${v.toFixed(0)}`;
+  return `$${v.toFixed(2)}`;
+}
+
 let nonceCounter = 0;
 
 /** Reset the nonce counter. Exported for testing only. */


### PR DESCRIPTION
## Summary

The session detail header now shows the session's estimated dollar cost as a badge between the token summary (`386.6k ctx / 308.2k out`) and the model id (`claude-opus-4-8`).

The breadcrumb fetches the existing `GET /api/v1/sessions/{id}/usage` endpoint, which already computes `cost_usd`/`has_cost` from the `model_pricing` table on both backends (`internal/db/usage.go` and `internal/postgres/usage.go`), so this is a frontend-only change with no parity impact.

Implementation details:

- The fetch is keyed on `(id, total_output_tokens, message_count, ended_at)` rather than session id alone, because cost can move without output tokens moving (input/cache tokens and explicitly reported `cost_usd` from usage events all feed the backend computation). The session row is replaced wholesale on SSE updates, so the badge refreshes as a live session accumulates usage.
- A monotonic request sequence counter discards stale out-of-order responses, both across session switches and for same-session refetches.
- A shared `formatCost` helper in `lib/utils/format.ts` mirrors the formatting already used across the usage dashboard (`$0.42`, `$12.34`, `$123` above one hundred), with a `<$0.01` floor so priced-but-cheap sessions don't render as `$0.00`.

Limitations/tradeoffs: sessions whose models have no pricing data, sessions with no token data, or a failed/unsupported usage request render no badge at all (graceful degradation, no placeholder). The existing per-component cost formatters in `lib/components/usage/` were intentionally left untouched to keep the diff focused.

Where to look: `frontend/src/lib/components/layout/SessionBreadcrumb.svelte` for the fetch effect and badge markup; `SessionBreadcrumb.test.ts` for the race-condition and badge-placement tests (the generated API barrel is now partially mocked there, keeping `OpenAPI` intact for `configureGeneratedClient`).

## Screenshots

Same session (`2c85392b`, claude-opus-4-8) in the session header, before and after.

**Before** — token summary directly followed by the model id:

![Session header before: token badge then model badge](https://raw.githubusercontent.com/chrislee3408/agentsview/pr-assets/cost-badge/docs/pr-assets/cost-badge-before.png)

**After** — estimated cost between the token summary and the model id:

![Session header after: token badge, cost badge, model badge](https://raw.githubusercontent.com/chrislee3408/agentsview/pr-assets/cost-badge/docs/pr-assets/cost-badge-after.png)
