### PR TITLE
Infer Antigravity CLI project when history rows lack conversationId

### DIFF
--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -247,6 +247,11 @@ func ParseAntigravityCLISessionWithStatus(
 		project = inferAntigravityProject(
 			filepath.Join(root, "history.jsonl"), id,
 		)
+		if project == "" {
+			project = inferAntigravityProjectFromHistoryFallback(
+				filepath.Join(root, "history.jsonl"), messages, info.ModTime(),
+			)
+		}
 	}
 
 	var firstMessage string
@@ -451,6 +456,94 @@ func buildAntigravityProjectMap(path string) map[string]string {
 func inferAntigravityProject(path, id string) string {
 	m := buildAntigravityProjectMap(path)
 	return m[id]
+}
+
+func inferAntigravityProjectFromHistoryFallback(
+	historyPath string, messages []ParsedMessage, dbMtime time.Time,
+) string {
+	var sessionPrompt string
+	var sessionTime time.Time
+	for _, msg := range messages {
+		if msg.Role == RoleUser && msg.Content != "" {
+			sessionPrompt = msg.Content
+			sessionTime = msg.Timestamp
+			break
+		}
+	}
+
+	if sessionPrompt == "" {
+		return ""
+	}
+	if sessionTime.IsZero() {
+		sessionTime = dbMtime
+	}
+
+	normSession := strings.ToLower(strings.Join(strings.Fields(sessionPrompt), " "))
+	if len(normSession) < 3 {
+		return ""
+	}
+
+	f, err := os.Open(historyPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	var bestWorkspace string
+	var minDiff time.Duration
+	var found bool
+	var ambiguous bool
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if gjson.GetBytes(line, "conversationId").Str != "" {
+			continue
+		}
+		display := gjson.GetBytes(line, "display").Str
+		workspace := gjson.GetBytes(line, "workspace").Str
+		tsMS := gjson.GetBytes(line, "timestamp").Int()
+
+		if display == "" || workspace == "" || tsMS == 0 {
+			continue
+		}
+
+		normRow := strings.ToLower(strings.Join(strings.Fields(display), " "))
+		if normRow != normSession {
+			continue
+		}
+
+		rowTime := time.UnixMilli(tsMS)
+		diff := rowTime.Sub(sessionTime)
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 60*time.Second {
+			continue
+		}
+
+		if !found {
+			bestWorkspace = workspace
+			minDiff = diff
+			found = true
+			ambiguous = false
+		} else if diff < minDiff {
+			bestWorkspace = workspace
+			minDiff = diff
+			ambiguous = false
+		} else if diff == minDiff && workspace != bestWorkspace {
+			ambiguous = true
+		}
+	}
+
+	if found && !ambiguous {
+		return bestWorkspace
+	}
+	return ""
 }
 
 // collectAntigravityHistoryMessages returns one user ParsedMessage

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -260,6 +260,109 @@ func TestAntigravityCLIDiscoverAndParseDB(t *testing.T) {
 	assert.Equal(t, "db prompt fallback", sess.FirstMessage)
 }
 
+func TestAntigravityCLIProjectFallbackPromptAndProximity(t *testing.T) {
+	root := t.TempDir()
+	id := "f0f0f0f0-f1f1-f2f2-f3f3-f4f4f4f4f4f4"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustMkdir(t, filepath.Join(root, "brain", id))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // user prompt: "user prompt text goes here", ts: 1779000000
+
+	// Create history.jsonl with a row omitting conversationId, matching text, and close timestamp (1779000000000 ms)
+	mustWrite(t, filepath.Join(root, "history.jsonl"),
+		[]byte(`{"display":"  user prompt text goes here  ","timestamp":1779000010000,"workspace":"/tmp/fallback-proj"}`))
+
+	sess, msgs, err := ParseAntigravityCLISession(dbPath, "", "m")
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "/tmp/fallback-proj", sess.Project, "should successfully fallback infer project")
+}
+
+func TestAntigravityCLIProjectFallbackStrictWindow(t *testing.T) {
+	root := t.TempDir()
+	id := "e0e0e0e0-e1e1-e2e2-e3e3-e4e4e4e4e4e4"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustMkdir(t, filepath.Join(root, "brain", id))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // user prompt: "user prompt text goes here", ts: 1779000000
+
+	// Create history.jsonl with timestamp outside the 1-minute window (e.g., 65 seconds later)
+	mustWrite(t, filepath.Join(root, "history.jsonl"),
+		[]byte(`{"display":"user prompt text goes here","timestamp":1779000065000,"workspace":"/tmp/too-late-proj"}`))
+
+	sess, _, err := ParseAntigravityCLISession(dbPath, "", "m")
+	require.NoError(t, err)
+	assert.Empty(t, sess.Project, "should reject match outside 1-minute window")
+}
+
+func TestAntigravityCLIProjectFallbackAmbiguous(t *testing.T) {
+	root := t.TempDir()
+	id := "d0d0d0d0-d1d1-d2d2-d3d3-d4d4d4d4d4d4"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustMkdir(t, filepath.Join(root, "brain", id))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // user prompt: "user prompt text goes here", ts: 1779000000
+
+	// Create history.jsonl with two rows having matching prompts, same timestamp difference, but different workspaces
+	mustWrite(t, filepath.Join(root, "history.jsonl"),
+		[]byte(`{"display":"user prompt text goes here","timestamp":1779000005000,"workspace":"/tmp/proj-a"}
+{"display":"user prompt text goes here","timestamp":1779000005000,"workspace":"/tmp/proj-b"}`))
+
+	sess, _, err := ParseAntigravityCLISession(dbPath, "", "m")
+	require.NoError(t, err)
+	assert.Empty(t, sess.Project, "should reject ambiguous match with different workspaces at same time closeness")
+}
+
+func TestAntigravityCLIProjectFallbackShortPrompt(t *testing.T) {
+	root := t.TempDir()
+	id := "c0c0c0c0-c1c1-c2c2-c3c3-c4c4c4c4c4c4"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	mustMkdir(t, filepath.Join(root, "brain", id))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityOvershortPromptDB(t, dbPath) // user prompt: "hi", ts: 1779000000
+
+	// Create history.jsonl with matching short prompt "hi"
+	mustWrite(t, filepath.Join(root, "history.jsonl"),
+		[]byte(`{"display":"hi","timestamp":1779000005000,"workspace":"/tmp/short-proj"}`))
+
+	sess, _, err := ParseAntigravityCLISession(dbPath, "", "m")
+	require.NoError(t, err)
+	assert.Empty(t, sess.Project, "should reject matching short prompts")
+}
+
+func createAntigravityOvershortPromptDB(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open")
+	defer db.Close()
+	createAntigravityStepTables(t, db)
+
+	tsEarly := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000000},
+	})
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsEarly},
+		{
+			num:   17,
+			wire:  pbWireBytes,
+			bytes: []byte("hi"),
+		},
+	})
+	mustExec(t, db,
+		`INSERT INTO steps (idx, step_type, step_payload) `+
+			`VALUES (?, ?, ?)`,
+		0, 14, userPayload)
+}
+
+
 func TestAntigravityCLIDBFileInfoIncludesSQLiteSidecars(t *testing.T) {
 	root := t.TempDir()
 	id := "44444444-5555-6666-7777-888888888888"

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -362,7 +362,6 @@ func createAntigravityOvershortPromptDB(t *testing.T, path string) {
 		0, 14, userPayload)
 }
 
-
 func TestAntigravityCLIDBFileInfoIncludesSQLiteSidecars(t *testing.T) {
 	root := t.TempDir()
 	id := "44444444-5555-6666-7777-888888888888"


### PR DESCRIPTION
Closes #579.

Newer Antigravity CLI history rows can carry `display`, `timestamp`, and `workspace` without a `conversationId`. The existing project map only consumes history rows that have a `conversationId`, so `.db` sessions whose matching history row omits it parse their transcript fine but render with an empty project.

This adds a fallback in `ParseAntigravityCLISessionWithStatus`: when the direct `conversationId` lookup yields no project, `inferAntigravityProjectFromHistoryFallback` scans `history.jsonl` for rows that have no `conversationId` and matches them against the session by:

- exact normalized first-user-prompt text (lowercased, whitespace-collapsed), and
- timestamp proximity within a ±60s window (falling back to the DB mtime when the parsed message has no timestamp).

It stays deliberately conservative to avoid mis-assigning projects: prompts shorter than 3 normalized characters are ignored, and if two candidate rows tie on closeness with different workspaces the match is treated as ambiguous and discarded.

Where to look: `internal/parser/antigravity_cli.go` for the inference logic, `internal/parser/antigravity_test.go` for coverage of the happy path, the strict window boundary, ambiguity rejection, and the short-prompt guard.