### PR TITLE
Keep app usable when PG sync backend is degraded

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -963,16 +963,14 @@ fn setup_menu(app: &mut App) -> Result<(), DynError> {
     let check_updates =
         MenuItemBuilder::with_id("check_updates", "Check for Updates...").build(app)?;
 
-    let mut builder = SubmenuBuilder::new(app, "File")
+    let builder = SubmenuBuilder::new(app, "File")
         .item(&about)
         .separator()
         .item(&check_updates)
         .separator();
 
     #[cfg(target_os = "macos")]
-    {
-        builder = builder.hide().hide_others().separator();
-    }
+    let builder = builder.hide().hide_others().separator();
 
     let app_submenu = builder.quit().build()?;
 
@@ -2117,10 +2115,24 @@ mod tests {
         perms.set_mode(0o700);
         fs::set_permissions(&script_path, perms).expect("set executable permissions");
 
-        let result = try_run_login_shell_env(
-            script_path.to_str().expect("script path utf-8"),
-            Duration::from_secs(2),
-        );
+        let mut attempts_left = 5;
+        let result = loop {
+            let result = try_run_login_shell_env(
+                script_path.to_str().expect("script path utf-8"),
+                Duration::from_secs(2),
+            );
+            match &result {
+                Err(LoginShellEnvError::Spawn(e)) if e.raw_os_error() == Some(26) => {
+                    attempts_left -= 1;
+                    if attempts_left == 0 {
+                        break result;
+                    }
+                    thread::sleep(Duration::from_millis(50));
+                    continue;
+                }
+                _ => break result,
+            }
+        };
         let _ = fs::remove_file(&script_path);
 
         match result {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -350,7 +350,6 @@
     sync.startPolling();
 
     const healthCleanup = setupVisibilityHealthCheck(getBase, {
-      onBackendAvailable: () => sync.clearBackendDegraded(),
       onBackendDegraded: () => sync.markBackendDegraded(),
     });
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -349,7 +349,10 @@
     sync.checkForUpdate();
     sync.startPolling();
 
-    const healthCleanup = setupVisibilityHealthCheck(getBase);
+    const healthCleanup = setupVisibilityHealthCheck(getBase, {
+      onBackendAvailable: () => sync.clearBackendDegraded(),
+      onBackendDegraded: () => sync.markBackendDegraded(),
+    });
 
     window.addEventListener("show-about", showAbout);
     const cleanup = registerShortcuts({ navigateMessage });

--- a/frontend/src/lib/components/layout/StatusBar.retry.test.ts
+++ b/frontend/src/lib/components/layout/StatusBar.retry.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { mount, tick, unmount } from "svelte";
+// @ts-ignore
+import StatusBar from "./StatusBar.svelte";
+import { sync } from "../../stores/sync.svelte.js";
+
+describe("StatusBar degraded backend retry", () => {
+  beforeEach(() => {
+    sync.backendDegraded = true;
+    sync.backendDegradedMessage = "sync not ready";
+    sync.lastSync = "2026-04-08T05:00:00Z";
+    sync.remoteUnreachable = false;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    sync.backendDegraded = false;
+    sync.backendDegradedMessage = null;
+    sync.lastSync = null;
+    sync.remoteUnreachable = false;
+  });
+
+  it("retries stats when sync-not-ready indicator is clicked", async () => {
+    const loadStats = vi
+      .spyOn(sync, "loadStats")
+      .mockResolvedValue(undefined);
+    const component = mount(StatusBar, {
+      target: document.body,
+    });
+    await tick();
+
+    document.querySelector<HTMLButtonElement>(".backend-warn")?.click();
+
+    expect(loadStats).toHaveBeenCalledOnce();
+
+    unmount(component);
+  });
+});

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -73,7 +73,7 @@
     {#if sync.backendDegraded}
       <button
         class="backend-warn"
-        onclick={() => sync.loadStatus()}
+        onclick={() => sync.loadStats()}
         title={sync.backendDegradedMessage ?? "sync not ready"}
       >
         sync not ready

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -70,6 +70,16 @@
       </button>
       <span class="sep">&middot;</span>
     {/if}
+    {#if sync.backendDegraded}
+      <button
+        class="backend-warn"
+        onclick={() => sync.loadStatus()}
+        title={sync.backendDegradedMessage ?? "sync not ready"}
+      >
+        sync not ready
+      </button>
+      <span class="sep">&middot;</span>
+    {/if}
     {#if sync.isDesktop}
       <div class="zoom-controls">
         <button
@@ -203,7 +213,15 @@
     font-weight: 500;
   }
 
-  .remote-warn:hover {
+  .backend-warn {
+    color: var(--accent-red);
+    font-size: 10px;
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .remote-warn:hover,
+  .backend-warn:hover {
     text-decoration: underline;
   }
 

--- a/frontend/src/lib/components/layout/StatusBar.test.ts
+++ b/frontend/src/lib/components/layout/StatusBar.test.ts
@@ -23,6 +23,8 @@ describe("StatusBar", () => {
     sync.serverVersion = null;
     sync.versionMismatch = false;
     sync.remoteUnreachable = false;
+    sync.backendDegraded = false;
+    sync.backendDegradedMessage = null;
   });
 
   afterEach(() => {
@@ -33,6 +35,8 @@ describe("StatusBar", () => {
     sync.serverVersion = null;
     sync.versionMismatch = false;
     sync.remoteUnreachable = false;
+    sync.backendDegraded = false;
+    sync.backendDegradedMessage = null;
     sync.progress = null;
     sync.syncing = false;
   });
@@ -86,6 +90,26 @@ describe("StatusBar", () => {
     expect(document.body.textContent).not.toContain(
       "remote server unreachable",
     );
+
+    unmount(component);
+  });
+
+  it("shows a sync-not-ready indicator when backend is degraded", async () => {
+    sync.backendDegraded = true;
+    sync.backendDegradedMessage = "sync not ready";
+    const component = mount(StatusBar, {
+      target: document.body,
+    });
+    await tick();
+
+    expect(document.body.textContent).toContain("sync not ready");
+    expect(
+      document.querySelector(".backend-warn")?.getAttribute("title"),
+    ).toBe("sync not ready");
+
+    sync.backendDegraded = false;
+    await tick();
+    expect(document.body.textContent).not.toContain("sync not ready");
 
     unmount(component);
   });

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -5,6 +5,7 @@ import {
   type SyncHandle,
 } from "../api/client.js";
 import {
+  ApiError as GeneratedApiError,
   MetadataService,
   SyncService,
 } from "../api/generated/index";
@@ -55,6 +56,11 @@ class SyncStore {
   // reach (network error, CSP block, or the server being down).
   // Surfaced in the status bar so the failure is not silent.
   remoteUnreachable: boolean = $state(false);
+  // True when the backend process answers but one of its dependencies
+  // is not ready yet, such as a PostgreSQL-backed server before PG
+  // becomes reachable.
+  backendDegraded: boolean = $state(false);
+  backendDegradedMessage: string | null = $state(null);
   updateAvailable: boolean = $state(false);
   latestVersion: string | null = $state(null);
   readonly buildCommit: string =
@@ -92,9 +98,35 @@ class SyncStore {
   private markRemoteReachable(reachable: boolean) {
     if (reachable) {
       this.remoteUnreachable = false;
-    } else if (isRemoteConnection()) {
+      this.clearBackendDegraded();
+      return;
+    }
+    this.clearBackendDegraded();
+    if (isRemoteConnection()) {
       this.remoteUnreachable = true;
     }
+  }
+
+  markBackendDegraded(message = "sync not ready") {
+    this.remoteUnreachable = false;
+    this.backendDegraded = true;
+    this.backendDegradedMessage = message;
+  }
+
+  clearBackendDegraded() {
+    this.backendDegraded = false;
+    this.backendDegradedMessage = null;
+  }
+
+  private markBackendFailure(error: unknown) {
+    if (
+      error instanceof GeneratedApiError &&
+      error.status >= 500
+    ) {
+      this.markBackendDegraded();
+      return;
+    }
+    this.markRemoteReachable(false);
   }
 
   async loadStatus() {
@@ -118,7 +150,7 @@ class SyncStore {
         this.notifySyncComplete();
       }
     } catch (error) {
-      this.markRemoteReachable(false);
+      this.markBackendFailure(error);
       this.pendingHydration = false;
       console.warn("Failed to load sync status:", error);
     }
@@ -158,6 +190,7 @@ class SyncStore {
         this.stats = result;
       }
     } catch (error) {
+      this.markBackendFailure(error);
       console.warn("Failed to load sync stats:", error);
     }
   }
@@ -173,7 +206,7 @@ class SyncStore {
         this.serverVersion.commit,
       );
     } catch (error) {
-      this.markRemoteReachable(false);
+      this.markBackendFailure(error);
       console.warn("Failed to load version info:", error);
     }
   }

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -142,13 +142,16 @@ class SyncStore {
         newLastSync !== null && newLastSync !== this.lastSync;
       this.lastSync = newLastSync;
       this.lastSyncStats = status.stats as unknown as SyncStats | null;
+      const shouldRetryStats = this.backendDegraded;
       // Suppress notifications on initial hydration and
       // when a local sync just completed (pendingHydration).
       if (this.pendingHydration) {
         this.pendingHydration = false;
       } else if (changed && !isInitial) {
-        this.loadStats();
+        await this.loadStats();
         this.notifySyncComplete();
+      } else if (shouldRetryStats) {
+        await this.loadStats();
       }
     } catch (error) {
       this.markBackendFailure(error);
@@ -192,8 +195,10 @@ class SyncStore {
         this.clearBackendDegraded();
       }
     } catch (error) {
-      this.markBackendFailure(error);
-      console.warn("Failed to load sync stats:", error);
+      if (this.statsVersion === version) {
+        this.markBackendFailure(error);
+        console.warn("Failed to load sync stats:", error);
+      }
     }
   }
 

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -92,13 +92,14 @@ class SyncStore {
     }
   }
 
-  /** Record whether the backend responded. Only flags a failure
-   * when a remote server is configured — local failures are handled
-   * by the visibility health check, which reloads the page. */
+  /** Record whether the backend process responded. Only flags a
+   * failure when a remote server is configured — local failures are
+   * handled by the visibility health check, which reloads the page.
+   * A successful liveness-style response does not prove PG-backed
+   * reads are healthy, so it must not clear backendDegraded. */
   private markRemoteReachable(reachable: boolean) {
     if (reachable) {
       this.remoteUnreachable = false;
-      this.clearBackendDegraded();
       return;
     }
     this.clearBackendDegraded();
@@ -188,6 +189,7 @@ class SyncStore {
       ) as unknown as Stats;
       if (this.statsVersion === version) {
         this.stats = result;
+        this.clearBackendDegraded();
       }
     } catch (error) {
       this.markBackendFailure(error);

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -17,6 +17,15 @@ const api = vi.hoisted(() => ({
   getVersion: vi.fn(),
   checkForUpdate: vi.fn(),
   isRemoteConnection: vi.fn(),
+  ApiError: class MockGeneratedApiError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  },
 }));
 
 vi.mock("../api/client.js", () => ({
@@ -32,6 +41,7 @@ vi.mock("../api/runtime.js", () => ({
 }));
 
 vi.mock("../api/generated/index", () => ({
+  ApiError: api.ApiError,
   MetadataService: {
     getApiV1Stats: vi.fn((params) => api.getStats(params)),
     getApiV1Version: vi.fn(() => api.getVersion()),
@@ -318,6 +328,8 @@ describe("SyncStore.remoteUnreachable", () => {
     vi.clearAllMocks();
     const s = sync as unknown as Record<string, unknown>;
     s.remoteUnreachable = false;
+    s.backendDegraded = false;
+    s.backendDegradedMessage = null;
     s.statusHydrated = false;
   });
 
@@ -355,5 +367,50 @@ describe("SyncStore.remoteUnreachable", () => {
     await sync.loadStatus();
 
     expect(sync.remoteUnreachable).toBe(false);
+  });
+
+  it("flags backend degraded instead of unreachable on 5xx", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(true);
+    vi.mocked(api.getSyncStatus).mockRejectedValue(
+      new api.ApiError(503, "pg unavailable"),
+    );
+
+    await sync.loadStatus();
+
+    expect(sync.remoteUnreachable).toBe(false);
+    expect(sync.backendDegraded).toBe(true);
+    expect(sync.backendDegradedMessage).toBe("sync not ready");
+  });
+
+  it("clears backend degraded when status recovers", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(true);
+    const s = sync as unknown as Record<string, unknown>;
+    s.backendDegraded = true;
+    s.backendDegradedMessage = "sync not ready";
+    vi.mocked(api.getSyncStatus).mockResolvedValue({
+      last_sync: "",
+      stats: MOCK_STATS,
+    });
+
+    await sync.loadStatus();
+
+    expect(sync.backendDegraded).toBe(false);
+    expect(sync.backendDegradedMessage).toBeNull();
+  });
+
+  it("clears backend degraded when the remote becomes unreachable", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(true);
+    const s = sync as unknown as Record<string, unknown>;
+    s.backendDegraded = true;
+    s.backendDegradedMessage = "sync not ready";
+    vi.mocked(api.getSyncStatus).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+
+    await sync.loadStatus();
+
+    expect(sync.backendDegraded).toBe(false);
+    expect(sync.backendDegradedMessage).toBeNull();
+    expect(sync.remoteUnreachable).toBe(true);
   });
 });

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -382,7 +382,7 @@ describe("SyncStore.remoteUnreachable", () => {
     expect(sync.backendDegradedMessage).toBe("sync not ready");
   });
 
-  it("clears backend degraded when status recovers", async () => {
+  it("keeps backend degraded when status recovers", async () => {
     vi.mocked(api.isRemoteConnection).mockReturnValue(true);
     const s = sync as unknown as Record<string, unknown>;
     s.backendDegraded = true;
@@ -393,6 +393,44 @@ describe("SyncStore.remoteUnreachable", () => {
     });
 
     await sync.loadStatus();
+
+    expect(sync.remoteUnreachable).toBe(false);
+    expect(sync.backendDegraded).toBe(true);
+    expect(sync.backendDegradedMessage).toBe("sync not ready");
+  });
+
+  it("keeps backend degraded when version loads", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(true);
+    const s = sync as unknown as Record<string, unknown>;
+    s.backendDegraded = true;
+    s.backendDegradedMessage = "sync not ready";
+    vi.mocked(api.getVersion).mockResolvedValue({
+      build_date: "",
+      commit: "abc123",
+      version: "dev",
+    });
+
+    await sync.loadVersion();
+
+    expect(sync.remoteUnreachable).toBe(false);
+    expect(sync.backendDegraded).toBe(true);
+    expect(sync.backendDegradedMessage).toBe("sync not ready");
+  });
+
+  it("clears backend degraded when stats load succeeds", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(true);
+    const s = sync as unknown as Record<string, unknown>;
+    s.backendDegraded = true;
+    s.backendDegradedMessage = "sync not ready";
+    vi.mocked(api.getStats).mockResolvedValue({
+      earliest_session: null,
+      machine_count: 1,
+      message_count: 100,
+      project_count: 3,
+      session_count: 8,
+    });
+
+    await sync.loadStats();
 
     expect(sync.backendDegraded).toBe(false);
     expect(sync.backendDegradedMessage).toBeNull();

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -175,6 +175,44 @@ describe("SyncStore.loadStats", () => {
     await p1;
     expect(sync.stats).toEqual(newer);
   });
+
+  it("ignores stale failure when a newer request succeeds", async () => {
+    const newer = {
+      session_count: 5,
+      message_count: 30,
+      project_count: 1,
+      machine_count: 1,
+      earliest_session: null,
+    };
+
+    let rejectOlder!: (err: Error) => void;
+    let resolveNewer!: (v: typeof newer) => void;
+
+    vi.mocked(api.getStats)
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectOlder = reject;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveNewer = r;
+        }),
+      );
+
+    const p1 = sync.loadStats({ includeOneShot: true });
+    const p2 = sync.loadStats({});
+
+    resolveNewer(newer);
+    await p2;
+    expect(sync.stats).toEqual(newer);
+    expect(sync.backendDegraded).toBe(false);
+
+    rejectOlder(new api.ApiError(503, "stale pg outage"));
+    await p1;
+    expect(sync.stats).toEqual(newer);
+    expect(sync.backendDegraded).toBe(false);
+  });
 });
 
 describe("SyncStore.triggerResync", () => {
@@ -391,12 +429,39 @@ describe("SyncStore.remoteUnreachable", () => {
       last_sync: "",
       stats: MOCK_STATS,
     });
+    vi.mocked(api.getStats).mockRejectedValue(
+      new api.ApiError(503, "pg unavailable"),
+    );
 
     await sync.loadStatus();
 
     expect(sync.remoteUnreachable).toBe(false);
     expect(sync.backendDegraded).toBe(true);
     expect(sync.backendDegradedMessage).toBe("sync not ready");
+  });
+
+  it("retries stats when status loads while backend is degraded", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(true);
+    const s = sync as unknown as Record<string, unknown>;
+    s.backendDegraded = true;
+    s.backendDegradedMessage = "sync not ready";
+    vi.mocked(api.getSyncStatus).mockResolvedValue({
+      last_sync: "",
+      stats: MOCK_STATS,
+    });
+    vi.mocked(api.getStats).mockResolvedValue({
+      earliest_session: null,
+      machine_count: 1,
+      message_count: 100,
+      project_count: 3,
+      session_count: 8,
+    });
+
+    await sync.loadStatus();
+
+    expect(api.getStats).toHaveBeenCalled();
+    expect(sync.backendDegraded).toBe(false);
+    expect(sync.backendDegradedMessage).toBeNull();
   });
 
   it("keeps backend degraded when version loads", async () => {

--- a/frontend/src/lib/utils/health.test.ts
+++ b/frontend/src/lib/utils/health.test.ts
@@ -82,14 +82,14 @@ describe("setupVisibilityHealthCheck", () => {
     cleanup();
   });
 
-  it("reloads on 5xx server error", async () => {
+  it("does not reload on 5xx server error", async () => {
     globalThis.fetch = vi
       .fn()
       .mockResolvedValue(new Response("", { status: 502 }));
     const cleanup = setupVisibilityHealthCheck(() => "/api/v1");
     fireVisible();
     await new Promise((r) => setTimeout(r, 50));
-    expect(reloadSpy).toHaveBeenCalledOnce();
+    expect(reloadSpy).not.toHaveBeenCalled();
     cleanup();
   });
 

--- a/frontend/src/lib/utils/health.test.ts
+++ b/frontend/src/lib/utils/health.test.ts
@@ -83,13 +83,17 @@ describe("setupVisibilityHealthCheck", () => {
   });
 
   it("does not reload on 5xx server error", async () => {
+    const onBackendDegraded = vi.fn();
     globalThis.fetch = vi
       .fn()
       .mockResolvedValue(new Response("", { status: 502 }));
-    const cleanup = setupVisibilityHealthCheck(() => "/api/v1");
+    const cleanup = setupVisibilityHealthCheck(() => "/api/v1", {
+      onBackendDegraded,
+    });
     fireVisible();
     await new Promise((r) => setTimeout(r, 50));
     expect(reloadSpy).not.toHaveBeenCalled();
+    expect(onBackendDegraded).toHaveBeenCalledWith(502);
     cleanup();
   });
 

--- a/frontend/src/lib/utils/health.ts
+++ b/frontend/src/lib/utils/health.ts
@@ -3,6 +3,11 @@ import { getAuthToken, isRemoteConnection } from "../api/runtime.js";
 const DEBOUNCE_MS = 5_000;
 const TIMEOUT_MS = 3_000;
 
+interface VisibilityHealthCheckOptions {
+  onBackendAvailable?: () => void;
+  onBackendDegraded?: (status: number) => void;
+}
+
 /**
  * Set up a visibilitychange listener that pings the backend when the
  * page becomes visible. If the backend is unreachable (network error or
@@ -25,6 +30,7 @@ const TIMEOUT_MS = 3_000;
  */
 export function setupVisibilityHealthCheck(
   getBaseUrl: () => string,
+  opts: VisibilityHealthCheckOptions = {},
 ): () => void {
   // In desktop mode with a local sidecar, Tauri owns recovery via
   // on_window_event focus. Skip the frontend handler to avoid racing
@@ -54,6 +60,11 @@ export function setupVisibilityHealthCheck(
     fetch(`${getBaseUrl()}/version`, init)
       .then((res) => {
         clearTimeout(timer);
+        if (res.status >= 500) {
+          opts.onBackendDegraded?.(res.status);
+          return;
+        }
+        opts.onBackendAvailable?.();
       })
       .catch(() => {
         clearTimeout(timer);

--- a/frontend/src/lib/utils/health.ts
+++ b/frontend/src/lib/utils/health.ts
@@ -4,7 +4,6 @@ const DEBOUNCE_MS = 5_000;
 const TIMEOUT_MS = 3_000;
 
 interface VisibilityHealthCheckOptions {
-  onBackendAvailable?: () => void;
   onBackendDegraded?: (status: number) => void;
 }
 
@@ -64,7 +63,6 @@ export function setupVisibilityHealthCheck(
           opts.onBackendDegraded?.(res.status);
           return;
         }
-        opts.onBackendAvailable?.();
       })
       .catch(() => {
         clearTimeout(timer);

--- a/frontend/src/lib/utils/health.ts
+++ b/frontend/src/lib/utils/health.ts
@@ -5,11 +5,13 @@ const TIMEOUT_MS = 3_000;
 
 /**
  * Set up a visibilitychange listener that pings the backend when the
- * page becomes visible. If the backend is unreachable (network error,
- * timeout, or 5xx), the page reloads automatically.
+ * page becomes visible. If the backend is unreachable (network error or
+ * timeout), the page reloads automatically.
  *
  * 4xx responses (401/403) are treated as proof the backend is alive
- * and do not trigger a reload — auth recovery is handled elsewhere.
+ * and do not trigger a reload — auth recovery is handled elsewhere. The same
+ * is true for 5xx responses: the backend process answered, so reloading the
+ * SPA is unlikely to repair a degraded dependency such as PostgreSQL.
  *
  * In desktop mode with a local sidecar, this handler is a no-op
  * because Tauri's on_window_event focus handler owns recovery.
@@ -52,7 +54,6 @@ export function setupVisibilityHealthCheck(
     fetch(`${getBaseUrl()}/version`, init)
       .then((res) => {
         clearTimeout(timer);
-        if (res.status >= 500) throw new Error(`HTTP ${res.status}`);
       })
       .catch(() => {
         clearTimeout(timer);


### PR DESCRIPTION
This changes the frontend health and sync-status paths so backend HTTP 5xx responses no longer reload or effectively take down the SPA. A PostgreSQL-backed server that is alive but not ready now leaves the UI usable and surfaces a degraded sync state instead.

The sync store now tracks backend degradation separately from remote connectivity. Generated API 5xx failures mark the backend as degraded, successful liveness calls only clear remote-unreachable state, and a successful `/stats` load clears the degraded backend warning because it exercises the backing store. Network failures still use the existing remote-unreachable path. The status bar shows a clickable `sync not ready` indicator for degraded backend responses, distinct from the existing `remote server unreachable` warning.

A follow-up also stabilizes the desktop Linux arm64 smoke test by retrying the same temporary-script `ETXTBSY` race handled by adjacent login-shell tests, and removes the Rust unused-mutable warning in menu setup.

The tradeoff is that degraded backend failures use a generic user-facing message rather than exposing backend-specific errors in the status bar; detailed failures still go to the console. Main review spots are `frontend/src/lib/utils/health.ts`, `frontend/src/lib/stores/sync.svelte.ts`, `frontend/src/lib/components/layout/StatusBar.svelte`, and `desktop/src-tauri/src/lib.rs`.
