### PR TITLE
Add claude-fable-5 fallback pricing

### DIFF
--- a/internal/pricing/fallback.go
+++ b/internal/pricing/fallback.go
@@ -2,7 +2,7 @@ package pricing
 
 // FallbackVersion must be bumped whenever FallbackPricing
 // rates change so the startup seeder knows to re-upsert.
-const FallbackVersion = "2026-05-30"
+const FallbackVersion = "2026-06-10"
 
 // FallbackPricing returns hardcoded pricing for key Claude
 // models. Used when the LiteLLM fetch fails.
@@ -40,6 +40,16 @@ func FallbackPricing() []ModelPricing {
 			OutputPerMTok:        25.0,
 			CacheCreationPerMTok: 6.25,
 			CacheReadPerMTok:     0.50,
+		},
+		{
+			// Fable 5 launched at double the Opus 4.8 rates and is
+			// not yet in the LiteLLM catalog, so it ships here so
+			// usage is priced until LiteLLM adds it.
+			ModelPattern:         "claude-fable-5",
+			InputPerMTok:         10.0,
+			OutputPerMTok:        50.0,
+			CacheCreationPerMTok: 12.50,
+			CacheReadPerMTok:     1.0,
 		},
 		{
 			ModelPattern:         "claude-haiku-4-5-20251001",

--- a/internal/pricing/fallback_test.go
+++ b/internal/pricing/fallback_test.go
@@ -77,6 +77,30 @@ func TestFallbackPricing_Opus48Rates(t *testing.T) {
 	assert.Equal(t, want, *got)
 }
 
+func TestFallbackPricing_Fable5Rates(t *testing.T) {
+	prices := FallbackPricing()
+	var got *ModelPricing
+	for i := range prices {
+		if prices[i].ModelPattern == "claude-fable-5" {
+			got = &prices[i]
+			break
+		}
+	}
+	require.NotNil(t, got, "claude-fable-5 entry missing from FallbackPricing")
+
+	// Source: https://platform.claude.com/docs/en/about-claude/pricing
+	// Fable 5 launched at double the Opus 4.8 rates and is not yet in
+	// the LiteLLM catalog, so the shipped fallback must price it.
+	want := ModelPricing{
+		ModelPattern:         "claude-fable-5",
+		InputPerMTok:         10.0,
+		OutputPerMTok:        50.0,
+		CacheCreationPerMTok: 12.50,
+		CacheReadPerMTok:     1.0,
+	}
+	assert.Equal(t, want, *got)
+}
+
 func TestFallbackPricing_HermesModels(t *testing.T) {
 	byPattern := make(map[string]ModelPricing)
 	for _, p := range FallbackPricing() {

--- a/internal/pricing/litellm_test.go
+++ b/internal/pricing/litellm_test.go
@@ -99,6 +99,7 @@ func TestFallbackPricing(t *testing.T) {
 		"claude-opus-4-6":           false,
 		"claude-opus-4-7":           false,
 		"claude-opus-4-8":           false,
+		"claude-fable-5":            false,
 		"claude-haiku-4-5-20251001": false,
 		"claude-sonnet-4-20250514":  false,
 		"claude-opus-4-20250514":    false,


### PR DESCRIPTION
Adds a fallback pricing entry for the new `claude-fable-5` model, which launched at double the Opus 4.8 rates: $10/MTok input, $50/MTok output, $12.50/MTok 5-minute cache writes, and $1/MTok cache reads (source: https://platform.claude.com/docs/en/about-claude/pricing). The model is not yet in the LiteLLM catalog, so without this entry Fable 5 usage shows as unpriced; the model ID already appears verbatim as `claude-fable-5` in synced session data, matching the exact-match lookup.

`FallbackVersion` is bumped to 2026-06-10 so the startup seeder re-upserts the fallback list into `model_pricing` on upgraded installs. The required-models registry test and a rates test for the new entry are extended alongside, following the existing per-model test pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)