### PR TITLE
Remove redundant DOMPurify types package

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,6 @@
         "@sveltejs/vite-plugin-svelte": "7.1.2",
         "@testing-library/svelte": "^5.3.1",
         "@tsconfig/svelte": "5.0.8",
-        "@types/dompurify": "3.2.0",
         "jsdom": "29.1.1",
         "openapi-typescript-codegen": "^0.30.0",
         "svelte": "5.55.10",
@@ -872,17 +871,6 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,6 @@
     "@sveltejs/vite-plugin-svelte": "7.1.2",
     "@testing-library/svelte": "^5.3.1",
     "@tsconfig/svelte": "5.0.8",
-    "@types/dompurify": "3.2.0",
     "jsdom": "29.1.1",
     "openapi-typescript-codegen": "^0.30.0",
     "svelte": "5.55.10",


### PR DESCRIPTION
## Summary
- Remove `@types/dompurify` from the frontend dependency manifest and lockfile.
- Rely on DOMPurify’s built-in type definitions instead of the deprecated stub package.

## Testing
- `npm run check` in `frontend`
- `npm test` in `frontend`
- Full frontend E2E run completed; unrelated pre-existing failures remain in session count and message-loading scenarios