### PR TITLE
fix: leave session labels untruncated

### DIFF
--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -103,7 +103,7 @@
   let displayLabel = $derived.by((): { text: string; isShell: boolean } => {
     const name = session.display_name ?? null;
     if (name) {
-      return { text: truncate(name, 50), isShell: false };
+      return { text: name, isShell: false };
     }
     let msg = session.first_message ?? "";
     if (msg.includes("<teammate-message")) {
@@ -114,18 +114,18 @@
       // Extract "Task #N: description" from the boilerplate.
       const taskMatch = msg.match(/Task\s*#?\d+[:\s]+(.+?)(?:\s+\d+\.|$)/s);
       if (taskMatch) {
-        return { text: truncate(taskMatch[1]!.trim(), 50), isShell: false };
+        return { text: taskMatch[1]!.trim(), isShell: false };
       }
       // Fallback: skip the "You are a teammate on ..." boilerplate.
       const afterTeam = msg.match(/team[."]\s*[^.]*?[.]\s+(.+)/s)
         ?? msg.match(/You are a teammate[^.]*\.\s+(.+)/s);
       if (afterTeam) {
-        return { text: truncate(afterTeam[1]!.trim(), 50), isShell: false };
+        return { text: afterTeam[1]!.trim(), isShell: false };
       }
     }
     const p = previewMessage(msg);
-    if (p.text) return { text: truncate(p.text, 50), isShell: p.isShell };
-    return { text: truncate(session.project, 30), isShell: false };
+    if (p.text) return { text: p.text, isShell: p.isShell };
+    return { text: session.project, isShell: false };
   });
 
   let timeStr = $derived(

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -250,6 +250,26 @@ describe("SessionList visible hydration", () => {
     expect(document.body.textContent).toContain("Renamed sidebar title");
   });
 
+  it("keeps long session labels intact for responsive CSS clipping", async () => {
+    const title =
+      "test: validate GitLab write parity against a real GitLab instance";
+    sessions.sessions = [
+      makeSession({
+        id: "long-title",
+        first_message: title,
+        is_index_only: false,
+      }),
+    ];
+    vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    const name = document.querySelector<HTMLElement>(".session-name");
+    expect(name).not.toBeNull();
+    expect(name?.textContent).toBe(title);
+  });
+
   it("hydrates newly visible rows after scrolling", async () => {
     sessions.sessions = Array.from({ length: 50 }, (_, i) =>
       makeSession({ id: `s${i}`, is_index_only: true }),


### PR DESCRIPTION
Session rows now keep the complete display label in the DOM and rely on the existing CSS overflow rules to add an ellipsis only when the rendered width requires it.

The previous JavaScript cap removed useful title context even on wider list layouts. This preserves responsive clipping behavior while avoiding premature truncation before layout.

Reviewers should look at the sidebar session label derivation and the focused regression test for long labels.