### PR TITLE
fix(stats): include non-Claude agents in peak_context_tokens distribution

### DIFF
--- a/cmd/agentsview/testdata/stats_golden.json
+++ b/cmd/agentsview/testdata/stats_golden.json
@@ -187,7 +187,7 @@
       }
     },
     "peak_context_tokens": {
-      "claude_only": true,
+      "claude_only": false,
       "null_count": 4,
       "scope_all": {
         "buckets": [

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -674,9 +674,13 @@ func (a *scopedAccumulator) finalize() ScopedDistribution {
 //     the human mean and buckets because the v1 human bucket shape
 //     starts at 2. ScopeAll keeps the [0,2) bucket for short sessions.
 //
-// PeakContextTokens is Claude-only: rows from other agents and rows
-// without hasPeakContext data are excluded from every bucket; the
-// Claude-specific null rows are tallied separately in NullCount.
+// PeakContextTokens includes every row with hasPeakContext data,
+// regardless of agent: the metric used to be Claude-only, but the
+// hermes/kimi/forge/zed parsers populate it now (#646). Rows without
+// the data are tallied in NullCount — but only for agents that report
+// the metric at least once in the window, so agents that never track
+// peak context stay outside the metric entirely instead of inflating
+// the null tally.
 func computeDistributions(s *SessionStats, rows []sessionStatsRow) {
 	durAll := newAccumulator(durationMinutesEdges)
 	durHuman := newAccumulator(durationMinutesEdges)
@@ -687,6 +691,15 @@ func computeDistributions(s *SessionStats, rows []sessionStatsRow) {
 	tptAll := newAccumulator(toolsPerTurnEdges)
 	tptHuman := newAccumulator(toolsPerTurnEdges)
 	var pcNull int
+
+	// Agents with at least one peak-context-bearing row in the window;
+	// only their data-less rows count toward NullCount.
+	peakAgents := map[string]bool{}
+	for _, r := range rows {
+		if r.hasPeakContext {
+			peakAgents[r.agent] = true
+		}
+	}
 
 	for _, r := range rows {
 		human := !r.isAutomated
@@ -709,16 +722,14 @@ func computeDistributions(s *SessionStats, rows []sessionStatsRow) {
 		if human && r.userMessageCount >= 2 {
 			umHuman.add(umv)
 		}
-		if r.agent == "claude" {
-			if r.hasPeakContext {
-				pv := float64(r.peakContextTokens)
-				pcAll.add(pv)
-				if human {
-					pcHuman.add(pv)
-				}
-			} else {
-				pcNull++
+		if r.hasPeakContext {
+			pv := float64(r.peakContextTokens)
+			pcAll.add(pv)
+			if human {
+				pcHuman.add(pv)
 			}
+		} else if peakAgents[r.agent] {
+			pcNull++
 		}
 		if r.assistantTurns > 0 {
 			tpt := float64(r.totalToolCalls) / float64(r.assistantTurns)
@@ -741,7 +752,7 @@ func computeDistributions(s *SessionStats, rows []sessionStatsRow) {
 		ScopeAll:   pcAll.finalize(),
 		ScopeHuman: pcHuman.finalize(),
 		NullCount:  pcNull,
-		ClaudeOnly: true,
+		ClaudeOnly: false,
 	}
 	s.Distributions.ToolsPerTurn = ScopedDistributionPair{
 		ScopeAll:   tptAll.finalize(),

--- a/internal/db/session_stats_test.go
+++ b/internal/db/session_stats_test.go
@@ -655,8 +655,8 @@ func TestGetSessionStats_Distributions(t *testing.T) {
 		"peak_context scope_human: %+v", gotPC)
 	assert.Equal(t, 1, gotPC[4].Count,
 		"peak_context scope_human: %+v", gotPC)
-	assert.True(t, stats.Distributions.PeakContextTokens.ClaudeOnly,
-		"peak_context.claude_only")
+	assert.False(t, stats.Distributions.PeakContextTokens.ClaudeOnly,
+		"peak_context.claude_only is always false since #646")
 	assert.Equal(t, 0,
 		stats.Distributions.PeakContextTokens.NullCount,
 		"peak_context.null_count")
@@ -727,10 +727,10 @@ func TestGetSessionStats_Distributions_NullPeakContext(t *testing.T) {
 		peakContext:    20_000,
 		hasPeakContext: true,
 	})
-	// Non-Claude session without peak-context must NOT increment
-	// NullCount: peak_context is Claude-only, so codex/cursor rows are
-	// outside the metric entirely. Guards against regressions that
-	// remove the r.agent == "claude" gate on the null branch.
+	// Session from an agent that never reports peak context in this
+	// window must NOT increment NullCount: such agents are outside the
+	// metric entirely, only data-less rows of peak-context-reporting
+	// agents tally as null (#646).
 	insertSessionFixture(t, d, sessionFixture{
 		id: "cx1", agent: "codex", userMsgs: 5,
 		startedAt:   hoursAgo(5),
@@ -751,6 +751,60 @@ func TestGetSessionStats_Distributions_NullPeakContext(t *testing.T) {
 	assert.Equal(t, 1, total,
 		"scope_all bucket total want 1 "+
 			"(the one Claude session with hasPeakContext=true)")
+}
+
+func TestGetSessionStats_Distributions_PeakContextNonClaude(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	// Regression for #646: hermes (and kimi/forge/zed) sessions carry
+	// peak_context_tokens, but the distribution only counted rows with
+	// agent == "claude" — an agent-filtered stats run reported all-zero
+	// buckets despite has_peak_context_tokens being true on every row.
+	insertSessionFixture(t, d, sessionFixture{
+		id: "h1", agent: "hermes", userMsgs: 5,
+		startedAt:      hoursAgo(5),
+		durationMin:    3.0,
+		peakContext:    25_000,
+		hasPeakContext: true,
+	})
+	insertSessionFixture(t, d, sessionFixture{
+		id: "h2", agent: "hermes", userMsgs: 5,
+		startedAt:      hoursAgo(5),
+		durationMin:    3.0,
+		peakContext:    120_000,
+		hasPeakContext: true,
+	})
+	// A hermes row without the data lands in NullCount, because hermes
+	// demonstrably reports the metric in this window.
+	insertSessionFixture(t, d, sessionFixture{
+		id: "h3", agent: "hermes", userMsgs: 5,
+		startedAt:   hoursAgo(5),
+		durationMin: 3.0,
+		// hasPeakContext left at false
+	})
+
+	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d", Agent: "hermes"})
+	require.NoError(t, err, "GetSessionStats")
+
+	pc := stats.Distributions.PeakContextTokens
+	total := 0
+	for _, b := range pc.ScopeAll.Buckets {
+		total += b.Count
+	}
+	assert.Equal(t, 2, total,
+		"scope_all bucket total want 2 (both hermes rows with data): %+v",
+		pc.ScopeAll.Buckets)
+	// peakContextEdges: 25k → [10k,50k) bucket 1; 120k → [100k,150k) bucket 3.
+	assert.Equal(t, 1, pc.ScopeAll.Buckets[1].Count,
+		"25k hermes session in bucket 1: %+v", pc.ScopeAll.Buckets)
+	assert.Equal(t, 1, pc.ScopeAll.Buckets[3].Count,
+		"120k hermes session in bucket 3: %+v", pc.ScopeAll.Buckets)
+	assert.InDelta(t, (25_000.0+120_000.0)/2.0, pc.ScopeAll.Mean, 0.01,
+		"scope_all mean over the two hermes rows with data")
+	assert.Equal(t, 1, pc.NullCount,
+		"null_count want 1 (h3: hermes reports the metric, h3 lacks it)")
+	assert.False(t, pc.ClaudeOnly, "claude_only must be false")
 }
 
 // seedVelocityMessages inserts len(offsetsSec) messages for sessionID,

--- a/internal/db/session_stats_types.go
+++ b/internal/db/session_stats_types.go
@@ -79,7 +79,10 @@ type PeakContextDistribution struct {
 	ScopeAll   ScopedDistribution `json:"scope_all"`
 	ScopeHuman ScopedDistribution `json:"scope_human"`
 	NullCount  int                `json:"null_count"`
-	ClaudeOnly bool               `json:"claude_only"`
+	// ClaudeOnly is kept for v1 schema compatibility and is always
+	// false: since #646 the distribution covers every agent that
+	// reports peak context (claude, hermes, kimi, forge, zed, ...).
+	ClaudeOnly bool `json:"claude_only"`
 }
 
 type StatsArchetypes struct {


### PR DESCRIPTION
Fixes #646

## Bug

The peak-context distribution in `computeDistributions` gated rows on `r.agent == "claude"`, but the hermes, kimi, forge and zed parsers populate `peak_context_tokens` now. An agent-filtered stats run (`agentsview stats --agent hermes --format json`) reported all-zero buckets and `mean: 0` even though every session carried `has_peak_context_tokens: true`.

## Fix

Gate on the data instead of the agent name: any row with `hasPeakContext` lands in the buckets.

Two contract details handled deliberately:

- **`null_count` stays meaningful.** It now tallies data-less rows only for agents that report the metric at least once in the window, so agents that never track peak context (e.g. codex today) remain outside the metric entirely instead of inflating the null tally. The existing guard test (`TestGetSessionStats_Distributions_NullPeakContext`, codex row must not count) passes unchanged.
- **`claude_only` is kept in the v1 schema for compatibility and now always reports `false`** — the distribution is no longer Claude-only by construction. Nothing outside tests read the field (checked `web/` and all non-test Go). Per the schema-v1 comment in `session_stats_types.go`, semantic tightening without a shape change stays within v1; happy to handle it differently if you'd rather bump or omit.

The other three `ClaudeOnly` surfaces (cache economics, outcomes, adoption) are genuinely Claude-specific (pricing, plan mode, skills) and are untouched.

## Tests

New `TestGetSessionStats_Distributions_PeakContextNonClaude`: two hermes rows with data land in the right buckets with the right mean under `--agent hermes`, a third hermes row without data lands in `null_count`. **Red on main, green with the fix.**

```
CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled" ./internal/db/ -count=1   # ok (full package)
go vet -tags "fts5,kit_posthog_disabled" ./internal/db/                            # clean
```

(`./cmd/agentsview` test binary fails to link in my local environment on clean main too — gcc 16 emutls vs the prebuilt DuckDB static lib — so relying on CI for that package.)