### PR TITLE
fix(duckdb): gate driver linkage off on windows/arm64

### DIFF
--- a/cmd/agentsview/duckdb_quack_duckdbtest_test.go
+++ b/cmd/agentsview/duckdb_quack_duckdbtest_test.go
@@ -1,4 +1,4 @@
-//go:build duckdbtest
+//go:build duckdbtest && !(windows && arm64)
 
 package main
 

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -7,7 +7,6 @@ import (
 	neturl "net/url"
 	"strings"
 
-	_ "github.com/duckdb/duckdb-go/v2"
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -16,7 +15,7 @@ func Open(path string) (*sql.DB, error) {
 	if path == "" {
 		return nil, fmt.Errorf("duckdb path is required")
 	}
-	db, err := sql.Open("duckdb", path)
+	db, err := openDuckDB(path)
 	if err != nil {
 		return nil, fmt.Errorf("opening duckdb file: %w", err)
 	}
@@ -43,7 +42,7 @@ func NewQuackStore(rawURL, token string, allowInsecure bool) (*Store, error) {
 	if err := ValidateQuackClientURL(rawURL, token, allowInsecure); err != nil {
 		return nil, err
 	}
-	conn, err := sql.Open("duckdb", "")
+	conn, err := openDuckDB("")
 	if err != nil {
 		return nil, fmt.Errorf("opening duckdb client: %w", err)
 	}

--- a/internal/duckdb/driver.go
+++ b/internal/duckdb/driver.go
@@ -1,0 +1,15 @@
+//go:build !(windows && arm64)
+
+package duckdb
+
+import (
+	"database/sql"
+
+	// Registers the "duckdb" database/sql driver, which statically links
+	// the prebuilt DuckDB library from duckdb-go-bindings.
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func openDuckDB(dsn string) (*sql.DB, error) {
+	return sql.Open("duckdb", dsn)
+}

--- a/internal/duckdb/driver_windows_arm64.go
+++ b/internal/duckdb/driver_windows_arm64.go
@@ -1,0 +1,22 @@
+//go:build windows && arm64
+
+package duckdb
+
+import (
+	"database/sql"
+	"errors"
+)
+
+// duckdb-go-bindings ships prebuilt static libraries only for
+// darwin/{amd64,arm64}, linux/{amd64,arm64}, and windows/amd64. Linking the
+// driver on windows/arm64 fails with undefined duckdb_* symbols, so this stub
+// keeps the rest of the binary buildable and reports a clear error if the
+// DuckDB backend is used.
+var errUnsupportedPlatform = errors.New(
+	"the DuckDB backend is not supported on windows/arm64: " +
+		"duckdb-go-bindings ships no prebuilt DuckDB library for this platform",
+)
+
+func openDuckDB(string) (*sql.DB, error) {
+	return nil, errUnsupportedPlatform
+}

--- a/internal/duckdb/driver_windows_arm64_test.go
+++ b/internal/duckdb/driver_windows_arm64_test.go
@@ -1,0 +1,24 @@
+//go:build windows && arm64
+
+package duckdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenReportsUnsupportedPlatform(t *testing.T) {
+	db, err := Open("sessions.duckdb")
+	require.Error(t, err)
+	assert.Nil(t, db)
+	assert.ErrorIs(t, err, errUnsupportedPlatform)
+}
+
+func TestNewQuackStoreReportsUnsupportedPlatform(t *testing.T) {
+	store, err := NewQuackStore("quack:localhost:8765", "token", false)
+	require.Error(t, err)
+	assert.Nil(t, store)
+	assert.ErrorIs(t, err, errUnsupportedPlatform)
+}

--- a/internal/duckdb/quack_smoke_duckdbtest_test.go
+++ b/internal/duckdb/quack_smoke_duckdbtest_test.go
@@ -1,4 +1,4 @@
-//go:build duckdbtest
+//go:build duckdbtest && !(windows && arm64)
 
 package duckdb
 

--- a/internal/duckdb/schema_test.go
+++ b/internal/duckdb/schema_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && arm64)
+
 package duckdb
 
 import (

--- a/internal/duckdb/smoke_test.go
+++ b/internal/duckdb/smoke_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && arm64)
+
 package duckdb
 
 import (
@@ -6,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && arm64)
+
 package duckdb
 
 import (

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && arm64)
+
 package duckdb
 
 import (

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -1,3 +1,5 @@
+//go:build !(windows && arm64)
+
 package duckdb
 
 import (


### PR DESCRIPTION
## Summary

duckdb-go-bindings ships prebuilt static DuckDB libraries only for darwin/{amd64,arm64}, linux/{amd64,arm64}, and windows/amd64. Since #609 the DuckDB driver links into every binary unconditionally, and since #598 the release workflow builds a native windows/arm64 binary — a combination that has never run together: linking `cmd/agentsview` for windows/arm64 fails with undefined `duckdb_*` symbols, which would fail the `build` matrix and block the entire next release (the `release` and `pypi` jobs need every leg, and `build_wheels.py --require-all` expects a windows_arm64 archive).

Driver registration now goes through an `openDuckDB` shim:

- `internal/duckdb/driver.go` (`!(windows && arm64)`) blank-imports `github.com/duckdb/duckdb-go/v2` and opens connections as before.
- `internal/duckdb/driver_windows_arm64.go` returns a clear unsupported-platform error from `Open` and `NewQuackStore` instead of linking the driver. The rest of the `internal/duckdb` package is plain `database/sql` and still compiles everywhere, so the SQLite-backed app is unaffected on windows/arm64 — only the `duckdb` subcommands report the platform limitation at runtime.

Verified by cross-linking windows/arm64 with llvm-mingw (fails on main with undefined `duckdb_*` symbols, links with this change) and by a full dry-run of the release workflow on a throwaway repo (https://github.com/wesm/agentsview-release-test/releases/tag/v0.99.0): all six build legs passed, including the manylinux glibc-2.28 guard and the macOS minos check; wheels built and smoke-tested for all platforms. Release archives grow from ~8MB to ~24–30MB compressed because the DuckDB static library now ships in every supported binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)